### PR TITLE
add keystore api

### DIFF
--- a/api-specs/openrpc-keystore-connector-api.json
+++ b/api-specs/openrpc-keystore-connector-api.json
@@ -1,17 +1,276 @@
 {
     "openrpc": "1.2.6",
     "info": {
-        "title": "Wallet JSON-RPC Keystore API",
+        "title": "Canton JSON-RPC Wallet API",
         "version": "1.0.0",
-        "description": "An OpenRPC specification for the Keystore connector which allows the wallet kernel to interact with a Keystore."
+        "description": "An OpenRPC specification for interacting with a Canton wallet over JSON-RPC."
     },
-    "methods": [],
+    "methods": [
+        {
+            "name": "signTransaction",
+            "params": [
+                {
+                    "name": "params",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "tx": {
+                                "type": "string",
+                                "description": "Bytestring of the prepared transaction for verification purposes."
+                            },
+                            "txHash": {
+                                "type": "string",
+                                "description": "Hash of the prepared transaction that the KeyStore will sign."
+                            },
+                            "publicKey": {
+                                "type": "string",
+                                "description": "Public key to use to sign the transaction."
+                            },
+                            "internalTxId": {
+                                "type": "string",
+                                "description": "Internal txId used by the Wallet Kernel to store the transaction."
+                            }
+                        },
+                        "required": ["tx", "txHash", "publicKey"]
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "title": "signTransactionResult",
+                "description": "The resulting transaction entry in the KeyStore. This will include the signature if the transaction was immediately signed.",
+                "schema": {
+                    "$ref": "#/components/schemas/Transaction"
+                }
+            },
+            "description": "Uses the KeyStore to sign a transaction. This will likely be an asynchronous operation."
+        },
+        {
+            "name": "getTransaction",
+            "description": "Get the status of a single transaction by its ID.",
+            "params": [
+                {
+                    "name": "params",
+                    "title": "getTransactionParams",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "txId": {
+                                "type": "string",
+                                "description": "Unique identifier of the transaction to retrieve."
+                            }
+                        },
+                        "required": ["txId"]
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "title": "getTransactionResult",
+                "schema": {
+                    "$ref": "#/components/schemas/Transaction"
+                }
+            }
+        },
+        {
+            "name": "getTransactions",
+            "description": "Get the status of multiple transactions, filtering by txIds or publicKeys. Either publicKeys or txIds must be provided.",
+            "params": [
+                {
+                    "name": "params",
+                    "title": "getTansactionParams",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "txIds": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "List of transaction IDs to retrieve"
+                            },
+                            "publicKeys": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "List of public keys to filter transactions by"
+                            }
+                        },
+                        "required": []
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "title": "getTransactionsResult",
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/components/schemas/Transaction"
+                    }
+                }
+            }
+        },
+        {
+            "name": "getKeys",
+            "params": [],
+            "result": {
+                "name": "result",
+                "title": "getKeysResult",
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/components/schemas/Key"
+                    }
+                }
+            },
+            "description": "Get a list of keys availabile for use in the KeyStore."
+        },
+        {
+            "name": "createKey",
+            "description": "Create a new key in the KeyStore.",
+            "params": [
+                {
+                    "name": "params",
+                    "title": "createKeyParams",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "A human readable name for the key."
+                            }
+                        },
+                        "required": ["name"]
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "title": "createKeyResult",
+                "schema": {
+                    "$ref": "#/components/schemas/Key"
+                }
+            }
+        },
+        {
+            "name": "getConfiguration",
+            "params": [],
+            "result": {
+                "name": "result",
+                "title": "getConfigurationResult",
+                "schema": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            }
+        },
+        {
+            "name": "setConfiguration",
+            "description": "Set configuration parameters for the KeyStore. The paramaters will change depending on the KeyStore implementation",
+            "params": [
+                {
+                    "name": "params",
+                    "title": "setConfigurationParams",
+                    "schema": {
+                        "type": "object",
+                        "description": "Configuration parameters to set",
+                        "additionalProperties": true
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "title": "getConfigurationResult",
+                "schema": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            }
+        },
+        {
+            "name": "subscribeTransactions",
+            "description": "Subscribe to updates for specific transactions. The server will emit updates when the status of the specified transactions have changed. On initial subscription, the server will emit the current status of all subscribed transactions.",
+            "params": [
+                {
+                    "name": "params",
+                    "title": "subscribeTransactionsParams",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "txIds": {
+                                "type": "array",
+                                "description": "Unique identifiers of the transactions to subscribe to",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "required": ["txIds"]
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "title": "subscribeTransactionsResult",
+                "schema": {
+                    "ref": "#/components/schemas/Transaction"
+                }
+            }
+        }
+    ],
     "components": {
         "schemas": {
             "Null": {
                 "title": "Null",
                 "type": "null",
                 "description": "Represents a null value, used in responses where no data is returned."
+            },
+            "Key": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for the key"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "A human readable name for the key"
+                    },
+                    "publicKey": {
+                        "type": "string",
+                        "description": "Public key associated with the key"
+                    }
+                },
+                "required": ["id", "name", "publicKey"]
+            },
+            "SigningStatus": {
+                "type": "string",
+                "enum": ["pending", "signed", "rejected"],
+                "description": "Status of the transaction signing process"
+            },
+            "Transaction": {
+                "type": "object",
+                "properties": {
+                    "txId": {
+                        "type": "string",
+                        "description": "Unique identifier of the signed transaction given by the KeyStore Provider. This may not be the same as the internal txId given by the Wallet Kernel."
+                    },
+                    "status": {
+                        "ref": "#/components/schemas/SigningStatus",
+                        "description": "Status of the transaction signing process."
+                    },
+                    "signature": {
+                        "type": "string",
+                        "description": "Signature of the transaction if it was signed."
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "description": "Additional metadata about the transaction."
+                    }
+                },
+                "required": ["txId", "status"]
             }
         }
     }


### PR DESCRIPTION
Adds an OpenRPC spec for the keystore connector API.

An addition I made to what was currently in the design doc is an `internalTxId` field for `signTransaction`. This is the ID that the Wallet Kernel will be tracking the transaction as - with multiple KeyStores, we can't be sure that the ID assigned by the KeyStore itself will be unique enough to be used as the WK's storage index.

The reason I have it passed in here is it may be useful for the KeyStore - Fireblocks for example has a field for `externalTxId`, and we may use the Wallet Kernel's ID in the Fireblocks `notes` field as a query parameter in a link to the visualizer.

I wasn't sure what to use for an event 'endpoint' (e.g. emits on a websocket), so I went with this:
```json
        {
            "name": "subscribeTransactions",
            "params": [
                {
                    "name": "params",
                    "title": "subscribeTransactionsParams",
                    "schema": {
                        "type": "object",
                        "properties": {
                            "txIds": {
                                "type": "array",
                                "description": "Unique identifiers of the transactions to subscribe to",
                                "items": {
                                    "type": "string"
                                }
                            }
                        },
                        "required": ["txIds"]
                    }
                }
            ],
            "result": {
                "name": "result",
                "title": "subscribeTransactionsResult",
                "schema": {
                    "ref": "#/components/schemas/Transaction"
                }
            }
        }
```

The `subscribe` indicates it is a subscription, and the `result` schema is the format the events will come in as.