### PR TITLE
add rpc dapp api client to sdk

### DIFF
--- a/core/wallet-dapp-rpc-client/tsconfig.json
+++ b/core/wallet-dapp-rpc-client/tsconfig.json
@@ -10,7 +10,8 @@
         "declarationDir": "build",
         "declaration": true,
         "resolveJsonModule": true,
-        "moduleResolution": "bundler"
+        "moduleResolution": "bundler",
+        "composite": true
     },
     "typedocOptions": {
         "name": "generated client",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -13,7 +13,11 @@
     },
     "author": "Marc Juchli <marc.juchli@digitalasset.com>",
     "license": "Apache-2.0",
+    "dependencies": {
+        "core-wallet-dapp-rpc-client": "workspace:^"
+    },
     "devDependencies": {
+        "@open-rpc/client-js": "^1.8.1",
         "@open-rpc/generator": "^2.0.0",
         "typescript": "^5.8.3"
     }

--- a/sdk/src/connect/index.ts
+++ b/sdk/src/connect/index.ts
@@ -39,7 +39,7 @@ export interface DAppRpcClientOptions {
     headers?: Record<string, string>
 }
 
-export class DAppClient {
+export class DAppProvider {
     private client: dappAPI.SpliceWalletJSONRPCDAppAPI
 
     constructor(config: DAppRpcClientOptions = {}) {

--- a/sdk/src/connect/index.ts
+++ b/sdk/src/connect/index.ts
@@ -40,15 +40,11 @@ export interface DAppRpcClientOptions {
 }
 
 export class DAppClient {
-    private client: dappAPI.WalletJSONRPCDAppAPI
+    private client: dappAPI.SpliceWalletJSONRPCDAppAPI
 
     constructor(config: DAppRpcClientOptions = {}) {
-        // const transport = new HTTPTransport(
-        //     config.baseUrl || 'http://localhost:3333'
-        // );
-
         const url = new URL(config.baseUrl || 'http://localhost:3333')
-        this.client = new dappAPI.WalletJSONRPCDAppAPI({
+        this.client = new dappAPI.SpliceWalletJSONRPCDAppAPI({
             transport: {
                 type: 'http',
                 host: url.hostname,

--- a/sdk/src/connect/index.ts
+++ b/sdk/src/connect/index.ts
@@ -1,4 +1,5 @@
 import { discover } from './discovery'
+import * as dappAPI from 'core-wallet-dapp-rpc-client'
 
 export enum ErrorCode {
     UserCancelled,
@@ -31,4 +32,34 @@ export async function connect(): Promise<ConnectResult> {
                 details: err instanceof Error ? err.message : String(err),
             } as ConnectError
         })
+}
+
+export interface DAppRpcClientOptions {
+    baseUrl?: string
+    headers?: Record<string, string>
+}
+
+export class DAppClient {
+    private client: dappAPI.WalletJSONRPCDAppAPI
+
+    constructor(config: DAppRpcClientOptions = {}) {
+        // const transport = new HTTPTransport(
+        //     config.baseUrl || 'http://localhost:3333'
+        // );
+
+        const url = new URL(config.baseUrl || 'http://localhost:3333')
+        this.client = new dappAPI.WalletJSONRPCDAppAPI({
+            transport: {
+                type: 'http',
+                host: url.hostname,
+                port: parseInt(url.port),
+                path: url.pathname && url.pathname !== '/' ? url.pathname : '',
+                protocol: '2.0',
+            },
+        })
+    }
+
+    public async connect() {
+        return this.client.connect()
+    }
 }

--- a/sdk/src/connect/index.ts
+++ b/sdk/src/connect/index.ts
@@ -46,7 +46,7 @@ export class DAppClient {
         const url = new URL(config.baseUrl || 'http://localhost:3333')
         this.client = new dappAPI.SpliceWalletJSONRPCDAppAPI({
             transport: {
-                type: 'http',
+                type: url.protocol === 'https:' ? 'https' : 'http',
                 host: url.hostname,
                 port: parseInt(url.port),
                 path: url.pathname && url.pathname !== '/' ? url.pathname : '',

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -2,8 +2,16 @@
     "extends": "../tsconfig.base.json",
     "compilerOptions": {
         "rootDir": "./src",
-        "outDir": "./dist"
+        "outDir": "./dist",
+        "moduleResolution": "node",
+        "baseUrl": ".",
+        "paths": {
+            "core-wallet-dapp-rpc-client": [
+                "../core/wallet-dapp-rpc-client/src"
+            ]
+        }
     },
     "include": ["src"],
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules"],
+    "references": [{ "path": "../core/wallet-dapp-rpc-client" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,7 +1710,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@open-rpc/client-js@npm:1.8.1":
+"@open-rpc/client-js@npm:1.8.1, @open-rpc/client-js@npm:^1.8.1":
   version: 1.8.1
   resolution: "@open-rpc/client-js@npm:1.8.1"
   dependencies:
@@ -3276,6 +3276,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"canton-wallet-api-specs@workspace:api-specs":
+  version: 0.0.0-use.local
+  resolution: "canton-wallet-api-specs@workspace:api-specs"
+  dependencies:
+    "@open-rpc/generator": "npm:^2.0.0"
+    "@open-rpc/mock-server": "npm:^1.7.8"
+  languageName: unknown
+  linkType: soft
+
+"canton-wallet-sdk@workspace:^, canton-wallet-sdk@workspace:sdk":
+  version: 0.0.0-use.local
+  resolution: "canton-wallet-sdk@workspace:sdk"
+  dependencies:
+    "@open-rpc/client-js": "npm:^1.8.1"
+    "@open-rpc/generator": "npm:^2.0.0"
+    core-wallet-dapp-rpc-client: "workspace:^"
+    typescript: "npm:^5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -3509,7 +3529,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-wallet-dapp-rpc-client@workspace:core/wallet-dapp-rpc-client":
+"core-wallet-dapp-rpc-client@workspace:^, core-wallet-dapp-rpc-client@workspace:core/wallet-dapp-rpc-client":
   version: 0.0.0-use.local
   resolution: "core-wallet-dapp-rpc-client@workspace:core/wallet-dapp-rpc-client"
   dependencies:
@@ -4216,6 +4236,7 @@ __metadata:
     "@types/react": "npm:^19.1.2"
     "@types/react-dom": "npm:^19.1.2"
     "@vitejs/plugin-react": "npm:^4.4.1"
+    canton-wallet-sdk: "workspace:^"
     eslint: "npm:^9.25.0"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.4.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3276,26 +3276,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"canton-wallet-api-specs@workspace:api-specs":
-  version: 0.0.0-use.local
-  resolution: "canton-wallet-api-specs@workspace:api-specs"
-  dependencies:
-    "@open-rpc/generator": "npm:^2.0.0"
-    "@open-rpc/mock-server": "npm:^1.7.8"
-  languageName: unknown
-  linkType: soft
-
-"canton-wallet-sdk@workspace:^, canton-wallet-sdk@workspace:sdk":
-  version: 0.0.0-use.local
-  resolution: "canton-wallet-sdk@workspace:sdk"
-  dependencies:
-    "@open-rpc/client-js": "npm:^1.8.1"
-    "@open-rpc/generator": "npm:^2.0.0"
-    core-wallet-dapp-rpc-client: "workspace:^"
-    typescript: "npm:^5.8.3"
-  languageName: unknown
-  linkType: soft
-
 "chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -4236,7 +4216,6 @@ __metadata:
     "@types/react": "npm:^19.1.2"
     "@types/react-dom": "npm:^19.1.2"
     "@vitejs/plugin-react": "npm:^4.4.1"
-    canton-wallet-sdk: "workspace:^"
     eslint: "npm:^9.25.0"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.4.19"
@@ -7581,7 +7560,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "splice-wallet-sdk@workspace:sdk"
   dependencies:
+    "@open-rpc/client-js": "npm:^1.8.1"
     "@open-rpc/generator": "npm:^2.0.0"
+    core-wallet-dapp-rpc-client: "workspace:^"
     typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This adds a DAppProvider, that is created from the core/wallet-dapp-rpc-client, to the sdk, so we can use the sdk in a DApp (like the example DApp). Note, the way this client is created only works for the rpc servers and not the browser extension. The current codegen'd `SpliceWalletJSONRPCDAppAPI` client is not suitable for the browser extension because the `PostMessageWindowTransport` doesn't  have the proper support (@mjuchli-da  can expand on this)