### PR TITLE
add splicer provider to tsconfig.json for sdk

### DIFF
--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -8,9 +8,13 @@
         "paths": {
             "core-wallet-dapp-rpc-client": [
                 "../core/wallet-dapp-rpc-client/src"
-            ]
+            ],
+            "splice-provider": ["../core/splice-provider/src"]
         }
     },
     "include": ["src"],
-    "references": [{ "path": "../core/wallet-dapp-rpc-client" }]
+    "references": [
+        { "path": "../core/wallet-dapp-rpc-client" },
+        { "path": "../core/splice-provider" }
+    ]
 }


### PR DESCRIPTION
While running `yarn workspace splice-wallet-sdk build`

We would get the following error:
```
src/connect/index.ts:2:38 - error TS2307: Cannot find module 'splice-provider' or its corresponding type declarations.

2 import { injectSpliceProvider } from 'splice-provider'
                                       ~~~~~~~~~~~~~~~~~

src/connect/index.ts:5:15 - error TS2307: Cannot find module 'splice-provider' or its corresponding type declarations.

5 export * from 'splice-provider'
                ~~~~~~~~~~~~~~~~~
```

This PR should fix it - tested by running

After running 

```
 yarn workspace splice-provider build
yarn install 
yarn workspace splice-wallet-sdk build
```
