### PR TITLE
add vite config alias to example DApp

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -16,6 +16,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@types/node": "^24.0.1",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
     plugins: [react()],
+    resolve: {
+        alias: {
+            'core-wallet-dapp-rpc-client': path.resolve(
+                __dirname,
+                '../core/wallet-dapp-rpc-client'
+            ),
+        },
+    },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2549,6 +2549,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^24.0.1":
+  version: 24.0.1
+  resolution: "@types/node@npm:24.0.1"
+  dependencies:
+    undici-types: "npm:~7.8.0"
+  checksum: 10c0/91cd50d1ac32a2172cbc67b65c78391fbd469b24743e3665427aa60bebaf4620cb9ac2e91c09a8081a78d08855c00faca659c287c1725ce8ca5e80ece3a20520
+  languageName: node
+  linkType: hard
+
 "@types/qs@npm:*":
   version: 6.14.0
   resolution: "@types/qs@npm:6.14.0"
@@ -4213,6 +4222,7 @@ __metadata:
   resolution: "example@workspace:example"
   dependencies:
     "@eslint/js": "npm:^9.25.0"
+    "@types/node": "npm:^24.0.1"
     "@types/react": "npm:^19.1.2"
     "@types/react-dom": "npm:^19.1.2"
     "@vitejs/plugin-react": "npm:^4.4.1"


### PR DESCRIPTION
Vite doesn't use the TypeScript `paths` mapping automatically, so this adds the Vite aliases to the example app. 

Previous error was: 

```
[vite]: Rollup failed to resolve import "core-wallet-dapp-rpc-client" from "/Users/rukminibasu/Desktop/IdeaProjects/splice-wallet-kernel/sdk/dist/connect/index.js".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
```

New output of the `yarn build:all`

```
rukminibasu@rukminibasufj726c splice-wallet-kernel % yarn build:all
[server]: Process started
[server]: Process exited (exit code 0), completed in 1s 349ms

[rpc-generator]: Process started
[rpc-generator]: Process exited (exit code 0), completed in 0s 984ms

[splice-provider]: Process started
[splice-provider]: Process exited (exit code 0), completed in 0s 433ms

[core-wallet-dapp-rpc-client]: Process started
[core-wallet-dapp-rpc-client]: [info] html generated at ./docs
[core-wallet-dapp-rpc-client]: Process exited (exit code 0), completed in 3s 973ms

[splice-wallet-sdk]: Process started
[splice-wallet-sdk]: Done!
[splice-wallet-sdk]: Process exited (exit code 0), completed in 1s 565ms

[example]: Process started
[example]: vite v6.3.5 building for production...
[example]: transforming...
[example]: [plugin vite:resolve] Module "events" has been externalized for browser compatibility, imported by "/Users/rukminibasu/.yarn/berry/cache/@open-rpc-client-js-npm-1.8.1-7d14528543-10c0.zip/node_modules/@open-rpc/client-js/build/RequestManager.js". See https://vite.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
[example]: [plugin vite:resolve] Module "events" has been externalized for browser compatibility, imported by "/Users/rukminibasu/.yarn/berry/cache/@open-rpc-client-js-npm-1.8.1-7d14528543-10c0.zip/node_modules/@open-rpc/client-js/build/transports/TransportRequestManager.js". See https://vite.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
[example]: ✓ 187 modules transformed.
[example]: rendering chunks...
[example]: computing gzip size...
[example]: dist/index.html                   0.49 kB │ gzip:   0.30 kB
[example]: dist/assets/index-6C5xsizv.css    1.41 kB │ gzip:   0.72 kB
[example]: dist/assets/index-BDoKUww5.js   491.95 kB │ gzip: 146.58 kB
[example]: ✓ built in 1.16s
[example]: Process exited (exit code 0), completed in 3s 806ms
Done in 12s 117ms
rukminibasu@rukminibasufj726c splice-wallet-kernel % git checkout -b rukmini/add-vite-config-alias-to-example
Switched to a new branch 'rukmini/add-vite-config-alias-to-example'
rukminibasu@rukminibasufj726c splice-wallet-kernel % yarn workspace example build
vite v6.3.5 building for production...
[plugin vite:resolve] Module "events" has been externalized for browser compatibility, imported by "/Users/rukminibasu/.yarn/berry/cache/@open-rpc-client-js-npm-1.8.1-7d14528543-10c0.zip/node_modules/@open-rpc/client-js/build/RequestManager.js". See https://vite.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
[plugin vite:resolve] Module "events" has been externalized for browser compatibility, imported by "/Users/rukminibasu/.yarn/berry/cache/@open-rpc-client-js-npm-1.8.1-7d14528543-10c0.zip/node_modules/@open-rpc/client-js/build/transports/TransportRequestManager.js". See https://vite.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
✓ 187 modules transformed.
dist/index.html                   0.49 kB │ gzip:   0.30 kB
dist/assets/index-6C5xsizv.css    1.41 kB │ gzip:   0.72 kB
dist/assets/index-BDoKUww5.js   491.95 kB │ gzip: 146.58 kB
✓ built in 1.16s

```