### PR TITLE
remove eslintignore file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-core/wallet-dapp-rpc-client
-core/ledger-client/generated-clients

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,14 +6,17 @@ import { includeIgnoreFile } from '@eslint/compat'
 import { fileURLToPath } from 'node:url'
 
 const gitignorePath = fileURLToPath(new URL('.gitignore', import.meta.url))
-const eslintIgnorePath = fileURLToPath(
-    new URL('.eslintignore', import.meta.url)
-)
 
 export default defineConfig([
     includeIgnoreFile(gitignorePath),
-    includeIgnoreFile(eslintIgnorePath),
-    globalIgnores(['.yarn/', '**/dist/', '**/build/', '.pnp.*']),
+    globalIgnores([
+        '.yarn/',
+        '**/dist/',
+        '**/build/',
+        '.pnp.*',
+        'core/wallet-dapp-rpc-client',
+        'core/ledger-client/generated-clients',
+    ]),
     {
         files: ['**/*.{js,mjs,cjs,ts,mts,cts}'],
         plugins: { js },


### PR DESCRIPTION
Saw a bunch of these warnings

```
ESLintIgnoreWarning: The ".eslintignore" file is no longer supported. Switch to using the "ignores" property in "eslint.config.js"
```

so moved the contents of eslintignore into the config file directly