### PR TITLE
fix typo in ecosystem.config.js

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,7 +1,7 @@
 export const apps = [
     {
         name: 'remote',
-        script: 'yarn workspace client-remote dev',
+        script: 'yarn workspace clients-remote dev',
     },
     {
         name: 'example dApp',


### PR DESCRIPTION
When running `yarn start:all` we would get the following error:
```
Usage Error: Workspace 'client-remote' not found. Did you mean any of the following:
```

This fixes the typo and I confirmed that all of the components started correctly.

<img width="589" alt="image" src="https://github.com/user-attachments/assets/e2455783-1633-4778-9a25-81ea79f7777c" />
