### PR TITLE
add clientId into state for callback

### DIFF
--- a/clients/remote/src/web/frontend/callback/login-callback.ts
+++ b/clients/remote/src/web/frontend/callback/login-callback.ts
@@ -16,16 +16,17 @@ export class LoginCallback extends LitElement {
         console.log('entered handle redirect')
         const url = new URL(window.location.href)
         const code = url.searchParams.get('code')
-        const state = url.searchParams.get('state')
+        const encodedState = url.searchParams.get('state')
 
-        if (!code && !state) {
+        if (!code && !encodedState) {
             console.error('missing state and code')
             return
         }
 
-        if (code && state) {
+        if (code && encodedState) {
+            const state = JSON.parse(atob(encodedState))
             const fetchConfig = await fetch(
-                `${state}/.well-known/openid-configuration`
+                `${state.domain}/.well-known/openid-configuration`
             )
             const config = await fetchConfig.json()
             const tokenEndpoint = config.token_endpoint
@@ -39,7 +40,7 @@ export class LoginCallback extends LitElement {
                     grant_type: 'authorization_code',
                     code,
                     redirect_uri: 'http://localhost:3002/callback/',
-                    client_id: 'my-client',
+                    client_id: state.clientId,
                 }),
             })
 

--- a/clients/remote/src/web/frontend/login/login.ts
+++ b/clients/remote/src/web/frontend/login/login.ts
@@ -48,10 +48,16 @@ export class LoginUI extends LitElement {
         const redirectUri = 'http://localhost:3002/callback/' //should probably be config driven?
         if (this.selectedNetwork.auth.type === 'implicit') {
             const domain = this.selectedNetwork.auth.domain
+
             const configUrl = `${domain}/.well-known/openid-configuration`
             const config = await fetch(configUrl).then((res) => res.json())
             const scope = this.selectedNetwork.auth.scope
             const audience = this.selectedNetwork.auth.audience
+            const statePayload = {
+                domain: domain,
+                clientId: this.selectedNetwork.auth.clientId,
+            }
+
             const params = new URLSearchParams({
                 response_type: 'code',
                 response_mode: 'fragment',
@@ -60,7 +66,7 @@ export class LoginUI extends LitElement {
                 nonce: crypto.randomUUID(),
                 scope,
                 audience,
-                state: domain,
+                state: btoa(JSON.stringify(statePayload)),
             })
 
             window.location.href = `${config.authorization_endpoint}?${params.toString()}`


### PR DESCRIPTION
Removes the hard coded clientId and instead adds it to the state in the auth redirect. 