### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: CI on PRs (Splice Contributors)
 run-name: ${{ github.actor }} is perfoming a Pull Request
 on: push
+permissions:
+    contents: read
 
 jobs:
     build:


### PR DESCRIPTION
Potential fix for [https://github.com/hyperledger-labs/splice-wallet-kernel/security/code-scanning/8](https://github.com/hyperledger-labs/splice-wallet-kernel/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient, as the workflow only reads repository contents and does not perform any write operations.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, or it can be added specifically to the `build` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
