### PR TITLE
improve get transactions

### DIFF
--- a/core/signing-fireblocks/src/index.ts
+++ b/core/signing-fireblocks/src/index.ts
@@ -101,6 +101,14 @@ export default class FireblocksSigningDriver implements SigningDriverInterface {
                             publicKey: tx.publicKey,
                         })
                     }
+                    if (
+                        params.txIds &&
+                        !params.publicKeys &&
+                        transactions.length == txIds.size
+                    ) {
+                        // stop if we are filtering by only txIds and have found all requested transactions
+                        break
+                    }
                 }
                 return {
                     transactions: transactions,


### PR DESCRIPTION
Improve performance of `getTransactions` when filtered by a list of transaction IDs by breaking if all are found. This will be particularly helpful for accounts with a large number transactions since it will short circuit the generator from continuing to paginate all transactions.