### PR TITLE
canton bootstrapping and console output

### DIFF
--- a/canton-bootstrap.canton
+++ b/canton-bootstrap.canton
@@ -3,7 +3,7 @@ nodes.local.start()
 
 // Bootstrap the synchronizer
 bootstrap.synchronizer(
-  synchronizerName = "da",
+  synchronizerName = "wallet",
   sequencers = Seq(sequencer1),
   mediators = Seq(mediator1),
   synchronizerOwners = Seq(sequencer1, mediator1),
@@ -11,11 +11,11 @@ bootstrap.synchronizer(
   staticSynchronizerParameters = StaticSynchronizerParameters.defaultsWithoutKMS(ProtocolVersion.forSynchronizer),
 )
 
-// Connect participant1 to da using the connect macro.
+// Connect participant1 to wallet using the connect macro.
 // The connect macro will inspect the synchronizer configuration to find the correct URL and Port.
 // The macro is convenient for local testing, but obviously doesn't work in a distributed setup.
-participant1.synchronizers.connect_local(sequencer1, alias = "da")
+participant1.synchronizers.connect_local(sequencer1, alias = "wallet")
 
 utils.retry_until_true {
-    participant1.synchronizers.active("da")
+    participant1.synchronizers.active("wallet")
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "start:all": "yarn pm2 start ecosystem.config.js --env development",
         "start:oauth2-mock-server": "oauth2-mock-server -a localhost -p 8082",
         "start:canton": "tsx ./scripts/src/start-canton.ts",
-        "stop:all": "yarn pm2 stop ecosystem.config.js --env development",
+        "stop:all": "yarn pm2 stop all",
         "generate:dapp": "yarn workspace core-rpc-generator build && open-rpc-generator generate -c ./rpc-generator-config-dapp.json",
         "generate:user": "yarn workspace core-rpc-generator build && open-rpc-generator generate -c ./rpc-generator-config-user.json",
         "generate:signing": "yarn workspace core-rpc-generator build && open-rpc-generator generate -c ./rpc-generator-config-signing.json",

--- a/scripts/src/start-canton.ts
+++ b/scripts/src/start-canton.ts
@@ -34,11 +34,13 @@ async function main() {
                 },
                 function (err) {
                     pm2.launchBus((err, bus) => {
-                        bus.on('log:out', (packet) => {
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        bus.on('log:out', (packet: any) => {
                             if (packet.process.name == processName)
                                 console.log(info(trimNewline(packet.data)))
                         })
-                        bus.on('log:err', (packet) => {
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        bus.on('log:err', (packet: any) => {
                             if (packet.process.name == processName)
                                 console.error(error(trimNewline(packet.data)))
                         })

--- a/scripts/src/start-canton.ts
+++ b/scripts/src/start-canton.ts
@@ -8,10 +8,12 @@ import {
     CANTON_CONF,
     error,
     info,
+    trimNewline,
 } from './utils.js'
 import { existsSync } from 'fs'
 import pm2 from 'pm2'
 
+const processName = 'canton'
 async function main() {
     if (existsSync(CANTON_BIN)) {
         console.log(
@@ -25,12 +27,22 @@ async function main() {
 
             pm2.start(
                 {
-                    name: 'canton',
+                    name: processName,
                     interpreter: '/bin/bash',
                     script: CANTON_BIN,
-                    args: `daemon --no-tty --config ${CANTON_CONF} --bootstrap ${CANTON_BOOTSTRAP}`,
+                    args: `daemon --no-tty --config ${CANTON_CONF} --bootstrap ${CANTON_BOOTSTRAP} --log-level-stdout=INFO --log-level-canton=INFO`,
                 },
                 function (err) {
+                    pm2.launchBus((err, bus) => {
+                        bus.on('log:out', (packet) => {
+                            if (packet.process.name == processName)
+                                console.log(info(trimNewline(packet.data)))
+                        })
+                        bus.on('log:err', (packet) => {
+                            if (packet.process.name == processName)
+                                console.error(error(trimNewline(packet.data)))
+                        })
+                    })
                     if (err) {
                         console.error(err)
                         return pm2.disconnect()

--- a/scripts/src/utils.ts
+++ b/scripts/src/utils.ts
@@ -8,7 +8,8 @@ export const info = (message: string): string => italic(blue(message))
 export const warn = (message: string): string => yellow(message)
 export const error = (message: string): string => red(message)
 export const success = (message: string): string => green(message)
-
+export const trimNewline = (message: string): string =>
+    message.replace(/\n$/, '')
 // Get the root of the current repository
 // Assumption: the root of the repository is the closest
 //     ancestor directory of the CWD that contains a .git directory


### PR DESCRIPTION
this pr:

- Changes naming convention for synchronizer from `da` to `wallet`
- Attaches a bus to pm2 when running `yarn start:canton` that logs console output (so potential debugging becomes easier)