### PR TITLE
Rename networkId to chainId

### DIFF
--- a/api-specs/openrpc-user-api.json
+++ b/api-specs/openrpc-user-api.json
@@ -99,8 +99,8 @@
                                 "type": "string",
                                 "description": "The party hint and name of the wallet."
                             },
-                            "networkId": {
-                                "title": "networkId",
+                            "chainId": {
+                                "title": "chainId",
                                 "type": "string",
                                 "description": "The network ID the wallet corresponds to."
                             },
@@ -112,7 +112,7 @@
                         },
                         "required": [
                             "partyHint",
-                            "networkId",
+                            "chainId",
                             "signingProviderId"
                         ]
                     }
@@ -327,13 +327,13 @@
                         "title": "AddSessionParams",
                         "type": "object",
                         "properties": {
-                            "networkId": {
-                                "title": "networkId",
+                            "chainId": {
+                                "title": "chainId",
                                 "type": "string",
                                 "description": "Network Id"
                             }
                         },
-                        "required": ["networkId"]
+                        "required": ["chainId"]
                     }
                 }
             ],
@@ -386,18 +386,13 @@
                         "type": "string",
                         "description": "Synchronizer ID"
                     },
-                    "networkId": {
-                        "title": "networkId",
+                    "chainId": {
+                        "title": "chainId",
                         "type": "string",
                         "description": "Network Id"
                     }
                 },
-                "required": [
-                    "name",
-                    "description",
-                    "networkId",
-                    "synchronizerId"
-                ]
+                "required": ["name", "description", "chainId", "synchronizerId"]
             },
             "Auth": {
                 "title": "type",
@@ -465,8 +460,8 @@
                         "type": "string",
                         "description": "The namespace of the party."
                     },
-                    "networkId": {
-                        "title": "networkId",
+                    "chainId": {
+                        "title": "chainId",
                         "type": "string",
                         "description": "The network ID the wallet corresponds to."
                     },
@@ -482,7 +477,7 @@
                     "hint",
                     "publicKey",
                     "namespace",
-                    "networkId",
+                    "chainId",
                     "signingProviderId"
                 ]
             },
@@ -491,12 +486,12 @@
                 "type": "object",
                 "description": "Filter for wallets",
                 "properties": {
-                    "networkIds": {
-                        "title": "networkIds",
+                    "chainIds": {
+                        "title": "chainIds",
                         "type": "array",
                         "description": "Filter wallets by network IDs.",
                         "items": {
-                            "title": "networkId",
+                            "title": "chainId",
                             "type": "string"
                         }
                     },

--- a/clients/remote/src/config/Config.test.ts
+++ b/clients/remote/src/config/Config.test.ts
@@ -5,7 +5,7 @@ import { ConfigUtils } from './ConfigUtils.js'
 test('config from json file', async () => {
     const jsonData = ConfigUtils.loadConfigFile('../test/config.json')
     const resp = s.configSchema.parse(jsonData)
-    expect(resp.store.networks[0].name).toBe('Password Auth')
+    expect(resp.store.networks[0].name).toBe('Local (password IDP)')
     expect(resp.store.networks[0].ledgerApi.baseUrl).toBe('https://test')
     expect(resp.store.networks[0].auth.clientId).toBe('wk-service-account')
     expect(resp.store.networks[0].auth.scope).toBe('openid')

--- a/clients/remote/src/dapp-api/controller.ts
+++ b/clients/remote/src/dapp-api/controller.ts
@@ -129,7 +129,7 @@ export const dappController = (
                 return {
                     kernel: kernelInfo,
                     isConnected: true,
-                    chainId: (await store.getCurrentNetwork()).networkId,
+                    chainId: (await store.getCurrentNetwork()).chainId,
                 }
             }
         },

--- a/clients/remote/src/user-api/controller.ts
+++ b/clients/remote/src/user-api/controller.ts
@@ -26,11 +26,11 @@ async function signingDriverCreate(
     store: Store,
     notifier: Notifier | undefined,
     ledgerClient: LedgerClient,
-    { signingProviderId, primary, partyHint, networkId }: CreateWalletParams
+    { signingProviderId, primary, partyHint, chainId }: CreateWalletParams
 ): Promise<CreateWalletResult> {
     switch (signingProviderId) {
         case 'participant': {
-            const network = await store.getNetwork(networkId)
+            const network = await store.getNetwork(chainId)
 
             const res = await ledgerClient.partiesPost({
                 partyIdHint: partyHint,
@@ -50,7 +50,7 @@ async function signingDriverCreate(
                 publicKey: 'placeholder-public-key',
                 namespace: 'placeholder-namespace',
                 signingProviderId: signingProviderId,
-                networkId: networkId,
+                chainId: chainId,
             }
 
             await store.addWallet(wallet)
@@ -102,7 +102,7 @@ export const userController = (
 
             const newNetwork = {
                 name: network.network.name,
-                networkId: network.network.networkId,
+                chainId: network.network.chainId,
                 description: network.network.description,
                 synchronizerId: network.network.synchronizerId,
                 auth,
@@ -117,7 +117,7 @@ export const userController = (
         createWallet: async (params: {
             primary?: boolean
             partyHint: string
-            networkId: string
+            chainId: string
             signingProviderId: string
         }) => {
             pino.pino().info(
@@ -139,7 +139,7 @@ export const userController = (
         removeWallet: async (params: { partyId: string }) =>
             Promise.resolve({}),
         listWallets: async (params: {
-            filter?: { networkIds?: string[]; signingProviderIds?: string[] }
+            filter?: { chainIds?: string[]; signingProviderIds?: string[] }
         }) => {
             // TODO: support filters
             return store.getWallets()
@@ -212,7 +212,7 @@ export const userController = (
         ): Promise<AddSessionResult> {
             try {
                 await store.setSession({
-                    network: params.networkId,
+                    network: params.chainId,
                     accessToken: authContext?.accessToken || '',
                 })
                 const network = await store.getCurrentNetwork()
@@ -223,13 +223,13 @@ export const userController = (
                 notifier?.emit('onConnected', {
                     kernel: kernelInfo,
                     sessionToken: authContext?.accessToken || '',
-                    chainId: network.networkId,
+                    chainId: network.chainId,
                 })
 
                 return Promise.resolve({
                     network: {
                         name: network.name,
-                        networkId: network.networkId,
+                        chainId: network.chainId,
                         synchronizerId: network.synchronizerId,
                         description: network.description,
                         ledgerApi: network.ledgerApi,

--- a/clients/remote/src/user-api/rpc-gen/typings.ts
+++ b/clients/remote/src/user-api/rpc-gen/typings.ts
@@ -24,7 +24,7 @@ export type SynchronizerId = string
  * Network Id
  *
  */
-export type NetworkId = string
+export type ChainId = string
 /**
  *
  * Structure representing the connected Networks
@@ -34,7 +34,7 @@ export interface Network {
     name: Name
     description: Description
     synchronizerId: SynchronizerId
-    networkId: NetworkId
+    chainId: ChainId
     [k: string]: any
 }
 export type Type = string
@@ -95,7 +95,7 @@ export type PartyId = string
  * Filter wallets by network IDs.
  *
  */
-export type NetworkIds = NetworkId[]
+export type ChainIds = ChainId[]
 /**
  *
  * Filter wallets by signing provider IDs.
@@ -108,7 +108,7 @@ export type SigningProviderIds = SigningProviderId[]
  *
  */
 export interface WalletFilter {
-    networkIds?: NetworkIds
+    chainIds?: ChainIds
     signingProviderIds?: SigningProviderIds
     [k: string]: any
 }
@@ -150,7 +150,7 @@ export interface Wallet {
     hint: Hint
     publicKey: PublicKey
     namespace: Namespace
-    networkId: NetworkId
+    chainId: ChainId
     signingProviderId: SigningProviderId
     [k: string]: any
 }
@@ -176,7 +176,7 @@ export interface RemoveNetworkParams {
 export interface CreateWalletParams {
     primary?: Primary
     partyHint: PartyHint
-    networkId: NetworkId
+    chainId: ChainId
     signingProviderId: SigningProviderId
     [k: string]: any
 }
@@ -201,7 +201,7 @@ export interface ExecuteParams {
     [k: string]: any
 }
 export interface AddSessionParams {
-    networkId: NetworkId
+    chainId: ChainId
     [k: string]: any
 }
 /**

--- a/clients/remote/src/user-api/server.test.ts
+++ b/clients/remote/src/user-api/server.test.ts
@@ -54,8 +54,8 @@ test('call connect rpc', async () => {
         result: {
             networks: [
                 {
-                    name: 'Password Auth',
-                    networkId: 'canton:local',
+                    name: 'Local (password IDP)',
+                    chainId: 'canton:local-password',
                     synchronizerId:
                         'wallet::1220aa7665e1190b584acc00a808f6a11a0a96aebf171f6f9a78d343b34461752ea2::34-0',
                     description: 'Unimplemented Password Auth',
@@ -69,8 +69,8 @@ test('call connect rpc', async () => {
                     },
                 },
                 {
-                    name: 'Mock OAuth Server',
-                    networkId: 'canton:local',
+                    name: 'Local (OAuth IDP)',
+                    chainId: 'canton:local-oauth',
                     synchronizerId:
                         'wallet::1220aa7665e1190b584acc00a808f6a11a0a96aebf171f6f9a78d343b34461752ea2::34-0',
                     description: 'Mock OAuth IDP',

--- a/clients/remote/src/web/frontend/callback/login-callback.ts
+++ b/clients/remote/src/web/frontend/callback/login-callback.ts
@@ -51,7 +51,7 @@ export class LoginCallback extends LitElement {
                 await userClient.transport.submit({
                     method: 'addSession',
                     params: {
-                        networkId: 'canton:local', // TODO: get from local storage or use inline callback in login.ts
+                        chainId: 'canton:local-oauth', // TODO: get from local storage or use inline callback in login.ts
                     },
                 })
 

--- a/clients/remote/src/web/frontend/networks/index.ts
+++ b/clients/remote/src/web/frontend/networks/index.ts
@@ -77,7 +77,7 @@ export class UserUiNetworks extends LitElement {
         }
 
         const networkParam: Network = {
-            networkId: formData.get('networkId') as string,
+            chainId: formData.get('chainId') as string,
             synchronizerId: formData.get('synchronizerId') as string,
             name: formData.get('name') as string,
             description: formData.get('description') as string,

--- a/clients/remote/src/web/frontend/wallets/index.ts
+++ b/clients/remote/src/web/frontend/wallets/index.ts
@@ -132,12 +132,12 @@ export class UserUiWallets extends LitElement {
         const partyHint = this._partyHintInput?.value || ''
         const primary = this._primaryCheckbox?.checked || false
         const signingProviderId = this.selectedSigningProvider
-        const networkId = 'placeholder-network-id'
+        const chainId = 'placeholder-network-id'
 
         const body: CreateWalletParams = {
             primary,
             partyHint,
-            networkId,
+            chainId,
             signingProviderId,
         }
 

--- a/clients/test/config.json
+++ b/clients/test/config.json
@@ -7,8 +7,8 @@
     "store": {
         "networks": [
             {
-                "name": "Password Auth",
-                "networkId": "canton:local",
+                "name": "Local (password IDP)",
+                "chainId": "canton:local-password",
                 "synchronizerId": "wallet::1220aa7665e1190b584acc00a808f6a11a0a96aebf171f6f9a78d343b34461752ea2::34-0",
                 "description": "Unimplemented Password Auth",
                 "ledgerApi": {
@@ -23,8 +23,8 @@
                 }
             },
             {
-                "name": "Mock OAuth Server",
-                "networkId": "canton:local",
+                "name": "Local (OAuth IDP)",
+                "chainId": "canton:local-oauth",
                 "synchronizerId": "wallet::1220aa7665e1190b584acc00a808f6a11a0a96aebf171f6f9a78d343b34461752ea2::34-0",
                 "description": "Mock OAuth IDP",
                 "ledgerApi": {

--- a/core/wallet-store/src/Store.ts
+++ b/core/wallet-store/src/Store.ts
@@ -20,7 +20,7 @@ export interface SigningProvider {
 }
 
 export interface WalletFilter {
-    networkIds?: string[]
+    chainIds?: string[]
     signingProviderIds?: string[]
 }
 
@@ -30,7 +30,7 @@ export interface Wallet {
     hint: string
     publicKey: string
     namespace: string
-    networkId: string
+    chainId: string
     signingProviderId: string
 }
 
@@ -65,12 +65,12 @@ export interface Store {
     removeSession(): Promise<void>
 
     // Network methods
-    getNetwork(name: string): Promise<NetworkConfig>
+    getNetwork(chainId: string): Promise<NetworkConfig>
     getCurrentNetwork(): Promise<NetworkConfig>
     listNetworks(): Promise<Array<NetworkConfig>>
     updateNetwork(network: NetworkConfig): Promise<void>
     addNetwork(network: NetworkConfig): Promise<void>
-    removeNetwork(name: string): Promise<void>
+    removeNetwork(chainId: string): Promise<void>
 
     // Transaction methods
     setTransaction(tx: Transaction): Promise<void>

--- a/core/wallet-store/src/StoreInternal.test.ts
+++ b/core/wallet-store/src/StoreInternal.test.ts
@@ -28,7 +28,7 @@ describe('StoreInternal', () => {
             signingProviderId: 'internal',
             publicKey: 'publicKey',
             namespace: 'namespace',
-            networkId: 'network1',
+            chainId: 'network1',
         }
         await store.addWallet(wallet)
         const wallets = await store.getWallets()
@@ -43,7 +43,7 @@ describe('StoreInternal', () => {
             signingProviderId: 'internal1',
             publicKey: 'publicKey',
             namespace: 'namespace',
-            networkId: 'network1',
+            chainId: 'network1',
         }
         const wallet2: Wallet = {
             primary: false,
@@ -52,7 +52,7 @@ describe('StoreInternal', () => {
             signingProviderId: 'internal2',
             publicKey: 'publicKey',
             namespace: 'namespace',
-            networkId: 'network1',
+            chainId: 'network1',
         }
         const wallet3: Wallet = {
             primary: false,
@@ -61,27 +61,26 @@ describe('StoreInternal', () => {
             signingProviderId: 'internal2',
             publicKey: 'publicKey',
             namespace: 'namespace',
-            networkId: 'network2',
+            chainId: 'network2',
         }
         await store.addWallet(wallet1)
         await store.addWallet(wallet2)
         await store.addWallet(wallet3)
         const getAllWallets = await store.getWallets()
-        const getWalletsByNetworkId = await store.getWallets({
-            networkIds: ['network1'],
+        const getWalletsByChainId = await store.getWallets({
+            chainIds: ['network1'],
         })
         const getWalletsBySigningProviderId = await store.getWallets({
             signingProviderIds: ['internal2'],
         })
-        const getWalletsByNetworkIdAndSigningProviderId =
-            await store.getWallets({
-                networkIds: ['network1'],
-                signingProviderIds: ['internal2'],
-            })
+        const getWalletsByChainIdAndSigningProviderId = await store.getWallets({
+            chainIds: ['network1'],
+            signingProviderIds: ['internal2'],
+        })
         expect(getAllWallets).toHaveLength(3)
-        expect(getWalletsByNetworkId).toHaveLength(2)
+        expect(getWalletsByChainId).toHaveLength(2)
         expect(getWalletsBySigningProviderId).toHaveLength(2)
-        expect(getWalletsByNetworkIdAndSigningProviderId).toHaveLength(1)
+        expect(getWalletsByChainIdAndSigningProviderId).toHaveLength(1)
     })
 
     test('should set and get primary wallet', async () => {
@@ -92,7 +91,7 @@ describe('StoreInternal', () => {
             signingProviderId: 'internal',
             publicKey: 'publicKey',
             namespace: 'namespace',
-            networkId: 'network1',
+            chainId: 'network1',
         }
         const wallet2: Wallet = {
             primary: false,
@@ -101,7 +100,7 @@ describe('StoreInternal', () => {
             signingProviderId: 'internal',
             publicKey: 'publicKey',
             namespace: 'namespace',
-            networkId: 'network1',
+            chainId: 'network1',
         }
         await store.addWallet(wallet1)
         await store.addWallet(wallet2)
@@ -132,7 +131,7 @@ describe('StoreInternal', () => {
         }
         const network: NetworkConfig = {
             name: 'testnet',
-            networkId: 'network1',
+            chainId: 'network1',
             synchronizerId: 'sync1::fingerprint',
             description: 'Test Network',
             ledgerApi,
@@ -143,10 +142,10 @@ describe('StoreInternal', () => {
         expect(listed).toHaveLength(1)
         expect(listed[0].name).toBe('testnet')
 
-        const fetched = await store.getNetwork('testnet')
+        const fetched = await store.getNetwork('network1')
         expect(fetched.description).toBe('Test Network')
 
-        await store.removeNetwork('testnet')
+        await store.removeNetwork('network1')
         const afterRemove = await store.listNetworks()
         expect(afterRemove).toHaveLength(0)
     })

--- a/core/wallet-store/src/StoreInternal.ts
+++ b/core/wallet-store/src/StoreInternal.ts
@@ -73,20 +73,20 @@ export class StoreInternal implements Store, AuthAware<StoreInternal> {
     // Wallet methods
 
     async getWallets(filter: WalletFilter = {}): Promise<Array<Wallet>> {
-        const { networkIds, signingProviderIds } = filter
-        const networkIdSet = networkIds ? new Set(networkIds) : null
+        const { chainIds, signingProviderIds } = filter
+        const chainIdSet = chainIds ? new Set(chainIds) : null
         const signingProviderIdSet = signingProviderIds
             ? new Set(signingProviderIds)
             : null
 
         return this.getStorage().wallets.filter((wallet) => {
-            const matchedNetworkIds = networkIdSet
-                ? networkIdSet.has(wallet.networkId)
+            const matchedChainIds = chainIdSet
+                ? chainIdSet.has(wallet.chainId)
                 : true
             const matchedStorageProviderIdS = signingProviderIdSet
                 ? signingProviderIdSet.has(wallet.signingProviderId)
                 : true
-            return matchedNetworkIds && matchedStorageProviderIdS
+            return matchedChainIds && matchedStorageProviderIdS
         })
     }
 
@@ -153,14 +153,14 @@ export class StoreInternal implements Store, AuthAware<StoreInternal> {
     }
 
     // Network methods
-    async getNetwork(name: string): Promise<NetworkConfig> {
+    async getNetwork(chainId: string): Promise<NetworkConfig> {
         this.assertConnected()
 
         const networks = await this.listNetworks()
         if (!networks) throw new Error('No networks available')
 
-        const network = networks.find((n) => n.name === name)
-        if (!network) throw new Error(`Network "${name}" not found`)
+        const network = networks.find((n) => n.chainId === chainId)
+        if (!network) throw new Error(`Network "${chainId}" not found`)
         return network
     }
 
@@ -169,15 +169,15 @@ export class StoreInternal implements Store, AuthAware<StoreInternal> {
         if (!session) {
             throw new Error('No session found')
         }
-        const networkId = session.network
-        if (!networkId) {
+        const chainId = session.network
+        if (!chainId) {
             throw new Error('No current network set in session')
         }
 
         const networks = await this.listNetworks()
-        const network = networks.find((n) => n.networkId === networkId)
+        const network = networks.find((n) => n.chainId === chainId)
         if (!network) {
-            throw new Error(`Network "${networkId}" not found`)
+            throw new Error(`Network "${chainId}" not found`)
         }
         return network
     }
@@ -187,24 +187,24 @@ export class StoreInternal implements Store, AuthAware<StoreInternal> {
     }
 
     async updateNetwork(network: NetworkConfig): Promise<void> {
-        this.removeNetwork(network.name) // Ensure no duplicates
+        this.removeNetwork(network.chainId) // Ensure no duplicates
         this.systemStorage.networks.push(network)
     }
 
     async addNetwork(network: NetworkConfig): Promise<void> {
         const networkAlreadyExists = this.systemStorage.networks.find(
-            (n) => n.name === network.name
+            (n) => n.chainId === network.chainId
         )
         if (networkAlreadyExists) {
-            throw new Error(`Network ${network.name} already exists`)
+            throw new Error(`Network ${network.chainId} already exists`)
         } else {
             this.systemStorage.networks.push(network)
         }
     }
 
-    async removeNetwork(name: string): Promise<void> {
+    async removeNetwork(chainId: string): Promise<void> {
         this.systemStorage.networks = this.systemStorage.networks.filter(
-            (n) => n.name !== name
+            (n) => n.chainId !== chainId
         )
     }
 

--- a/core/wallet-store/src/config/schema.ts
+++ b/core/wallet-store/src/config/schema.ts
@@ -27,7 +27,7 @@ export const authSchema = z.discriminatedUnion('type', [
 
 export const networkConfigSchema = z.object({
     name: z.string(),
-    networkId: z.string(),
+    chainId: z.string(),
     synchronizerId: z.string(),
     description: z.string(),
     ledgerApi: ledgerApiSchema,

--- a/core/wallet-ui-components/src/components/NetworkForm.ts
+++ b/core/wallet-ui-components/src/components/NetworkForm.ts
@@ -47,9 +47,9 @@ export class NetworkForm extends LitElement {
                     required
                 />
                 <input
-                    name="networkId"
+                    name="chainId"
                     placeholder="Network Id"
-                    .value=${this.editingNetwork?.networkId ?? ''}
+                    .value=${this.editingNetwork?.chainId ?? ''}
                     required
                 />
                 <input

--- a/core/wallet-ui-components/src/components/NetworkTable.ts
+++ b/core/wallet-ui-components/src/components/NetworkTable.ts
@@ -29,7 +29,7 @@ export class NetworkTable extends LitElement {
                         (net) => html`
                             <tr>
                                 <td>${net.name}</td>
-                                <td>${net.networkId}</td>
+                                <td>${net.chainId}</td>
                                 <td>${net.description}</td>
                                 <td>${net.auth.type}</td>
                                 <td>${net.synchronizerId}</td>

--- a/core/wallet-user-rpc-client/src/index.ts
+++ b/core/wallet-user-rpc-client/src/index.ts
@@ -26,7 +26,7 @@ export type SynchronizerId = string
  * Network Id
  *
  */
-export type NetworkId = string
+export type ChainId = string
 /**
  *
  * Structure representing the connected Networks
@@ -36,7 +36,7 @@ export interface Network {
     name: Name
     description: Description
     synchronizerId: SynchronizerId
-    networkId: NetworkId
+    chainId: ChainId
     [k: string]: any
 }
 export type Type = string
@@ -97,7 +97,7 @@ export type PartyId = string
  * Filter wallets by network IDs.
  *
  */
-export type NetworkIds = NetworkId[]
+export type ChainIds = ChainId[]
 /**
  *
  * Filter wallets by signing provider IDs.
@@ -110,7 +110,7 @@ export type SigningProviderIds = SigningProviderId[]
  *
  */
 export interface WalletFilter {
-    networkIds?: NetworkIds
+    chainIds?: ChainIds
     signingProviderIds?: SigningProviderIds
     [k: string]: any
 }
@@ -152,7 +152,7 @@ export interface Wallet {
     hint: Hint
     publicKey: PublicKey
     namespace: Namespace
-    networkId: NetworkId
+    chainId: ChainId
     signingProviderId: SigningProviderId
     [k: string]: any
 }
@@ -178,7 +178,7 @@ export interface RemoveNetworkParams {
 export interface CreateWalletParams {
     primary?: Primary
     partyHint: PartyHint
-    networkId: NetworkId
+    chainId: ChainId
     signingProviderId: SigningProviderId
     [k: string]: any
 }
@@ -203,7 +203,7 @@ export interface ExecuteParams {
     [k: string]: any
 }
 export interface AddSessionParams {
-    networkId: NetworkId
+    chainId: ChainId
     [k: string]: any
 }
 /**

--- a/core/wallet-user-rpc-client/src/openrpc.json
+++ b/core/wallet-user-rpc-client/src/openrpc.json
@@ -99,8 +99,8 @@
                                 "type": "string",
                                 "description": "The party hint and name of the wallet."
                             },
-                            "networkId": {
-                                "title": "networkId",
+                            "chainId": {
+                                "title": "chainId",
                                 "type": "string",
                                 "description": "The network ID the wallet corresponds to."
                             },
@@ -112,7 +112,7 @@
                         },
                         "required": [
                             "partyHint",
-                            "networkId",
+                            "chainId",
                             "signingProviderId"
                         ]
                     }
@@ -327,13 +327,13 @@
                         "title": "AddSessionParams",
                         "type": "object",
                         "properties": {
-                            "networkId": {
-                                "title": "networkId",
+                            "chainId": {
+                                "title": "chainId",
                                 "type": "string",
                                 "description": "Network Id"
                             }
                         },
-                        "required": ["networkId"]
+                        "required": ["chainId"]
                     }
                 }
             ],
@@ -386,18 +386,13 @@
                         "type": "string",
                         "description": "Synchronizer ID"
                     },
-                    "networkId": {
-                        "title": "networkId",
+                    "chainId": {
+                        "title": "chainId",
                         "type": "string",
                         "description": "Network Id"
                     }
                 },
-                "required": [
-                    "name",
-                    "description",
-                    "networkId",
-                    "synchronizerId"
-                ]
+                "required": ["name", "description", "chainId", "synchronizerId"]
             },
             "Auth": {
                 "title": "type",
@@ -465,8 +460,8 @@
                         "type": "string",
                         "description": "The namespace of the party."
                     },
-                    "networkId": {
-                        "title": "networkId",
+                    "chainId": {
+                        "title": "chainId",
                         "type": "string",
                         "description": "The network ID the wallet corresponds to."
                     },
@@ -482,7 +477,7 @@
                     "hint",
                     "publicKey",
                     "namespace",
-                    "networkId",
+                    "chainId",
                     "signingProviderId"
                 ]
             },
@@ -491,12 +486,12 @@
                 "type": "object",
                 "description": "Filter for wallets",
                 "properties": {
-                    "networkIds": {
-                        "title": "networkIds",
+                    "chainIds": {
+                        "title": "chainIds",
                         "type": "array",
                         "description": "Filter wallets by network IDs.",
                         "items": {
-                            "title": "networkId",
+                            "title": "chainId",
                             "type": "string"
                         }
                     },


### PR DESCRIPTION
We use `networkId` and `chainId` interchangeably to refer to a [CAIP-2 blockchain ID](https://chainagnostic.org/CAIPs/caip-2), so we decided to settle on one (@mjuchli-da )

This PR also bases Store operations around networks (get, add, update...) to be keyed on `chainId` rather than the human readable network name. 