### PR TITLE
refactor ledger client instantiation  

### DIFF
--- a/clients/remote/package.json
+++ b/clients/remote/package.json
@@ -16,7 +16,6 @@
     "type": "module",
     "dependencies": {
         "@metamask/rpc-errors": "^7.0.2",
-        "axios": "^1.11.0",
         "core-ledger-client": "workspace:^",
         "core-types": "workspace:^",
         "core-wallet-auth": "workspace:^",
@@ -29,7 +28,6 @@
         "jose": "^6.0.12",
         "lit": "^3.3.0",
         "pino": "^9.7.0",
-        "qs": "^6.14.0",
         "socket.io": "^4.8.1",
         "uuid": "^11.1.0",
         "vite-express": "^0.21.1",
@@ -43,7 +41,6 @@
         "@types/express": "^5.0.2",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.30",
-        "@types/qs": "^6",
         "@types/supertest": "^6.0.3",
         "express-rate-limit": "^7.5.1",
         "jest": "^29.7.0",

--- a/clients/remote/src/dapp-api/controller.ts
+++ b/clients/remote/src/dapp-api/controller.ts
@@ -45,7 +45,6 @@ export const dappController = (
     kernelInfo: KernelInfoConfig,
     store: Store,
     notificationService: NotificationService,
-    ledgerClient: LedgerClient,
     context?: AuthContext
 ) =>
     buildController({
@@ -69,6 +68,11 @@ export const dappController = (
             if (wallet === undefined) {
                 throw new Error('No primary wallet found')
             }
+
+            const ledgerClient = new LedgerClient(
+                network.ledgerApi.baseUrl,
+                context.accessToken
+            )
 
             const userId = context.userId
             const notifier = notificationService.getNotifier(userId)
@@ -109,6 +113,11 @@ export const dappController = (
             if (wallet === undefined) {
                 throw new Error('No primary wallet found')
             }
+
+            const ledgerClient = new LedgerClient(
+                network.ledgerApi.baseUrl,
+                context.accessToken
+            )
 
             return prepareSubmission(
                 context.userId,

--- a/clients/remote/src/dapp-api/server.test.ts
+++ b/clients/remote/src/dapp-api/server.test.ts
@@ -5,7 +5,6 @@ import { dapp } from './server.js'
 import { StoreInternal } from 'core-wallet-store'
 import { AuthService } from 'core-wallet-auth'
 import { ConfigUtils } from '../config/ConfigUtils.js'
-import { LedgerClient } from 'core-ledger-client'
 import { Notifier } from '../notification/NotificationService.js'
 import { configSchema } from '../config/Config.js'
 
@@ -25,10 +24,6 @@ const configFile = ConfigUtils.loadConfigFile(configPath)
 const config = configSchema.parse(configFile)
 const store = new StoreInternal(config.store)
 
-const ledgerClient = new LedgerClient('http://localhost:5003', () =>
-    Promise.resolve('fake-token')
-)
-
 const notificationService = {
     getNotifier: jest.fn<() => Notifier>().mockReturnValue({
         on: jest.fn(),
@@ -39,13 +34,7 @@ const notificationService = {
 
 test('call connect rpc', async () => {
     const response = await request(
-        dapp(
-            config.kernel,
-            ledgerClient,
-            notificationService,
-            authService,
-            store
-        )
+        dapp(config.kernel, notificationService, authService, store)
     )
         .post('/rpc')
         .send({ jsonrpc: '2.0', id: 0, method: 'connect', params: [] })

--- a/clients/remote/src/dapp-api/server.ts
+++ b/clients/remote/src/dapp-api/server.ts
@@ -8,8 +8,6 @@ import { jwtAuth } from '../middleware/jwtAuth.js'
 import { AuthService, AuthAware } from 'core-wallet-auth'
 import { rpcRateLimit } from '../middleware/rateLimit.js'
 import cors from 'cors'
-import { LedgerClient } from 'core-ledger-client'
-
 import { createServer } from 'http'
 import { Server } from 'socket.io'
 import {
@@ -22,7 +20,6 @@ const logger = pino({ name: 'main', level: 'debug' })
 
 export const dapp = (
     kernelInfo: KernelInfo,
-    ledgerClient: LedgerClient,
     notificationService: NotificationService,
     authService: AuthService,
     store: Store & AuthAware<Store>
@@ -40,7 +37,6 @@ export const dapp = (
                     kernelInfo,
                     store.withAuthContext(req.authContext),
                     notificationService,
-                    ledgerClient,
                     req.authContext
                 ),
                 logger,

--- a/clients/remote/src/user-api/controller.ts
+++ b/clients/remote/src/user-api/controller.ts
@@ -75,7 +75,6 @@ export const userController = (
     store: Store,
     notificationService: NotificationService,
     authContext: AuthContext | undefined,
-    ledgerClient: LedgerClient,
     _logger: Logger
 ) => {
     const logger = _logger.child({ component: 'user-controller' })
@@ -135,6 +134,17 @@ export const userController = (
                 ? notificationService.getNotifier(authContext.userId)
                 : undefined
 
+            const network = await store.getCurrentNetwork()
+
+            if (authContext === undefined || network === undefined) {
+                throw new Error('Unauthenticated context')
+            }
+
+            const ledgerClient = new LedgerClient(
+                network.ledgerApi.baseUrl,
+                authContext?.accessToken
+            )
+
             const result = await signingDriverCreate(
                 store,
                 notifier,
@@ -178,6 +188,15 @@ export const userController = (
             const notifier = notificationService.getNotifier(userId)
 
             const transaction = await store.getTransaction(commandId)
+
+            if (authContext === undefined || network === undefined) {
+                throw new Error('Unauthenticated context')
+            }
+
+            const ledgerClient = new LedgerClient(
+                network.ledgerApi.baseUrl,
+                authContext?.accessToken
+            )
 
             switch (wallet.signingProviderId) {
                 case 'participant': {

--- a/clients/remote/src/user-api/server.test.ts
+++ b/clients/remote/src/user-api/server.test.ts
@@ -5,7 +5,6 @@ import { user } from './server.js'
 import { StoreInternal } from 'core-wallet-store'
 import { AuthService } from 'core-wallet-auth'
 import { ConfigUtils } from '../config/ConfigUtils.js'
-import { LedgerClient } from 'core-ledger-client'
 import { Notifier } from '../notification/NotificationService.js'
 import { configSchema } from '../config/Config.js'
 
@@ -24,9 +23,6 @@ const configFile = ConfigUtils.loadConfigFile(configPath)
 const config = configSchema.parse(configFile)
 
 const store = new StoreInternal(config.store)
-const ledgerClient = new LedgerClient('http://localhost:5003', async () => {
-    return ''
-})
 
 const notificationService = {
     getNotifier: jest.fn<() => Notifier>().mockReturnValue({
@@ -38,13 +34,7 @@ const notificationService = {
 
 test('call connect rpc', async () => {
     const response = await request(
-        user(
-            config.kernel,
-            ledgerClient,
-            notificationService,
-            authService,
-            store
-        )
+        user(config.kernel, notificationService, authService, store)
     )
         .post('/rpc')
         .send({ jsonrpc: '2.0', id: 0, method: 'listNetworks', params: [] })

--- a/clients/remote/src/user-api/server.ts
+++ b/clients/remote/src/user-api/server.ts
@@ -8,7 +8,6 @@ import { AuthService, AuthAware } from 'core-wallet-auth'
 import { jwtAuth } from '../middleware/jwtAuth.js'
 import { rpcRateLimit } from '../middleware/rateLimit.js'
 import cors from 'cors'
-import { LedgerClient } from 'core-ledger-client'
 import { NotificationService } from '../notification/NotificationService.js'
 import { KernelInfo } from '../config/Config.js'
 
@@ -16,7 +15,6 @@ const logger = pino({ name: 'main', level: 'debug' })
 
 export const user = (
     kernelInfo: KernelInfo,
-    ledgerClient: LedgerClient,
     notificationService: NotificationService,
     authService: AuthService,
     store: Store & AuthAware<Store>
@@ -35,7 +33,6 @@ export const user = (
                     store.withAuthContext(req.authContext),
                     notificationService,
                     req.authContext,
-                    ledgerClient,
                     logger
                 ),
                 logger,

--- a/core/ledger-client/src/LedgerClient.ts
+++ b/core/ledger-client/src/LedgerClient.ts
@@ -20,12 +20,10 @@ export class LedgerClient {
     private readonly client: Client<paths>
     private readonly getToken!: () => Promise<string>
 
-    constructor(baseUrl: string, getToken: () => Promise<string>) {
-        this.getToken = getToken
+    constructor(baseUrl: string, token: string) {
         this.client = createClient<paths>({
             baseUrl,
             fetch: async (url: RequestInfo, options: RequestInit = {}) => {
-                const token = await this.getToken()
                 return fetch(url, {
                     ...options,
                     headers: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3209,7 +3209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/qs@npm:*, @types/qs@npm:^6":
+"@types/qs@npm:*":
   version: 6.14.0
   resolution: "@types/qs@npm:6.14.0"
   checksum: 10c0/5b3036df6e507483869cdb3858201b2e0b64b4793dc4974f188caa5b5732f2333ab9db45c08157975054d3b070788b35088b4bc60257ae263885016ee2131310
@@ -4902,9 +4902,7 @@ __metadata:
     "@types/express": "npm:^5.0.2"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.15.30"
-    "@types/qs": "npm:^6"
     "@types/supertest": "npm:^6.0.3"
-    axios: "npm:^1.11.0"
     core-ledger-client: "workspace:^"
     core-types: "workspace:^"
     core-wallet-auth: "workspace:^"
@@ -4920,7 +4918,6 @@ __metadata:
     lit: "npm:^3.3.0"
     pino: "npm:^9.7.0"
     pino-pretty: "npm:^13.0.0"
-    qs: "npm:^6.14.0"
     socket.io: "npm:^4.8.1"
     supertest: "npm:^7.1.1"
     ts-jest-resolver: "npm:^2.0.1"


### PR DESCRIPTION
Refactors the ledger client to be instantiated per request and to use the access token from the authContext of the request and the baseUrl from the network configuration based off of the currentSession.