### PR TITLE
docs: add party allocation example

### DIFF
--- a/clients/remote/src/ledger/party-allocation-service.test.ts
+++ b/clients/remote/src/ledger/party-allocation-service.test.ts
@@ -18,6 +18,7 @@ const MockTopologyWriteService: jest.MockedClass<any> = jest
         }),
         addTransactions: jest.fn<AsyncFn>(),
         authorizePartyToParticipant: jest.fn<AsyncFn>(),
+        submitExternalPartyTopology: jest.fn<AsyncFn>(),
     }))
 
 // Add static method to the mock class

--- a/clients/remote/src/ledger/party-allocation-service.ts
+++ b/clients/remote/src/ledger/party-allocation-service.ts
@@ -124,8 +124,10 @@ export class PartyAllocationService {
             )
         )
 
-        await this.topologyClient.addTransactions(signedTopologyTxs)
-        await this.topologyClient.authorizePartyToParticipant(partyId)
+        await this.topologyClient.submitExternalPartyTopology(
+            signedTopologyTxs,
+            partyId
+        )
         await this.ledgerClient.grantUserRights(userId, partyId)
 
         return { hint, partyId, namespace }

--- a/core/ledger-client/src/TopologyWriteService.ts
+++ b/core/ledger-client/src/TopologyWriteService.ts
@@ -240,6 +240,14 @@ export class TopologyWriteService {
         })
     }
 
+    async submitExternalPartyTopology(
+        signedTopologyTxs: SignedTopologyTransaction[],
+        partyId: string
+    ) {
+        await this.addTransactions(signedTopologyTxs)
+        await this.authorizePartyToParticipant(partyId)
+    }
+
     async generateTransactions(
         publicKey: string,
         partyId: string
@@ -266,7 +274,7 @@ export class TopologyWriteService {
         }).response
     }
 
-    async addTransactions(
+    private async addTransactions(
         signedTopologyTxs: SignedTopologyTransaction[]
     ): Promise<AddTransactionsResponse> {
         const request = AddTransactionsRequest.create({
@@ -318,7 +326,7 @@ export class TopologyWriteService {
         })
     }
 
-    async authorizePartyToParticipant(
+    private async authorizePartyToParticipant(
         partyId: string
     ): Promise<AuthorizeResponse> {
         const hash = await this.waitForPartyToParticipantProposal(partyId)

--- a/docs/wallet-integration-guide/examples/01-auth.ts
+++ b/docs/wallet-integration-guide/examples/01-auth.ts
@@ -75,14 +75,15 @@ if (preparedParty) {
     console.error('Error creating prepared party.')
 }
 
-const createPingCommand = (party: string) => [
+console.log('Create ping command')
+const createPingCommand = [
     {
         CreateCommand: {
             templateId: '#AdminWorkflows:Canton.Internal.Ping:Ping',
             createArguments: {
-                id: 'my-test',
-                initiator: party,
-                responder: party,
+                id: v4(),
+                initiator: preparedParty!.partyId!,
+                responder: preparedParty!.partyId!,
             },
         },
     },
@@ -91,15 +92,21 @@ const createPingCommand = (party: string) => [
 sdk.userLedger?.setPartyId(preparedParty!.partyId!)
 
 const commandId = v4()
+
+console.log('Prepare command submission for ping create command')
 const prepareResponse = await sdk.userLedger?.prepareSubmission(
-    createPingCommand(preparedParty!.partyId!),
+    createPingCommand,
     v4()
 )
+
+console.log('Sign transaction hash')
 
 const signedCommandHash = signTransactionHash(
     prepareResponse!.preparedTransactionHash!,
     keyPair.privateKey
 )
+
+console.log('Submit command')
 
 sdk.userLedger?.executeSubmission(
     prepareResponse!,

--- a/docs/wallet-integration-guide/examples/01-auth.ts
+++ b/docs/wallet-integration-guide/examples/01-auth.ts
@@ -91,13 +91,9 @@ const createPingCommand = [
 
 sdk.userLedger?.setPartyId(preparedParty!.partyId!)
 
-const commandId = v4()
-
 console.log('Prepare command submission for ping create command')
-const prepareResponse = await sdk.userLedger?.prepareSubmission(
-    createPingCommand,
-    v4()
-)
+const prepareResponse =
+    await sdk.userLedger?.prepareSubmission(createPingCommand)
 
 console.log('Sign transaction hash')
 
@@ -108,9 +104,19 @@ const signedCommandHash = signTransactionHash(
 
 console.log('Submit command')
 
-sdk.userLedger?.executeSubmission(
-    prepareResponse!,
-    signedCommandHash,
-    keyPair.publicKey,
-    commandId
-)
+sdk.userLedger
+    ?.executeSubmission(
+        prepareResponse!,
+        signedCommandHash,
+        keyPair.publicKey,
+        v4()
+    )
+    .then((executeSubmissionResponse) => {
+        console.log(
+            'Executed command submission succeeded',
+            executeSubmissionResponse
+        )
+    })
+    .catch((error) =>
+        console.error('Failed to submit command with error %d', error)
+    )

--- a/docs/wallet-integration-guide/examples/01-auth.ts
+++ b/docs/wallet-integration-guide/examples/01-auth.ts
@@ -76,18 +76,9 @@ if (preparedParty) {
 }
 
 console.log('Create ping command')
-const createPingCommand = [
-    {
-        CreateCommand: {
-            templateId: '#AdminWorkflows:Canton.Internal.Ping:Ping',
-            createArguments: {
-                id: v4(),
-                initiator: preparedParty!.partyId!,
-                responder: preparedParty!.partyId!,
-            },
-        },
-    },
-]
+const createPingCommand = await sdk.topology?.createPingCommand(
+    preparedParty!.partyId!
+)
 
 sdk.userLedger?.setPartyId(preparedParty!.partyId!)
 

--- a/docs/wallet-integration-guide/examples/01-auth.ts
+++ b/docs/wallet-integration-guide/examples/01-auth.ts
@@ -1,4 +1,5 @@
 import { createKeyPair, signTransactionHash } from '@splice/core-signing-lib'
+import { v4 } from 'uuid'
 import {
     localAuthDefault,
     localLedgerDefault,
@@ -43,15 +44,11 @@ await sdk.connectTopology()
 console.log('Connected to topology')
 
 const keyPair = createKeyPair()
-console.log('public key is:  ' + keyPair.publicKey)
-console.log('Created keypair')
+
 const preparedParty = await sdk.topology?.prepareExternalPartyTopology(
     keyPair.publicKey,
-    'my-test-party1'
+    v4()
 )
-
-console.log('namspace is,' + preparedParty?.namespace)
-console.log('Prepared external party topology')
 
 if (preparedParty) {
     const base64StringCombinedHash = Buffer.from(

--- a/docs/wallet-integration-guide/examples/01-auth.ts
+++ b/docs/wallet-integration-guide/examples/01-auth.ts
@@ -48,8 +48,7 @@ const keyPair = createKeyPair()
 
 console.log('generated keypair')
 const preparedParty = await sdk.topology?.prepareExternalPartyTopology(
-    keyPair.publicKey,
-    v4()
+    keyPair.publicKey
 )
 
 console.log('Prepared external topology')
@@ -65,7 +64,6 @@ if (preparedParty) {
         base64StringCombinedHash,
         keyPair.privateKey
     )
-    console.log('Signed the hash for partyId: ' + preparedParty.partyId)
 
     await sdk.topology
         ?.submitExternalPartyTopology(signedHash, preparedParty)

--- a/docs/wallet-integration-guide/examples/01-auth.ts
+++ b/docs/wallet-integration-guide/examples/01-auth.ts
@@ -45,20 +45,26 @@ console.log('Connected to topology')
 
 const keyPair = createKeyPair()
 
+console.log('generated keypair')
 const preparedParty = await sdk.topology?.prepareExternalPartyTopology(
     keyPair.publicKey,
     v4()
 )
 
+console.log('Prepared external topology')
+
 if (preparedParty) {
+    console.log('Signing the hash')
     const base64StringCombinedHash = Buffer.from(
         preparedParty?.combinedHash,
         'hex'
     ).toString('base64')
+
     const signedHash = signTransactionHash(
         base64StringCombinedHash,
         keyPair.privateKey
     )
+    console.log('Signed the hash for partyId: ' + preparedParty.partyId)
 
     await sdk.topology
         ?.submitExternalPartyTopology(signedHash, preparedParty)

--- a/docs/wallet-integration-guide/examples/01-auth.ts
+++ b/docs/wallet-integration-guide/examples/01-auth.ts
@@ -1,10 +1,11 @@
-import { createKeyPair, signTransactionHash } from '@splice/core-signing-lib'
 import { v4 } from 'uuid'
 import {
     localAuthDefault,
     localLedgerDefault,
     localTopologyDefault,
     WalletSDKImpl,
+    createKeyPair,
+    signTransactionHash,
 } from '@splice/sdk-wallet'
 
 const sdk = new WalletSDKImpl().configure({

--- a/docs/wallet-integration-guide/examples/01-auth.ts
+++ b/docs/wallet-integration-guide/examples/01-auth.ts
@@ -43,13 +43,23 @@ await sdk.connectTopology()
 console.log('Connected to topology')
 
 const keyPair = createKeyPair()
+console.log('public key is:  ' + keyPair.publicKey)
+console.log('Created keypair')
 const preparedParty = await sdk.topology?.prepareExternalPartyTopology(
-    keyPair.publicKey
+    keyPair.publicKey,
+    'my-test-party1'
 )
 
+console.log('namspace is,' + preparedParty?.namespace)
+console.log('Prepared external party topology')
+
 if (preparedParty) {
-    const signedHash = signTransactionHash(
+    const base64StringCombinedHash = Buffer.from(
         preparedParty?.combinedHash,
+        'hex'
+    ).toString('base64')
+    const signedHash = signTransactionHash(
+        base64StringCombinedHash,
         keyPair.privateKey
     )
 

--- a/docs/wallet-integration-guide/examples/01-auth.ts
+++ b/docs/wallet-integration-guide/examples/01-auth.ts
@@ -79,11 +79,11 @@ const createPingCommand = await sdk.topology?.createPingCommand(
     preparedParty!.partyId!
 )
 
-sdk.userLedger?.setPartyId(preparedParty!.partyId!)
+sdk.adminLedger?.setPartyId(preparedParty!.partyId!)
 
 console.log('Prepare command submission for ping create command')
 const prepareResponse =
-    await sdk.userLedger?.prepareSubmission(createPingCommand)
+    await sdk.adminLedger?.prepareSubmission(createPingCommand)
 
 console.log('Sign transaction hash')
 
@@ -94,7 +94,7 @@ const signedCommandHash = signTransactionHash(
 
 console.log('Submit command')
 
-sdk.userLedger
+sdk.adminLedger
     ?.executeSubmission(
         prepareResponse!,
         signedCommandHash,

--- a/docs/wallet-integration-guide/examples/package.json
+++ b/docs/wallet-integration-guide/examples/package.json
@@ -13,6 +13,7 @@
         "run-01": "tsx ./01-auth.ts"
     },
     "devDependencies": {
+        "@types/node": "^24.3.0",
         "tsx": "^4.20.3",
         "typescript": "^5.8.3"
     },

--- a/docs/wallet-integration-guide/examples/package.json
+++ b/docs/wallet-integration-guide/examples/package.json
@@ -15,7 +15,8 @@
     "devDependencies": {
         "@types/node": "^24.3.0",
         "tsx": "^4.20.3",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "uuid": "^11.1.0"
     },
     "dependencies": {
         "@splice/core-signing-lib": "workspace:^",

--- a/docs/wallet-integration-guide/examples/package.json
+++ b/docs/wallet-integration-guide/examples/package.json
@@ -19,7 +19,6 @@
         "uuid": "^11.1.0"
     },
     "dependencies": {
-        "@splice/core-signing-lib": "workspace:^",
         "@splice/sdk-wallet": "workspace:^"
     }
 }

--- a/docs/wallet-integration-guide/examples/package.json
+++ b/docs/wallet-integration-guide/examples/package.json
@@ -17,6 +17,7 @@
         "typescript": "^5.8.3"
     },
     "dependencies": {
+        "@splice/core-signing-lib": "workspace:^",
         "@splice/sdk-wallet": "workspace:^"
     }
 }

--- a/sdk/wallet-sdk/src/index.ts
+++ b/sdk/wallet-sdk/src/index.ts
@@ -9,6 +9,7 @@ import { Logger } from '@splice/core-types'
 export * from './ledgerController.js'
 export * from './authController.js'
 export * from './topologyController.js'
+export { signTransactionHash, createKeyPair } from '@splice/core-signing-lib'
 
 type AuthFactory = () => AuthController
 type LedgerFactory = (userId: string, token: string) => LedgerController

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -57,10 +57,9 @@ export class TopologyController {
         const namespace =
             TopologyWriteService.createFingerprintFromKey(publicKey)
 
-        //can't use base64 encoded public key because it has invalid charcters
         const partyId = partyHint
             ? `${partyHint}::${namespace}`
-            : `${publicKey}::${namespace}`
+            : `${namespace}::${namespace}`
 
         const transactions = await this.topologyClient
             .generateTransactions(publicKey, partyId)

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -56,6 +56,7 @@ export class TopologyController {
         const namespace =
             TopologyWriteService.createFingerprintFromKey(publicKey)
 
+        //can't use base64 encoded public key because it has invalid charcters
         const partyId = partyHint
             ? `${partyHint}::${namespace}`
             : `${publicKey}::${namespace}`
@@ -152,7 +153,7 @@ export const localTopologyDefault = (
     userAdminToken: string
 ): TopologyController => {
     return new TopologyController(
-        'http://127.0.0.1:5012',
+        '127.0.0.1:5012',
         'http://127.0.0.1:5003',
         userId,
         userAdminToken,

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -102,7 +102,7 @@ export class TopologyController {
 
         await this.topologyClient.addTransactions(signedTopologyTxs)
         await this.topologyClient.authorizePartyToParticipant(
-            preparedParty.namespace
+            preparedParty.partyId
         )
         await this.client.grantUserRights(this.userId, preparedParty.partyId)
 

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -116,8 +116,8 @@ export class TopologyController {
                 )
         )
 
-        await this.topologyClient.addTransactions(signedTopologyTxs)
-        await this.topologyClient.authorizePartyToParticipant(
+        await this.topologyClient.submitExternalPartyTopology(
+            signedTopologyTxs,
             preparedParty.partyId
         )
         await this.client.grantUserRights(this.userId, preparedParty.partyId)

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -5,6 +5,7 @@ import {
 } from '@splice/core-ledger-client'
 import { signTransactionHash } from '@splice/core-signing-lib'
 import { pino } from 'pino'
+import { v4 } from 'uuid'
 
 export type PreparedParty = {
     partyTransactions: Uint8Array<ArrayBufferLike>[]
@@ -84,6 +85,21 @@ export class TopologyController {
         }
 
         return Promise.resolve(result)
+    }
+
+    createPingCommand(partyId: string) {
+        return [
+            {
+                CreateCommand: {
+                    templateId: '#AdminWorkflows:Canton.Internal.Ping:Ping',
+                    createArguments: {
+                        id: v4(),
+                        initiator: partyId,
+                        responder: partyId,
+                    },
+                },
+            },
+        ]
     }
 
     async submitExternalPartyTopology(

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -59,7 +59,7 @@ export class TopologyController {
 
         const partyId = partyHint
             ? `${partyHint}::${namespace}`
-            : `${namespace}::${namespace}`
+            : `${namespace.slice(0, 5)}::${namespace}`
 
         const transactions = await this.topologyClient
             .generateTransactions(publicKey, partyId)

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -123,8 +123,8 @@ export class TopologyController {
         privateKey: string
     ): Promise<AllocatedParty> {
         const preparedParty = await this.prepareExternalPartyTopology(
-            partyHint,
-            publicKey
+            publicKey,
+            partyHint
         )
         const signedHash = signTransactionHash(
             preparedParty.combinedHash,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8145,6 +8145,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docs-wallet-integration-guide-examples@workspace:docs/wallet-integration-guide/examples"
   dependencies:
+    "@splice/core-signing-lib": "workspace:^"
     "@splice/sdk-wallet": "workspace:^"
     tsx: "npm:^4.20.3"
     typescript: "npm:^5.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8150,6 +8150,7 @@ __metadata:
     "@types/node": "npm:^24.3.0"
     tsx: "npm:^4.20.3"
     typescript: "npm:^5.8.3"
+    uuid: "npm:^11.1.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8145,7 +8145,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docs-wallet-integration-guide-examples@workspace:docs/wallet-integration-guide/examples"
   dependencies:
-    "@splice/core-signing-lib": "workspace:^"
     "@splice/sdk-wallet": "workspace:^"
     "@types/node": "npm:^24.3.0"
     tsx: "npm:^4.20.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8147,6 +8147,7 @@ __metadata:
   dependencies:
     "@splice/core-signing-lib": "workspace:^"
     "@splice/sdk-wallet": "workspace:^"
+    "@types/node": "npm:^24.3.0"
     tsx: "npm:^4.20.3"
     typescript: "npm:^5.8.3"
   languageName: unknown


### PR DESCRIPTION
This adds an example for how to use the wallet-sdk to allocate an external party and command submission.