### PR TITLE
ci: add workflow to lint PR titles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: CI on PRs (Splice Contributors)
 run-name: ${{ github.actor }} is perfoming a Pull Request
-on: push
+on: pull_request
 permissions:
     contents: read
 
@@ -23,8 +23,10 @@ jobs:
             - name: Install dependencies
               run: yarn install --immutable
 
-            # - name: Validate current commit with commitlint
-            #   run: yarn commitlint --last --verbose
+            - name: Validate current PR title with commitlint
+              run: echo "$TITLE" | yarn commitlint --verbose
+              env:
+                  TITLE: ${{ github.event.pull_request.title }}
 
             - name: prettier code
               run: yarn run prettier . --check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
             - name: Install dependencies
               run: yarn install --immutable
 
-            - name: Validate current commit with commitlint
-              run: yarn commitlint --last --verbose
+            # - name: Validate current commit with commitlint
+            #   run: yarn commitlint --last --verbose
 
             - name: prettier code
               run: yarn run prettier . --check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: CI on PRs (Splice Contributors)
 run-name: ${{ github.actor }} is perfoming a Pull Request
-on: pull_request
+on: push
 permissions:
     contents: read
 
@@ -22,11 +22,6 @@ jobs:
 
             - name: Install dependencies
               run: yarn install --immutable
-
-            - name: Validate current PR title with commitlint
-              run: echo "$TITLE" | yarn commitlint --verbose
-              env:
-                  TITLE: ${{ github.event.pull_request.title }}
 
             - name: prettier code
               run: yarn run prettier . --check

--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -1,0 +1,31 @@
+name: Conventional Commits
+run-name: Validating PR title
+on:
+    pull_request:
+        types: [opened, reopened, synchronize, edited]
+permissions:
+    contents: read
+
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Enable Corepack
+              run: corepack enable
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 'v22.16.0'
+                  cache: 'yarn'
+
+            - name: Install dependencies
+              run: yarn install --immutable
+
+            - name: Validate current PR title with commitlint
+              run: echo "$TITLE" | yarn commitlint --verbose
+              env:
+                  TITLE: ${{ github.event.pull_request.title }}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-yarn commitlint --edit $1
+# yarn commitlint --edit $1

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,0 @@
-# yarn commitlint --edit $1


### PR DESCRIPTION
Linting each individual commit per PR push had some issues:

1. By default, PRs squash their commits when merging into `main` -- this makes `commitlint` on every dev's on a PR meaningless
2. Once merged, the commit on `main` always starts with the PR's title, so the final commits wouldnt even get the format. 

ergo, its probably better to be linting PR titles, not dev commits