### PR TITLE
chore: allow starting workflow manually (for non-contributors)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: CI on PRs (Splice Contributors)
 run-name: ${{ github.actor }} is perfoming a Pull Request
-on: push
+on: [push, workflow_dispatch]
 permissions:
     contents: read
 


### PR DESCRIPTION
chore: added worflow_dispatch to our build, this allow it to be manually triggered for non-contributors