### PR TITLE
docs: fix some warnings in the docs

### DIFF
--- a/docs/wallet-integration-guide/conf.py
+++ b/docs/wallet-integration-guide/conf.py
@@ -3,4 +3,5 @@ project = "Wallet Integration Guide"
 extensions = [
     'sphinx_copybutton',
     'sphinx_tabs.tabs',
+    'sphinx.ext.todo',
 ]

--- a/docs/wallet-integration-guide/src/canton-network-overview/index.rst
+++ b/docs/wallet-integration-guide/src/canton-network-overview/index.rst
@@ -20,7 +20,7 @@ largest financial and crypto institutions alike. Participants include Goldman Sa
 like DTCC and Deutsche Börse, and (crypto) trading firms like DRW and QCP.
 
 Canton's High-level architecture
----------------------
+--------------------------------
 Nodes and Consensus
 ^^^^^^^^^^^^^^^^^^^
 The Canton network is composed of nodes known as **validators** that achieve consensus through **synchronizers**. 
@@ -32,6 +32,7 @@ Transaction data is only distributed on a **need-to-know basis** to maintain con
 * In Canton, state and transactions get distributed only to nodes/validators that are specified in the smart contracts.
 
 .. _parties:
+
 Parties
 ^^^^^^^
 In Canton, **parties** are the core on-ledger identities, and are the wallet addresses, similar to an address or Externally Owned Account 

--- a/docs/wallet-integration-guide/src/finding-and-reading-data/index.rst
+++ b/docs/wallet-integration-guide/src/finding-and-reading-data/index.rst
@@ -1,5 +1,5 @@
 Finding and Reading Data
-=======================
+========================
 
 
 Reading from ledger
@@ -12,7 +12,7 @@ To facilitate this change easily, the ledger controller
 in the Wallet SDK allows you to change these, but forces them to be required for certain operations.
 This is to ensure that you always have the correct context when reading data from the ledger.
 
-.. literalinclude:: ../../examples/snippets/change-party-and-syncrhonizer.ts
+.. literalinclude:: ../../examples/snippets/change-party-and-synchronizer.ts
     :language: typescript
     :dedent:
 


### PR DESCRIPTION
There are a handful of warnings in the docs that are really minor and easy to fix.

There are still more warnings that need to be addressed before they can fail the build, but I'll bank the wins I have here in this PR.