### PR TITLE
fix: core-tx-visualizer imports

### DIFF
--- a/core/tx-visualizer/src/hashing_scheme_v2.ts
+++ b/core/tx-visualizer/src/hashing_scheme_v2.ts
@@ -15,7 +15,7 @@ import {
     TextMap_Entry,
     Value,
 } from '@splice/core-ledger-proto'
-import { mkByteArray, sha256 } from './utils'
+import { mkByteArray, sha256 } from './utils.js'
 
 // Hash purpose reserved for prepared transaction
 const PREPARED_TRANSACTION_HASH_PURPOSE = Uint8Array.from([

--- a/core/tx-visualizer/src/index.ts
+++ b/core/tx-visualizer/src/index.ts
@@ -1,6 +1,6 @@
 import { PreparedTransaction } from '@splice/core-ledger-proto'
-import { computePreparedTransaction } from './hashing_scheme_v2'
-import { fromBase64, toBase64, toHex } from './utils'
+import { computePreparedTransaction } from './hashing_scheme_v2.js'
+import { fromBase64, toBase64, toHex } from './utils.js'
 
 /**
  * Decodes a base64 encoded prepared transaction into a well-typed data model, generated directly from Protobuf definitions.


### PR DESCRIPTION
Fixes this error when we run the example party allocation script with `yarn workspace docs-wallet-integration-guide-examples run-01`


```
 node:internal/modules/run_main:123
    triggerUncaughtException(
    ^
Error: Qualified path resolution failed: we looked for the following paths, but none could be accessed.

Source path: /Users/rukminibasu/Desktop/IdeaProjects/splice-wallet-kernel/core/tx-visualizer/dist/hashing_scheme_v2
Not found: /Users/rukminibasu/Desktop/IdeaProjects/splice-wallet-kernel/core/tx-visualizer/dist/hashing_scheme_v2

    at makeError (/Users/rukminibasu/Desktop/IdeaProjects/splice-wallet-kernel/.pnp.cjs:26799:34)
    at resolveUnqualified (/Users/rukminibasu/Desktop/IdeaProjects/splice-wallet-kernel/.pnp.cjs:28534:13)
    at resolveRequest (/Users/rukminibasu/Desktop/IdeaProjects/splice-wallet-kernel/.pnp.cjs:28574:14)
    at Object.resolveRequest (/Users/rukminibasu/Desktop/IdeaProjects/splice-wallet-kernel/.pnp.cjs:28630:26)
    at resolve$1 (file:///Users/rukminibasu/Desktop/IdeaProjects/splice-wallet-kernel/.pnp.loader.mjs:2043:21)
    at nextResolve (node:internal/modules/esm/hooks:748:28)
    at resolveBase (file:///Users/rukminibasu/.yarn/berry/cache/tsx-npm-4.20.5-9ac8e9c8bf-10c0.zip/node_modules/tsx/dist/esm/index.mjs?1756322619029:2:3744)
    at resolveDirectory (file:///Users/rukminibasu/.yarn/berry/cache/tsx-npm-4.20.5-9ac8e9c8bf-10c0.zip/node_modules/tsx/dist/esm/index.mjs?1756322619029:2:4243)
    at resolveTsPaths (file:///Users/rukminibasu/.yarn/berry/cache/tsx-npm-4.20.5-9ac8e9c8bf-10c0.zip/node_modules/tsx/dist/esm/index.mjs?1756322619029:2:4984)
    at resolve (file:///Users/rukminibasu/.yarn/berry/cache/tsx-npm-4.20.5-9ac8e9c8bf-10c0.zip/node_modules/tsx/dist/esm/index.mjs?1756322619029:2:5361)
```