### PR TITLE
ci: improve release pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish packages
+run-name: Publishing to npm
+
+on:
+    push:
+        branches:
+            - latest
+permissions:
+    contents: read
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  fetch-tags: true
+
+            - name: Enable Corepack
+              run: corepack enable
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 'v22.16.0'
+                  cache: 'yarn'
+
+            - name: Install dependencies
+              run: yarn install --immutable
+
+            - name: Generate
+              run: yarn generate:all
+
+            - name: Build
+              run: yarn build:all
+
+            # NX does not currently support publishing through yarn: https://github.com/nrwl/nx/issues/29242
+            # So we publish all workspaces through yarn directly
+            - name: Publish
+              run: |
+                  yarn config set npmAuthToken ${{ secrets.NPM_TOKEN_DA }}
+                  yarn workspaces foreach --no-private -t -A --include 'core/*' --include 'sdk/*' npm publish --tolerate-republish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
-name: Release packages
+name: Version and release
 run-name: ${{ github.actor }} is cutting a release
 on:
-    push:
+    pull_request:
+        types: [opened, reopened, synchronize, edited]
         branches:
             - latest
 permissions:
@@ -34,18 +35,12 @@ jobs:
                   git config --global user.name github-actions
                   git config --global user.email github-actions@github.com
 
-            - name: Generate
-              run: yarn generate:all
-
-            - name: Build
-              run: yarn build:all
-
             - name: Release
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: yarn nx release --skip-publish
 
-            - name: Open Release PR
+            - name: Open Version Bump PR
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
@@ -66,10 +61,3 @@ jobs:
                   git push origin $BRANCH_NAME
 
                   gh pr create -f -a ${{ github.actor }} -B main
-
-            # NX does not currently support publishing through yarn: https://github.com/nrwl/nx/issues/29242
-            # So we publish all workspaces through yarn directly
-            - name: Publish
-              run: |
-                  yarn config set npmAuthToken ${{ secrets.NPM_TOKEN_DA }}
-                  yarn workspaces foreach --no-private -t -A --include 'core/*' --include 'sdk/*' npm publish --tolerate-republish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
             - latest
 permissions:
     contents: write
-    pull-requests: write
 jobs:
     release:
         runs-on: ubuntu-latest
@@ -38,26 +37,4 @@ jobs:
             - name: Release
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: yarn nx release --skip-publish
-
-            - name: Open Version Bump PR
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  BRANCH_NAME=ci/${{ github.run_id }}
-                  RELEASE_COMMIT_HASH=$(git log --pretty=oneline | grep "chore(release)" | cut -d " " -f 1)
-
-                  if [[ -z $RELEASE_COMMIT_HASH ]]; then
-                      echo "No release commit found"
-                      exit 1
-                  fi
-
-                  git checkout main
-                  git branch $BRANCH_NAME
-
-                  git checkout $BRANCH_NAME
-                  git cherry-pick $RELEASE_COMMIT_HASH
-
-                  git push origin $BRANCH_NAME
-
-                  gh pr create -f -a ${{ github.actor }} -B main
+              run: yarn nx release --skip-publish --dry-run

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,10 @@
+# Release
+
+This repository is a monorepo of independently versioned Javascript packages. We use Conventional Commits to track changes to individual packages over time. When it comes time to publish updates to NPM, a maintainer runs through the following process:
+
+1. Open a PR from `main` against `latest`
+2. Wait for the `release.yml` workflow to complete on the PR -- this pushes new tags and commits to the branch
+3. Merge into `latest`
+4. Wait for the `publish.yml` workflow to complete on `latest`. Afterwards, any updated packages should be pushed to NPM
+    - Check the page here to confirm: https://www.npmjs.com/org/canton-network
+5. Open a PR from `latest` back into `main` to merge in the package.json changes


### PR DESCRIPTION
The pipeline as implemented before seemed brittle, and prone to causing git conflicts. I think this is an improvement:

1. Open a Release PR from `main` to `latest`
2. Before merging, the Release PR triggers an `nx release`
3. This pushes the new tags/releases, adds a version bump commit to the same PR, and also opens a version bump PR against `main`
4. The Release PR is merged into `latest`, which now already contains the version bumps
5. The Publish workflow now runs on `latest`, which only publishes to NPM
6. We merge the Version Bump PR back into `main`, and the flow is complete

When it comes time for the next bump, there _should_ be no conflicts, because `main` and `latest` have the same code on both of them at this point