### PR TITLE
docs: backport of a handful of fixes

### DIFF
--- a/docs/wallet-integration-guide/src/exchange-integration/workflows.rst
+++ b/docs/wallet-integration-guide/src/exchange-integration/workflows.rst
@@ -241,10 +241,11 @@ We therefore recommend the following approach:
 * Consider keeping a pool of `k` large amount UTXOs to be able to execute up to `k`
   withdrawals at the same time.
   Run a periodic background job to manage this pool using self-transfers.
-    * From an implementation perspective, these self-transfers are a special kind of
-      withdrawal. We thus recommend to implement them using the same code path as withdrawals:
-      start with writing the self-transfer request into the Canton Integration DB and have
-      the Withdrawal Automation execute it.
+
+  * From an implementation perspective, these self-transfers are a special kind of
+    withdrawal. We thus recommend to implement them using the same code path as withdrawals:
+    start with writing the self-transfer request into the Canton Integration DB and have
+    the Withdrawal Automation execute it.
 
 
 .. _mvp-for-cn-tokens:

--- a/docs/wallet-integration-guide/src/fees/index.rst
+++ b/docs/wallet-integration-guide/src/fees/index.rst
@@ -1,7 +1,3 @@
-Fees
-====
-
-
 ..
    Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 ..


### PR DESCRIPTION
Backport a handful of fixes to the docs:

* `fees/index.rst` is not permitted to have multiple top-level headers in DA's consolidated docs build
* `exchange-integration/workflows.rst` has some bad indentation; fix that too.