### PR TITLE
feat(core-scan-client): fetch amulet active synchronizer id

### DIFF
--- a/core/scan-client/src/scan-client.ts
+++ b/core/scan-client/src/scan-client.ts
@@ -108,4 +108,29 @@ export class ScanClient {
             return Promise.resolve(response.data)
         }
     }
+
+    public async GetAmuletSynchronizerId(): Promise<string | undefined> {
+        const dsoInfo = await this.get('/v0/dso')
+
+        const payloadObj = JSON.parse(
+            JSON.stringify(dsoInfo.amulet_rules.contract.payload)
+        )
+
+        const initActiveSynchronizer =
+            payloadObj?.configSchedule?.initialValue?.decentralizedSynchronizer
+                ?.activeSynchronizer
+        const futureValues = payloadObj?.configSchedule?.futureValues as []
+
+        if (futureValues.length > 0) {
+            let updatedValue = undefined
+            for (const value of futureValues) {
+                const parsed = JSON.parse(JSON.stringify(value))
+                if (parsed?.decentralizedSynchronizer?.activeSynchronizer) {
+                    updatedValue =
+                        parsed.decentralizedSynchronizer.activeSynchronizer
+                }
+            }
+            return updatedValue ?? initActiveSynchronizer
+        } else return initActiveSynchronizer
+    }
 }

--- a/docs/wallet-integration-guide/examples/config.ts
+++ b/docs/wallet-integration-guide/examples/config.ts
@@ -1,0 +1,4 @@
+// Node cannot resolve subdomain.localhost, therefore add the following mapping to your /etc/hosts
+// 127.0.0.1   scan.localhost
+export const LOCALNET_SCAN_API = 'http://scan.localhost:4000/api/scan'
+export const LOCALNET_REGISTRY_API = 'http://scan.localhost:4000'

--- a/docs/wallet-integration-guide/examples/scripts/01-auth.ts
+++ b/docs/wallet-integration-guide/examples/scripts/01-auth.ts
@@ -17,6 +17,8 @@ const sdk = new WalletSDKImpl().configure({
     topologyFactory: localTopologyDefault,
     tokenStandardFactory: localTokenStandardDefault,
 })
+const fixedLocalNetSynchronizer =
+    'wallet::1220e7b23ea52eb5c672fb0b1cdbc916922ffed3dd7676c223a605664315e2d43edd'
 
 console.log('SDK initialized')
 
@@ -44,7 +46,7 @@ await sdk.adminLedger
         console.error('Error listing wallets:', error)
     })
 
-await sdk.connectTopology()
+await sdk.connectTopology(fixedLocalNetSynchronizer)
 console.log('Connected to topology')
 
 const keyPair = createKeyPair()

--- a/docs/wallet-integration-guide/examples/scripts/02-auth-localnet.ts
+++ b/docs/wallet-integration-guide/examples/scripts/02-auth-localnet.ts
@@ -6,8 +6,8 @@ import {
     localNetTokenStandardDefault,
     createKeyPair,
     signTransactionHash,
-    LocalNetDefaultScanApi,
 } from '@canton-network/wallet-sdk'
+import { LOCALNET_SCAN_API } from '../config.js'
 import { v4 } from 'uuid'
 
 // it is important to configure the SDK correctly else you might run into connectivity or authentication issues
@@ -45,7 +45,7 @@ await sdk.adminLedger
         console.error('Error listing wallets:', error)
     })
 
-await sdk.connectTopology(LocalNetDefaultScanApi)
+await sdk.connectTopology(LOCALNET_SCAN_API)
 console.log('Connected to topology')
 
 const keyPair = createKeyPair()

--- a/docs/wallet-integration-guide/examples/scripts/02-auth-localnet.ts
+++ b/docs/wallet-integration-guide/examples/scripts/02-auth-localnet.ts
@@ -6,6 +6,7 @@ import {
     localNetTokenStandardDefault,
     createKeyPair,
     signTransactionHash,
+    LocalNetDefaultScanApi,
 } from '@canton-network/wallet-sdk'
 import { v4 } from 'uuid'
 
@@ -44,7 +45,7 @@ await sdk.adminLedger
         console.error('Error listing wallets:', error)
     })
 
-await sdk.connectTopology()
+await sdk.connectTopology(LocalNetDefaultScanApi)
 console.log('Connected to topology')
 
 const keyPair = createKeyPair()
@@ -115,3 +116,5 @@ sdk.userLedger
     .catch((error) =>
         console.error('Failed to submit command with error %d', error)
     )
+
+sdk.userLedger?.listSynchronizers()

--- a/docs/wallet-integration-guide/examples/scripts/03-ping-localnet.ts
+++ b/docs/wallet-integration-guide/examples/scripts/03-ping-localnet.ts
@@ -3,10 +3,10 @@ import {
     localNetAuthDefault,
     localNetLedgerDefault,
     localNetTopologyDefault,
-    LocalNetDefaultScanApi,
     createKeyPair,
 } from '@canton-network/wallet-sdk'
 import { v4 } from 'uuid'
+import { LOCALNET_SCAN_API } from '../config.js'
 
 // it is important to configure the SDK correctly else you might run into connectivity or authentication issues
 const sdk = new WalletSDKImpl().configure({
@@ -31,7 +31,7 @@ await sdk.userLedger
     })
 
 const keyPair = createKeyPair()
-await sdk.connectTopology(LocalNetDefaultScanApi)
+await sdk.connectTopology(LOCALNET_SCAN_API)
 
 console.log('generated keypair')
 const allocatedParty = await sdk.topology?.prepareSignAndSubmitExternalParty(

--- a/docs/wallet-integration-guide/examples/scripts/03-ping-localnet.ts
+++ b/docs/wallet-integration-guide/examples/scripts/03-ping-localnet.ts
@@ -3,6 +3,7 @@ import {
     localNetAuthDefault,
     localNetLedgerDefault,
     localNetTopologyDefault,
+    LocalNetDefaultScanApi,
     createKeyPair,
 } from '@canton-network/wallet-sdk'
 import { v4 } from 'uuid'
@@ -30,7 +31,7 @@ await sdk.userLedger
     })
 
 const keyPair = createKeyPair()
-await sdk.connectTopology()
+await sdk.connectTopology(LocalNetDefaultScanApi)
 
 console.log('generated keypair')
 const allocatedParty = await sdk.topology?.prepareSignAndSubmitExternalParty(

--- a/docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet.ts
+++ b/docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet.ts
@@ -5,10 +5,10 @@ import {
     localNetTopologyDefault,
     localNetTokenStandardDefault,
     createKeyPair,
-    LocalNetDefaultScanApi,
 } from '@canton-network/wallet-sdk'
 import { pino } from 'pino'
 import { v4 } from 'uuid'
+import { LOCALNET_REGISTRY_API, LOCALNET_SCAN_API } from '../config.js'
 
 const logger = pino({ name: '04-token-standard-localnet', level: 'info' })
 
@@ -30,7 +30,7 @@ const keyPairSender = createKeyPair()
 const keyPairReceiver = createKeyPair()
 
 await sdk.connectAdmin()
-await sdk.connectTopology(LocalNetDefaultScanApi)
+await sdk.connectTopology(LOCALNET_SCAN_API)
 
 const sender = await sdk.topology?.prepareSignAndSubmitExternalParty(
     keyPairSender.privateKey,
@@ -61,9 +61,7 @@ await sdk.userLedger
 
 sdk.tokenStandard?.setSynchronizerId(synchonizerId)
 
-// Node cannot resolve subdomain.localhost, therefore add the following mapping to your /etc/hosts
-// 127.0.0.1   scan.localhost
-sdk.tokenStandard?.setTransferFactoryRegistryUrl('http://scan.localhost:4000')
+sdk.tokenStandard?.setTransferFactoryRegistryUrl(LOCALNET_REGISTRY_API)
 
 const [tapCommand, disclosedContracts] = await sdk.tokenStandard!.createTap(
     sender!.partyId,

--- a/docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet.ts
+++ b/docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet.ts
@@ -5,6 +5,7 @@ import {
     localNetTopologyDefault,
     localNetTokenStandardDefault,
     createKeyPair,
+    LocalNetDefaultScanApi,
 } from '@canton-network/wallet-sdk'
 import { pino } from 'pino'
 import { v4 } from 'uuid'
@@ -29,7 +30,7 @@ const keyPairSender = createKeyPair()
 const keyPairReceiver = createKeyPair()
 
 await sdk.connectAdmin()
-await sdk.connectTopology()
+await sdk.connectTopology(LocalNetDefaultScanApi)
 
 const sender = await sdk.topology?.prepareSignAndSubmitExternalParty(
     keyPairSender.privateKey,
@@ -47,8 +48,7 @@ logger.info(`Created party: ${receiver!.partyId}`)
 
 const synchronizers = await sdk.userLedger?.listSynchronizers()
 
-// @ts-ignore
-const synchonizerId = synchronizers!.connectedSynchronizers[0].synchronizerId
+const synchonizerId = synchronizers!.connectedSynchronizers![0].synchronizerId
 
 await sdk.userLedger
     ?.listWallets()

--- a/docs/wallet-integration-guide/examples/snippets/allocate-party.ts
+++ b/docs/wallet-integration-guide/examples/snippets/allocate-party.ts
@@ -4,6 +4,7 @@ import {
     localNetAuthDefault,
     localNetLedgerDefault,
     localNetTopologyDefault,
+    LocalNetDefaultScanApi,
 } from '@canton-network/wallet-sdk'
 
 // it is important to configure the SDK correctly else you might run into connectivity or authentication issues
@@ -13,7 +14,7 @@ const sdk = new WalletSDKImpl().configure({
     ledgerFactory: localNetLedgerDefault, // or use your specific configuration
     topologyFactory: localNetTopologyDefault, // or use your specific configuration
 })
-await sdk.connectTopology()
+await sdk.connectTopology(LocalNetDefaultScanApi)
 
 const { publicKey, privateKey } = TopologyController.createNewKeyPair()
 //partyHint is optional but recommended to make it easier to identify the party

--- a/docs/wallet-integration-guide/examples/snippets/allocate-party.ts
+++ b/docs/wallet-integration-guide/examples/snippets/allocate-party.ts
@@ -4,8 +4,8 @@ import {
     localNetAuthDefault,
     localNetLedgerDefault,
     localNetTopologyDefault,
-    LocalNetDefaultScanApi,
 } from '@canton-network/wallet-sdk'
+import { LOCALNET_SCAN_API } from '../config.js'
 
 // it is important to configure the SDK correctly else you might run into connectivity or authentication issues
 const sdk = new WalletSDKImpl().configure({
@@ -14,7 +14,7 @@ const sdk = new WalletSDKImpl().configure({
     ledgerFactory: localNetLedgerDefault, // or use your specific configuration
     topologyFactory: localNetTopologyDefault, // or use your specific configuration
 })
-await sdk.connectTopology(LocalNetDefaultScanApi)
+await sdk.connectTopology(LOCALNET_SCAN_API)
 
 const { publicKey, privateKey } = TopologyController.createNewKeyPair()
 //partyHint is optional but recommended to make it easier to identify the party

--- a/docs/wallet-integration-guide/examples/snippets/create-topology-transactions.ts
+++ b/docs/wallet-integration-guide/examples/snippets/create-topology-transactions.ts
@@ -4,8 +4,8 @@ import {
     localNetAuthDefault,
     localNetLedgerDefault,
     localNetTopologyDefault,
-    LocalNetDefaultScanApi,
 } from '@canton-network/wallet-sdk'
+import { LOCALNET_SCAN_API } from '../config.js'
 
 // it is important to configure the SDK correctly else you might run into connectivity or authentication issues
 const sdk = new WalletSDKImpl().configure({
@@ -15,7 +15,7 @@ const sdk = new WalletSDKImpl().configure({
     topologyFactory: localNetTopologyDefault, // or use your specific configuration
 })
 
-await sdk.connectTopology(LocalNetDefaultScanApi)
+await sdk.connectTopology(LOCALNET_SCAN_API)
 
 const { publicKey, privateKey } = TopologyController.createNewKeyPair()
 //partyHint is optional but recommended to make it easier to identify the party

--- a/docs/wallet-integration-guide/examples/snippets/create-topology-transactions.ts
+++ b/docs/wallet-integration-guide/examples/snippets/create-topology-transactions.ts
@@ -4,6 +4,7 @@ import {
     localNetAuthDefault,
     localNetLedgerDefault,
     localNetTopologyDefault,
+    LocalNetDefaultScanApi,
 } from '@canton-network/wallet-sdk'
 
 // it is important to configure the SDK correctly else you might run into connectivity or authentication issues
@@ -14,7 +15,7 @@ const sdk = new WalletSDKImpl().configure({
     topologyFactory: localNetTopologyDefault, // or use your specific configuration
 })
 
-await sdk.connectTopology()
+await sdk.connectTopology(LocalNetDefaultScanApi)
 
 const { publicKey, privateKey } = TopologyController.createNewKeyPair()
 //partyHint is optional but recommended to make it easier to identify the party

--- a/docs/wallet-integration-guide/examples/snippets/submit-signed-topology-transaction.ts
+++ b/docs/wallet-integration-guide/examples/snippets/submit-signed-topology-transaction.ts
@@ -3,6 +3,7 @@ import {
     localNetAuthDefault,
     localNetLedgerDefault,
     localNetTopologyDefault,
+    LocalNetDefaultScanApi,
 } from '@canton-network/wallet-sdk'
 
 // it is important to configure the SDK correctly else you might run into connectivity or authentication issues
@@ -12,7 +13,7 @@ const sdk = new WalletSDKImpl().configure({
     ledgerFactory: localNetLedgerDefault, // or use your specific configuration
     topologyFactory: localNetTopologyDefault, // or use your specific configuration
 })
-await sdk.connectTopology()
+await sdk.connectTopology(LocalNetDefaultScanApi)
 
 const preparedParty = {
     partyTransactions: [], // array of topology transactions

--- a/docs/wallet-integration-guide/examples/snippets/submit-signed-topology-transaction.ts
+++ b/docs/wallet-integration-guide/examples/snippets/submit-signed-topology-transaction.ts
@@ -3,8 +3,8 @@ import {
     localNetAuthDefault,
     localNetLedgerDefault,
     localNetTopologyDefault,
-    LocalNetDefaultScanApi,
 } from '@canton-network/wallet-sdk'
+import { LOCALNET_SCAN_API } from '../config.js'
 
 // it is important to configure the SDK correctly else you might run into connectivity or authentication issues
 const sdk = new WalletSDKImpl().configure({
@@ -13,7 +13,7 @@ const sdk = new WalletSDKImpl().configure({
     ledgerFactory: localNetLedgerDefault, // or use your specific configuration
     topologyFactory: localNetTopologyDefault, // or use your specific configuration
 })
-await sdk.connectTopology(LocalNetDefaultScanApi)
+await sdk.connectTopology(LOCALNET_SCAN_API)
 
 const preparedParty = {
     partyTransactions: [], // array of topology transactions

--- a/docs/wallet-integration-guide/examples/tsconfig.json
+++ b/docs/wallet-integration-guide/examples/tsconfig.json
@@ -5,5 +5,5 @@
         "module": "nodenext",
         "noEmit": true
     },
-    "include": ["scripts/*.ts", "snippets/*.ts"]
+    "include": ["scripts/*.ts", "snippets/*.ts", "config.ts"]
 }

--- a/sdk/wallet-sdk/package.json
+++ b/sdk/wallet-sdk/package.json
@@ -17,6 +17,7 @@
     "dependencies": {
         "@canton-network/core-ledger-client": "workspace:^",
         "@canton-network/core-ledger-proto": "workspace:^",
+        "@canton-network/core-scan-client": "workspace:^",
         "@canton-network/core-signing-lib": "workspace:^",
         "@canton-network/core-tx-visualizer": "workspace:^",
         "@canton-network/core-types": "workspace:^",

--- a/sdk/wallet-sdk/src/index.ts
+++ b/sdk/wallet-sdk/src/index.ts
@@ -4,6 +4,7 @@ import {
     localTokenStandardDefault,
     TokenStandardController,
 } from './tokenStandardController.js'
+import { ScanClient } from '@canton-network/core-scan-client'
 import {
     localTopologyDefault,
     TopologyController,
@@ -25,12 +26,15 @@ type AuthFactory = () => AuthController
 type LedgerFactory = (userId: string, token: string) => LedgerController
 type TopologyFactory = (
     userId: string,
-    adminAccessToken: string
+    adminAccessToken: string,
+    synchronizerId: string
 ) => TopologyController
 type TokenStandardFactory = (
     userId: string,
     token: string
 ) => TokenStandardController
+
+export const LocalNetDefaultScanApi = 'http://scan.localhost:4000/api/scan'
 
 export interface Config {
     authFactory: AuthFactory
@@ -45,7 +49,7 @@ export interface WalletSDK {
     configure(config: Config): WalletSDK
     connect(): Promise<WalletSDK>
     connectAdmin(): Promise<WalletSDK>
-    connectTopology(): Promise<WalletSDK>
+    connectTopology(synchronizer: string | ScanClient): Promise<WalletSDK>
     userLedger: LedgerController | undefined
     adminLedger: LedgerController | undefined
     topology: TopologyController | undefined
@@ -118,12 +122,40 @@ export class WalletSDKImpl implements WalletSDK {
     /** Connects to the topology service using admin credentials.
      * @returns A promise that resolves to the WalletSDK instance.
      */
-    async connectTopology(): Promise<WalletSDK> {
+    async connectTopology(synchronizer: string): Promise<WalletSDK> {
         if (this.auth.userId === undefined)
             throw new Error('UserId is not defined in AuthController.')
+        if (synchronizer === undefined)
+            throw new Error(
+                'Synchronizer is not defined in connectTopology. Either provide a synchronizerId or a scanClient base url.'
+            )
         const { userId, accessToken } = await this.auth.getAdminToken()
         this.logger?.info(`Connecting user ${userId} with token ${accessToken}`)
-        this.topology = this.topologyFactory(userId, accessToken)
+        let synchronizerId: string
+        if (synchronizer.includes('::')) {
+            synchronizerId = synchronizer
+        } else if (synchronizer.startsWith('http')) {
+            const scanClient = new ScanClient(
+                synchronizer,
+                this.logger!,
+                accessToken
+            )
+            const amuletSynchronizerId =
+                await scanClient.GetAmuletSynchronizerId()
+            if (amuletSynchronizerId === undefined) {
+                throw new Error('SynchronizerId is not defined in ScanClient.')
+            } else {
+                synchronizerId = amuletSynchronizerId
+            }
+        } else
+            throw new Error(
+                'invalid Synchronizer format. Either provide a synchronizerId or a scanClient base url.'
+            )
+        this.topology = this.topologyFactory(
+            userId,
+            accessToken,
+            synchronizerId
+        )
         return this
     }
 }

--- a/sdk/wallet-sdk/src/index.ts
+++ b/sdk/wallet-sdk/src/index.ts
@@ -34,8 +34,6 @@ type TokenStandardFactory = (
     token: string
 ) => TokenStandardController
 
-export const LocalNetDefaultScanApi = 'http://scan.localhost:4000/api/scan'
-
 export interface Config {
     authFactory: AuthFactory
     ledgerFactory: LedgerFactory

--- a/sdk/wallet-sdk/src/tokenStandardController.ts
+++ b/sdk/wallet-sdk/src/tokenStandardController.ts
@@ -77,7 +77,6 @@ export class TokenStandardController {
             afterOffset
         )
     }
-
     async createTap(
         receiver: string,
         amount: string,

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -185,15 +185,15 @@ export class TopologyController {
  */
 export const localNetTopologyDefault = (
     userId: string,
-    userAdminToken: string
+    userAdminToken: string,
+    synchronizerId: string
 ): TopologyController => {
     return new TopologyController(
         '127.0.0.1:2902',
         'http://127.0.0.1:2975',
         userId,
         userAdminToken,
-        //TODO: fetch this from a localnet API endpoint
-        'global-domain::122098544e6d707a02edee40ff295792b2b526fa30fa7a284a477041eb23d1d26763'
+        synchronizerId
     )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,7 +1555,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@canton-network/core-scan-client@workspace:core/scan-client":
+"@canton-network/core-scan-client@workspace:^, @canton-network/core-scan-client@workspace:core/scan-client":
   version: 0.0.0-use.local
   resolution: "@canton-network/core-scan-client@workspace:core/scan-client"
   dependencies:
@@ -1923,6 +1923,7 @@ __metadata:
   dependencies:
     "@canton-network/core-ledger-client": "workspace:^"
     "@canton-network/core-ledger-proto": "workspace:^"
+    "@canton-network/core-scan-client": "workspace:^"
     "@canton-network/core-signing-lib": "workspace:^"
     "@canton-network/core-tx-visualizer": "workspace:^"
     "@canton-network/core-types": "workspace:^"


### PR DESCRIPTION
fetch the synchronizer from the amulet DSO (initial and future values) instead of having it hardcoded