### PR TITLE
docs: link to docs site in readme

### DIFF
--- a/sdk/wallet-sdk/README.md
+++ b/sdk/wallet-sdk/README.md
@@ -50,4 +50,4 @@ console.log('SDK initialized')
 await sdk.connect()
 ```
 
-For more examples and code snippets, see the [docs](https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/docs/wallet-integration-guide/src).
+For more guides, examples and code snippets, see the [docs](https://docs.digitalasset.com/integrate/devnet/index.html).


### PR DESCRIPTION
The docs site wasnt live originally, so updating the link now that it is 