### PR TITLE
feat(wallet-sdk): accept transfer

### DIFF
--- a/core/ledger-client/src/token-standard-service.ts
+++ b/core/ledger-client/src/token-standard-service.ts
@@ -55,7 +55,7 @@ export class TokenStandardService {
     async createAcceptTransferInstruction(
         transferInstructionCid: string,
         transferFactoryRegistryUrl: string
-    ): Promise<ExerciseCommand> {
+    ): Promise<[ExerciseCommand, DisclosedContract[]]> {
         try {
             const client = this.tokenStandardClient(transferFactoryRegistryUrl)
             const choiceContext = await client.post(
@@ -80,7 +80,7 @@ export class TokenStandardService {
                 },
             }
 
-            return exercise
+            return [exercise, choiceContext.disclosedContracts]
         } catch (e) {
             this.logger.error(
                 'Failed to create accept transfer instruction:',
@@ -270,6 +270,7 @@ export class TokenStandardService {
                 choice: 'TransferFactory_Transfer',
                 choiceArgument: choiceArgs,
             }
+
             return [exercise, transferFactory.choiceContext.disclosedContracts]
         } catch (e) {
             this.logger.error('Failed to execute transfer:', e)

--- a/docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet.ts
+++ b/docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet.ts
@@ -120,7 +120,6 @@ await sdk.userLedger?.prepareSignAndExecuteTransaction(
 )
 logger.info('Submitted transfer transaction')
 
-
 const holdings = await sdk.tokenStandard?.listHoldingTransactions()
 
 const transferCid = holdings!.transactions
@@ -137,7 +136,10 @@ sdk.userLedger?.setPartyId(receiver!.partyId)
 sdk.tokenStandard?.setPartyId(receiver!.partyId)
 
 const [acceptTransferCommand, disclosedContracts3] =
-    await sdk.tokenStandard!.acceptTransferInstruction(transferCid)
+    await sdk.tokenStandard!.exerciseTransferInstructionChoice(
+        transferCid,
+        'Accept'
+    )
 
 await sdk.userLedger?.prepareSignAndExecuteTransaction(
     [{ ExerciseCommand: acceptTransferCommand }],

--- a/docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet.ts
+++ b/docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet.ts
@@ -69,7 +69,7 @@ const [tapCommand, disclosedContracts] = await sdk.tokenStandard!.createTap(
     {
         instrumentId: 'Amulet',
         instrumentAdmin:
-            'DSO::122098544e6d707a02edee40ff295792b2b526fa30fa7a284a477041eb23d1d26763',
+            'DSO::12200901488a1b3ff2d4d9ed3aac14af530811522e16f8819e56c41ec937dbcaec92', //TODO: get this from scan
     }
 )
 
@@ -107,7 +107,7 @@ const [transferCommand, disclosedContracts2] =
         {
             instrumentId: 'Amulet',
             instrumentAdmin:
-                'DSO::122098544e6d707a02edee40ff295792b2b526fa30fa7a284a477041eb23d1d26763', // todo: get from scan
+                'DSO::12200901488a1b3ff2d4d9ed3aac14af530811522e16f8819e56c41ec937dbcaec92', // todo: get from scan
         },
         {}
     )
@@ -118,5 +118,32 @@ await sdk.userLedger?.prepareSignAndExecuteTransaction(
     v4(),
     disclosedContracts2
 )
-
 logger.info('Submitted transfer transaction')
+
+
+const holdings = await sdk.tokenStandard?.listHoldingTransactions()
+
+const transferCid = holdings!.transactions
+    .flatMap((object) =>
+        object.events.flatMap(
+            (t) =>
+                (t.label as any)?.tokenStandardChoice?.exerciseResult?.output
+                    ?.value?.transferInstructionCid
+        )
+    )
+    .find((v) => v !== undefined)
+
+sdk.userLedger?.setPartyId(receiver!.partyId)
+sdk.tokenStandard?.setPartyId(receiver!.partyId)
+
+const [acceptTransferCommand, disclosedContracts3] =
+    await sdk.tokenStandard!.acceptTransferInstruction(transferCid)
+
+await sdk.userLedger?.prepareSignAndExecuteTransaction(
+    [{ ExerciseCommand: acceptTransferCommand }],
+    keyPairReceiver.privateKey,
+    v4(),
+    disclosedContracts3
+)
+
+console.log('Accepted transfer instruction')

--- a/sdk/wallet-sdk/src/tokenStandardController.ts
+++ b/sdk/wallet-sdk/src/tokenStandardController.ts
@@ -11,6 +11,8 @@ import {
 } from '@canton-network/core-ledger-client'
 import { HoldingV1 } from '@canton-network/core-token-standard'
 
+export type TransactionInstructionChoice = 'Accept' | 'Reject'
+
 /**
  * TokenStandardController handles token standard management tasks.
  * This controller requires a userId and token.
@@ -148,14 +150,30 @@ export class TokenStandardController {
         }
     }
 
-    async acceptTransferInstruction(
-        transferInstructionCid: string
+    /** Execute the choice TransferInstruction_Accept o TransferInstruction_Reject
+     *  on the provided transfer instruction.
+     * @param transferInstructionCid The contract ID of the transfer instruction to accept or reject
+     * @param instructionChoice is either Accept or Reject
+     * @returns A promise that resolves to an array of
+     *  active contracts interface view values and cids.
+     */
+
+    async exerciseTransferInstructionChoice(
+        transferInstructionCid: string,
+        instructionChoice: TransactionInstructionChoice
     ): Promise<[Types['ExerciseCommand'], Types['DisclosedContract'][]]> {
         try {
-            return await this.service.createAcceptTransferInstruction(
-                transferInstructionCid,
-                this.transferFactoryRegistryUrl
-            )
+            if (instructionChoice === 'Accept') {
+                return await this.service.createAcceptTransferInstruction(
+                    transferInstructionCid,
+                    this.transferFactoryRegistryUrl
+                )
+            } else {
+                return await this.service.createRejectTransferInstruction(
+                    transferInstructionCid,
+                    this.transferFactoryRegistryUrl
+                )
+            }
         } catch (error) {
             this.logger.error(
                 { error },

--- a/sdk/wallet-sdk/src/tokenStandardController.ts
+++ b/sdk/wallet-sdk/src/tokenStandardController.ts
@@ -150,7 +150,7 @@ export class TokenStandardController {
 
     async acceptTransferInstruction(
         transferInstructionCid: string
-    ): Promise<[unknown, DisclosedContract[]]> {
+    ): Promise<[Types['ExerciseCommand'], Types['DisclosedContract'][]]> {
         try {
             return await this.service.createAcceptTransferInstruction(
                 transferInstructionCid,

--- a/sdk/wallet-sdk/src/tokenStandardController.ts
+++ b/sdk/wallet-sdk/src/tokenStandardController.ts
@@ -147,6 +147,23 @@ export class TokenStandardController {
             throw error
         }
     }
+
+    async acceptTransferInstruction(
+        transferInstructionCid: string
+    ): Promise<[unknown, DisclosedContract[]]> {
+        try {
+            return await this.service.createAcceptTransferInstruction(
+                transferInstructionCid,
+                this.transferFactoryRegistryUrl
+            )
+        } catch (error) {
+            this.logger.error(
+                { error },
+                'Failed to accept transfer instruction'
+            )
+            throw error
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Adds the accept/reject transfer to the wallet-sdk, which executes the choice TransferInstruction_Accept/TransferInstruction_Reject on the provided transfer instruction