### PR TITLE
fix: transfer pre approval use ledger api

### DIFF
--- a/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
+++ b/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
@@ -66,8 +66,6 @@ sdk.tokenStandard?.setSynchronizerId(synchonizerId)
 sdk.tokenStandard?.setTransferFactoryRegistryUrl(LOCALNET_REGISTRY_API_URL.href)
 await new Promise((res) => setTimeout(res, 5000))
 
-logger.info('creating external party proposal for party: ' + receiver?.partyId)
-
 sdk.validator?.setPartyId(receiver?.partyId!)
 
 sdk.userLedger?.setPartyId(receiver?.partyId!)
@@ -80,9 +78,22 @@ const instrumentAdminPartyId =
 
 await new Promise((res) => setTimeout(res, 5000))
 
-await sdk.validator?.externalPartyPreApprovalSetup(keyPairReceiver.privateKey)
+logger.info('creating transfer preapproval proposal')
 
-logger.info('submitted external party proposal for ' + receiver?.partyId)
+const transferPreApprovalProposal =
+    sdk.userLedger?.createTransferPreapprovalCommand(
+        'app_user_localnet-localparty-1::122051dda3eb7110475dea361052b6072ef66b635d23196887a0eacaa2533598bf93', // TODO: find out how to get this not through validator api
+        receiver?.partyId!,
+        instrumentAdminPartyId
+    )
+
+await sdk.userLedger?.prepareSignAndExecuteTransaction(
+    [transferPreApprovalProposal],
+    keyPairReceiver.privateKey,
+    v4()
+)
+
+logger.info('transfer pre approval proposal is created')
 
 sdk.userLedger?.setPartyId(sender?.partyId!)
 

--- a/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
+++ b/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
@@ -52,14 +52,14 @@ const synchronizers = await sdk.userLedger?.listSynchronizers()
 
 const synchonizerId = synchronizers!.connectedSynchronizers![0].synchronizerId
 
-await sdk.userLedger
-    ?.listWallets()
-    .then((wallets) => {
-        logger.info(wallets, 'Wallets:')
-    })
-    .catch((error) => {
-        logger.error({ error }, 'Error listing wallets')
-    })
+// await sdk.userLedger
+//     ?.listWallets()
+//     .then((wallets) => {
+//         logger.info(wallets, 'Wallets:')
+//     })
+//     .catch((error) => {
+//         logger.error({ error }, 'Error listing wallets')
+//     })
 
 sdk.tokenStandard?.setSynchronizerId(synchonizerId)
 

--- a/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
+++ b/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
@@ -52,14 +52,14 @@ const synchronizers = await sdk.userLedger?.listSynchronizers()
 
 const synchonizerId = synchronizers!.connectedSynchronizers![0].synchronizerId
 
-// await sdk.userLedger
-//     ?.listWallets()
-//     .then((wallets) => {
-//         logger.info(wallets, 'Wallets:')
-//     })
-//     .catch((error) => {
-//         logger.error({ error }, 'Error listing wallets')
-//     })
+await sdk.userLedger
+    ?.listWallets()
+    .then((wallets) => {
+        logger.info(wallets, 'Wallets:')
+    })
+    .catch((error) => {
+        logger.error({ error }, 'Error listing wallets')
+    })
 
 sdk.tokenStandard?.setSynchronizerId(synchonizerId)
 

--- a/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
+++ b/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
@@ -67,6 +67,7 @@ sdk.tokenStandard?.setTransferFactoryRegistryUrl(LOCALNET_REGISTRY_API_URL.href)
 await new Promise((res) => setTimeout(res, 5000))
 
 sdk.validator?.setPartyId(receiver?.partyId!)
+const validatorOperatorParty = await sdk.validator?.getValidatorUser()
 
 sdk.userLedger?.setPartyId(receiver?.partyId!)
 sdk.tokenStandard?.setSynchronizerId(synchonizerId)
@@ -82,7 +83,7 @@ logger.info('creating transfer preapproval proposal')
 
 const transferPreApprovalProposal =
     sdk.userLedger?.createTransferPreapprovalCommand(
-        'app_user_localnet-localparty-1::122051dda3eb7110475dea361052b6072ef66b635d23196887a0eacaa2533598bf93', // TODO: find out how to get this not through validator api
+        validatorOperatorParty!, // TODO: find out how to get this not through validator api
         receiver?.partyId!,
         instrumentAdminPartyId
     )

--- a/sdk/wallet-sdk/src/ledgerController.ts
+++ b/sdk/wallet-sdk/src/ledgerController.ts
@@ -252,6 +252,15 @@ export class LedgerController {
         return await this.client.get('/v2/state/ledger-end')
     }
 
+    /**
+     * This creates a TransferPreapprovalCommand
+     * The validator auto accepts when the provider is the validator operatory party
+     * And this allows us to auto accept incoming transfer for the receiver party
+     * @param validatorOperatorParty operator party retrieved through the getValidatorUser call
+     * @param receiverParty party for which the auto accept is created for
+     * @param dsoParty Party that the sender expects to represent the DSO party of the AmuletRules contract they are calling
+     */
+
     createTransferPreapprovalCommand(
         validatorOperatorParty: string,
         receiverParty: string,

--- a/sdk/wallet-sdk/src/ledgerController.ts
+++ b/sdk/wallet-sdk/src/ledgerController.ts
@@ -252,6 +252,24 @@ export class LedgerController {
         return await this.client.get('/v2/state/ledger-end')
     }
 
+    createTransferPreapprovalCommand(
+        validatorOperatorParty: string,
+        receiverParty: string,
+        dsoParty: string
+    ) {
+        return {
+            CreateCommand: {
+                templateId:
+                    '#splice-wallet:Splice.Wallet.TransferPreapproval:TransferPreapprovalProposal',
+                createArguments: {
+                    provider: validatorOperatorParty,
+                    receiver: receiverParty,
+                    expectedDso: dsoParty,
+                },
+            },
+        }
+    }
+
     /**
      * Retrieves active contracts with optional filtering by template IDs and parties.
      * @param options Optional parameters for filtering:

--- a/sdk/wallet-sdk/src/validatorController.ts
+++ b/sdk/wallet-sdk/src/validatorController.ts
@@ -168,6 +168,15 @@ export class ValidatorController {
             }
         )
     }
+
+    /**  Looks up the validator operator party
+     */
+
+    async getValidatorUser() {
+        const validatorUserResponse =
+            await this.validatorClient.get('/v0/validator-user')
+        return validatorUserResponse.party_id
+    }
 }
 
 /**

--- a/sdk/wallet-sdk/src/validatorController.ts
+++ b/sdk/wallet-sdk/src/validatorController.ts
@@ -62,6 +62,8 @@ export class ValidatorController {
     }
 
     /**
+     * @deprecated
+     * Use the ledgerController.createTransferPreapprovalCommand() and ledgerController.prepareSignAndExecuteTransaction() instead
      * Create the ExternalPartySetupProposal contract as the validator operator
      * @param partyId
      * returns contractId used in prepareExternalPartyProposal
@@ -76,6 +78,8 @@ export class ValidatorController {
     }
 
     /**
+     * @deprecated
+     * Use the ledgerController.createTransferPreapprovalCommand() and ledgerController.prepareSignAndExecuteTransaction() instead
      * Given a contract id of an ExternalPartySetupProposal, prepare the transaction
      * to accept it such that it can be signed externally
      * @param contractId contract id of an ExternalPartySetupProposal
@@ -91,6 +95,8 @@ export class ValidatorController {
     }
 
     /**
+     * @deprecated
+     * Use the ledgerController.createTransferPreapprovalCommand() and ledgerController.prepareSignAndExecuteTransaction() instead
      * Submit a transaction prepared using prepareExternalPartyProposal
      * together with its signature
      * @param publicKey hex-encoded public key
@@ -117,6 +123,7 @@ export class ValidatorController {
     }
 
     /**
+     * @deprecated Use the ledgerController.createTransferPreapprovalCommand() and ledgerController.prepareSignAndExecuteTransaction() instead
      * Creates an ExternalpartySetupProposal contract as validator operator
      * Prepares and submits the transaction so that the party can
      * Auto accept transfers


### PR DESCRIPTION
Uses the ledger api to create a `TransferPreapprovalProposal` which gets auto accepted by the validator. This can be used as an alternative to the `ValidatorController` `createExternalPartyProposal`, `prepareExternalPartyProposal`, and `submitPartyProposal`.