### PR TITLE
chore: test example scripts in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
               run: yarn script:fetch:localnet
 
             - name: Start Localnet
-              run: yarn start:localnet &
+              run: yarn start:localnet
 
             - name: Test example scripts
               run: yarn script:test:examples

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
                   retention-days: 30
 
             - name: Download localnet
-              run: yarn script:fetch:splice
+              run: yarn script:fetch:localnet
 
             - name: Start Localnet
               run: yarn start:localnet &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,8 @@ jobs:
             - name: Start Canton
               run: yarn start:canton &
 
-            - run: DAPP_API_PORT=3008 yarn workspace @canton-network/clients-remote run start &
+            - name: Start remote WK
+              run: DAPP_API_PORT=3008 yarn workspace @canton-network/clients-remote run start &
 
             - run: yarn workspace @canton-network/example run dev &
 
@@ -119,6 +120,15 @@ jobs:
                   name: playwright-report
                   path: example/playwright-report/
                   retention-days: 30
+
+            - name: Download localnet
+              run: yarn script:fetch:splice
+
+            - name: Start Localnet
+              run: yarn start:localnet &
+
+            - name: Test example scripts
+              run: yarn script:test:examples
 
     build-docs:
         runs-on: ubuntu-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,9 @@
     "files.watcherExclude": {
         "**/target": true
     },
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "always"
+    },
     "metals.inlayHints.implicitArguments.enable": true,
     "metals.inlayHints.implicitConversions.enable": true
 }

--- a/docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet.ts
+++ b/docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet.ts
@@ -80,7 +80,7 @@ await sdk.userLedger?.prepareSignAndExecuteTransaction(
     disclosedContracts
 )
 
-await new Promise((res) => setTimeout(res, 5000))
+await new Promise((res) => setTimeout(res, 10000))
 
 const utxos = await sdk.tokenStandard?.listHoldingUtxos(false)
 logger.info(utxos, 'List Available Token Standard Holding UTXOs')

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -9,7 +9,7 @@ const sharedEnvDevelopment = {
 export const apps = [
     {
         name: 'remote',
-        script: 'yarn workspace @canton-network/clients-remote dev',
+        script: 'DAPP_API_PORT=3008 yarn workspace @canton-network/clients-remote dev',
         env_development: sharedEnvDevelopment,
     },
     {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "script:fetch:localnet": "tsx ./scripts/src/fetch-localnet.ts",
         "script:openrpc:titles": "tsx ./scripts/src/schema-title-validation.ts",
         "script:validate:package": "tsx ./scripts/src/package-and-verify-wallet-sdk.ts",
+        "script:test:examples": "tsx ./scripts/src/test-example-scripts.ts",
         "full:rebuild": "yarn clean:all && yarn generate:all && yarn build:all"
     },
     "workspaces": [

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.1.0",
         "oauth2-mock-server": "^8.1.0",
+        "pino-pretty": "^13.1.1",
         "pm2": "^6.0.8",
         "prettier": "^3.5.3",
         "ts-proto": "^2.7.7",

--- a/scripts/src/test-example-scripts.ts
+++ b/scripts/src/test-example-scripts.ts
@@ -30,9 +30,21 @@ async function executeScript(name: string) {
 async function cmd(command: string): Promise<void> {
     const [bin, ...args] = command.split(' ')
     const child = child_process.spawn(bin, args, {
-        stdio: 'inherit',
+        stdio: ['ignore', 'pipe', 'pipe'],
         shell: true,
     })
+
+    // spawn pino-pretty
+    const pretty = child_process.spawn('yarn', ['pino-pretty'], {
+        stdio: ['pipe', process.stdout, process.stderr],
+        shell: true,
+    })
+
+    // pipe logs: child.stdout → pino-pretty.stdin
+    child.stdout.pipe(pretty.stdin)
+
+    // also forward stderr directly
+    child.stderr.pipe(process.stderr)
 
     await new Promise<void>((resolve, reject) => {
         child.on('close', (code) => {

--- a/scripts/src/test-example-scripts.ts
+++ b/scripts/src/test-example-scripts.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'fs'
+import path from 'path'
+import { error, getRepoRoot, success } from './utils.js'
+import child_process from 'child_process'
+
+const dir = path.join(
+    getRepoRoot(),
+    'docs/wallet-integration-guide/examples/scripts'
+)
+
+// do not run these tests; exceptions can be full filename or just any length subset of its starting characters
+const exceptions = ['01-auth.ts', '05-']
+
+const scripts = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.ts'))
+    .filter((f) => !exceptions.find((e) => f.startsWith(e)))
+
+async function executeScript(name: string) {
+    console.log(success(`\n=== Executing script: ${name} ===`))
+    await cmd(`yarn tsx ${path.join(dir, name)}`).then(() => {
+        console.log(success(`Script ${name} executed successfully`))
+    })
+    console.log(success(`=== Finished script: ${name} ===\n`))
+}
+
+async function cmd(command: string): Promise<void> {
+    const [bin, ...args] = command.split(' ')
+    const child = child_process.spawn(bin, args, {
+        stdio: 'inherit',
+        shell: true,
+    })
+
+    await new Promise<void>((resolve, reject) => {
+        child.on('close', (code) => {
+            if (code !== 0) {
+                reject(new Error(`Command failed: ${command}`))
+            } else {
+                resolve()
+            }
+        })
+    })
+}
+
+for (const script of scripts) {
+    try {
+        await executeScript(script)
+    } catch {
+        console.log(error(`=== Failed running script: ${script} ===\n`))
+        process.exit(1)
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13626,7 +13626,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pino-pretty@npm:^13.0.0":
+"pino-pretty@npm:^13.0.0, pino-pretty@npm:^13.1.1":
   version: 13.1.1
   resolution: "pino-pretty@npm:13.1.1"
   dependencies:
@@ -15103,6 +15103,7 @@ __metadata:
     lint-staged: "npm:^16.1.0"
     nx: "npm:^21.3.11"
     oauth2-mock-server: "npm:^8.1.0"
+    pino-pretty: "npm:^13.1.1"
     pm2: "npm:^6.0.8"
     prettier: "npm:^3.5.3"
     ts-proto: "npm:^2.7.7"


### PR DESCRIPTION
This approach creates a script to automatically run all tests defined in `examples/scripts` in the wallet-integration-guide. It requires localnet to be up & running via docker compose, and then executes each script directly with `tsx`. 

If the execution exits with a non-zero code, then the script is assumed to have failed.  

PR for snippets here: #476 