### PR TITLE
ci: make warnings in docs fail the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,4 +152,4 @@ jobs:
 
             - name: Build docs
               working-directory: docs/wallet-integration-guide
-              run: poetry run sphinx-build -c . src build
+              run: poetry run sphinx-build -c . src build --fail-on-warning

--- a/docs/wallet-integration-guide/README.md
+++ b/docs/wallet-integration-guide/README.md
@@ -9,5 +9,5 @@ poetry install
 Run this to start the docs server:
 
 ```sh
-poetry run sphinx-autobuild -c . src build
+poetry run sphinx-autobuild -c . src build -W
 ```

--- a/docs/wallet-integration-guide/src/exchange-integration/node-operations.rst
+++ b/docs/wallet-integration-guide/src/exchange-integration/node-operations.rst
@@ -249,7 +249,7 @@ We recommend to handle the upgrade as follows:
 2. Open the migration dump and extract the ``acs_timestamp`` from it, e.g., using ``jq .acs_timestamp < /domain-upgrade-dump/domain_migration_dump.json``.
    This is the timestamp at which the synchronizer was paused.
 3. Wait for your Tx History Ingestion to have caught up to record time
-   ``acs_timestamp`` or higher. Note that you must consume :ref:`<offset_checkpoints>`
+   ``acs_timestamp`` or higher. Note that you must consume :ref:`offset checkpoints <offset-checkpoints>`
    to guarantee that your Tx History Ingestion advances past ``acs_timestamp``.
 
 4. Upgrade your validator and connect it to the new synchronizer following the

--- a/docs/wallet-integration-guide/src/exchange-integration/txingestion.rst
+++ b/docs/wallet-integration-guide/src/exchange-integration/txingestion.rst
@@ -3,7 +3,7 @@
 Transaction History Ingestion Details
 =====================================
 
-.. _offset_checkpoints:
+.. _offset-checkpoints:
 
 Offset Checkpoints
 ^^^^^^^^^^^^^^^^^^

--- a/docs/wallet-integration-guide/src/release-notes/index.rst
+++ b/docs/wallet-integration-guide/src/release-notes/index.rst
@@ -10,6 +10,7 @@ Below are the release notes for the Wallet SDK versions, detailing new features,
 
 * Range filter for `listHoldingTransactions(afterOffset?: string,beforeOffset?: string)`
 * Transfer pre-approval support:
+
 .. code-block:: javascript
 
     const sdk = new WalletSDKImpl().configure({
@@ -28,6 +29,7 @@ Below are the release notes for the Wallet SDK versions, detailing new features,
     await sdk.validator?.externalPartyPreApprovalSetup(keyPairReceiver.privateKey)
 
 * Support added for 2-step transfers (propose / accept)
+
 .. code-block:: javascript
 
     const [acceptTransferCommand, disclosedContracts3] =
@@ -37,6 +39,7 @@ Below are the release notes for the Wallet SDK versions, detailing new features,
         )
 
 * ``listHoldingsUtxo`` has been extended to only ``nonLocked`` UTXOs
+
 .. code-block:: javascript
 
     //new optional parameter, default is true (to be backwards compatible


### PR DESCRIPTION
Docs changes have calmed down _somewhat_, and either way the number of warnings has dropped by quite a bit since the docs build became enabled.

So this is a good time to make warnings fail the build too!