### PR TITLE
docs: remove inline tocs now that the website supports two level headers

### DIFF
--- a/docs/wallet-integration-guide/src/exchange-integration/extensions.rst
+++ b/docs/wallet-integration-guide/src/exchange-integration/extensions.rst
@@ -6,12 +6,6 @@ Integration Extensions
 This page describes the following additional features that you can consider adding to your integration,
 beyond the MVP described in the :ref:`exchange-integration-overview` section:
 
-.. contents::
-   :local:
-   :depth: 2
-   :backlinks: none
-
-
 Optimizing App Rewards
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/wallet-integration-guide/src/exchange-integration/workflows.rst
+++ b/docs/wallet-integration-guide/src/exchange-integration/workflows.rst
@@ -4,12 +4,6 @@
 Integration Workflows
 =====================
 
-.. contents::
-   :local:
-   :depth: 2
-   :backlinks: none
-
-
 Overview
 --------
 


### PR DESCRIPTION
They are no longer required thanks to https://github.com/DACH-NY/docs-website/pull/949#pullrequestreview-3212363762