### PR TITLE
fix: optionally pass dso

### DIFF
--- a/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
+++ b/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
@@ -82,7 +82,7 @@ await new Promise((res) => setTimeout(res, 5000))
 logger.info('creating transfer preapproval proposal')
 
 const transferPreApprovalProposal =
-    sdk.userLedger?.createTransferPreapprovalCommand(
+    await sdk.userLedger?.createTransferPreapprovalCommand(
         validatorOperatorParty!, // TODO: find out how to get this not through validator api
         receiver?.partyId!,
         instrumentAdminPartyId

--- a/sdk/wallet-sdk/src/ledgerController.ts
+++ b/sdk/wallet-sdk/src/ledgerController.ts
@@ -295,7 +295,7 @@ export class LedgerController {
                         createArguments: {
                             provider: validatorOperatorParty,
                             receiver: receiverParty,
-                            expectedDso: dsoParty!,
+                            expectedDso: dsoParty,
                         },
                     },
                 }

--- a/sdk/wallet-sdk/src/ledgerController.ts
+++ b/sdk/wallet-sdk/src/ledgerController.ts
@@ -251,7 +251,7 @@ export class LedgerController {
      * @param validatorOperatorParty operator party retrieved through the getValidatorUser call
      * @param receiverParty party for which the auto accept is created for
      * @param dsoParty Party that the sender expects to represent the DSO party of the AmuletRules contract they are calling
-     * dsoParty is required for splice-wallet package versions greater than or higher than 0.1.11
+     * dsoParty is required for splice-wallet package versions equal or higher than 0.1.11
      */
 
     async createTransferPreapprovalCommand(

--- a/sdk/wallet-sdk/src/ledgerController.ts
+++ b/sdk/wallet-sdk/src/ledgerController.ts
@@ -273,7 +273,7 @@ export class LedgerController {
 
         const version =
             spliceWalletPackageVersionResponse.packagePreference
-                ?.packageReference?.packageId
+                ?.packageReference?.packageVersion
 
         if (this.compareVersions(version!, '0.1.11') === -1) {
             return {

--- a/sdk/wallet-sdk/src/ledgerController.ts
+++ b/sdk/wallet-sdk/src/ledgerController.ts
@@ -264,7 +264,7 @@ export class LedgerController {
     createTransferPreapprovalCommand(
         validatorOperatorParty: string,
         receiverParty: string,
-        dsoParty: string
+        dsoParty?: string
     ) {
         return {
             CreateCommand: {
@@ -273,7 +273,7 @@ export class LedgerController {
                 createArguments: {
                     provider: validatorOperatorParty,
                     receiver: receiverParty,
-                    expectedDso: dsoParty,
+                    ...(dsoParty && { expectedDso: dsoParty }),
                 },
             },
         }

--- a/sdk/wallet-sdk/src/ledgerController.ts
+++ b/sdk/wallet-sdk/src/ledgerController.ts
@@ -251,6 +251,7 @@ export class LedgerController {
      * @param validatorOperatorParty operator party retrieved through the getValidatorUser call
      * @param receiverParty party for which the auto accept is created for
      * @param dsoParty Party that the sender expects to represent the DSO party of the AmuletRules contract they are calling
+     * dsoParty is required for splice-wallet package versions greater than or higher than 0.1.11
      */
 
     async createTransferPreApprovalCommand(
@@ -286,16 +287,20 @@ export class LedgerController {
                 },
             }
         } else {
-            return {
-                CreateCommand: {
-                    templateId:
-                        '#splice-wallet:Splice.Wallet.TransferPreapproval:TransferPreapprovalProposal',
-                    createArguments: {
-                        provider: validatorOperatorParty,
-                        receiver: receiverParty,
-                        expectedDso: dsoParty!,
+            if (dsoParty) {
+                return {
+                    CreateCommand: {
+                        templateId:
+                            '#splice-wallet:Splice.Wallet.TransferPreapproval:TransferPreapprovalProposal',
+                        createArguments: {
+                            provider: validatorOperatorParty,
+                            receiver: receiverParty,
+                            expectedDso: dsoParty!,
+                        },
                     },
-                },
+                }
+            } else {
+                new Error('dsoParty is undefined')
             }
         }
     }

--- a/sdk/wallet-sdk/src/ledgerController.ts
+++ b/sdk/wallet-sdk/src/ledgerController.ts
@@ -254,7 +254,7 @@ export class LedgerController {
      * dsoParty is required for splice-wallet package versions greater than or higher than 0.1.11
      */
 
-    async createTransferPreApprovalCommand(
+    async createTransferPreapprovalCommand(
         validatorOperatorParty: string,
         receiverParty: string,
         dsoParty?: string


### PR DESCRIPTION
This adds a package version check for the `splice-wallet` daml version before creating the `TransferPreApprovalProposal` because in versions < `0.1.11` we need to omit `expectedDso` when creating the command.