### PR TITLE
feat(wallet-sdk): add multi hosted party support

### DIFF
--- a/core/ledger-client/src/topology-write-service.ts
+++ b/core/ledger-client/src/topology-write-service.ts
@@ -256,29 +256,46 @@ export class TopologyWriteService {
     async generateTransactions(
         publicKey: string,
         partyId: PartyId,
-        confirmingThreshold: number = 1
+        confirmingThreshold: number = 1,
+        participantIds?: string[]
     ): Promise<GenerateTransactionsResponse> {
         const signingPublicKey = signingPublicKeyFromEd25519(publicKey)
         const namespace =
             TopologyWriteService.createFingerprintFromKey(signingPublicKey)
 
-        const { participantId } = await this.ledgerClient.get(
-            '/v2/parties/participant-id'
-        )
+        if (participantIds === undefined || participantIds.length === 0) {
+            const { participantId } = await this.ledgerClient.get(
+                '/v2/parties/participant-id'
+            )
 
-        const req = this.generateTransactionsRequest(
-            namespace,
-            partyId,
-            [participantId],
-            signingPublicKey,
-            confirmingThreshold
-        )
+            const req = this.generateTransactionsRequest(
+                namespace,
+                partyId,
+                [participantId],
+                signingPublicKey,
+                confirmingThreshold
+            )
 
-        return this.topologyClient.generateTransactions(req, {
-            meta: {
-                Authorization: `Bearer ${this.userAdminToken}`,
-            },
-        }).response
+            return this.topologyClient.generateTransactions(req, {
+                meta: {
+                    Authorization: `Bearer ${this.userAdminToken}`,
+                },
+            }).response
+        } else {
+            const req = this.generateTransactionsRequest(
+                namespace,
+                partyId,
+                participantIds,
+                signingPublicKey,
+                confirmingThreshold
+            )
+
+            return this.topologyClient.generateTransactions(req, {
+                meta: {
+                    Authorization: `Bearer ${this.userAdminToken}`,
+                },
+            }).response
+        }
     }
 
     private async addTransactions(

--- a/core/ledger-client/src/topology-write-service.ts
+++ b/core/ledger-client/src/topology-write-service.ts
@@ -350,7 +350,7 @@ export class TopologyWriteService {
         })
     }
 
-  async authorizePartyToParticipant(
+    async authorizePartyToParticipant(
         partyId: PartyId
     ): Promise<AuthorizeResponse> {
         const hash = await this.waitForPartyToParticipantProposal(partyId)

--- a/core/ledger-client/src/topology-write-service.ts
+++ b/core/ledger-client/src/topology-write-service.ts
@@ -180,7 +180,6 @@ export class TopologyWriteService {
     private generateTransactionsRequest(
         namespace: string,
         partyId: PartyId,
-        // participantId: string,
         participantIds: string[],
         publicKey: SigningPublicKey,
         confirmingThreshold: number = 1
@@ -200,6 +199,7 @@ export class TopologyWriteService {
             },
         })
 
+        //TODO: export HostingParticipant type that takes in (participantId, participant permission)
         const hostingParticipants = participantIds.map((pId) => {
             return PartyToParticipant_HostingParticipant.create({
                 participantUid: pId,

--- a/docs/wallet-integration-guide/examples/package.json
+++ b/docs/wallet-integration-guide/examples/package.json
@@ -15,7 +15,8 @@
         "run-02": "tsx ./scripts/02-auth-localnet.ts | pino-pretty",
         "run-03": "tsx ./scripts/03-ping-localnet.ts | pino-pretty",
         "run-04": "tsx ./scripts/04-token-standard-localnet.ts | pino-pretty",
-        "run-05": "tsx ./scripts/05-token-standard-transfer-autoaccept.ts| pino-pretty"
+        "run-05": "tsx ./scripts/05-token-standard-transfer-autoaccept.ts| pino-pretty",
+        "run-06": "tsx ./scripts/06-multi-hosted-party.ts | pino-pretty"
     },
     "devDependencies": {
         "@canton-network/core-signing-lib": "workspace:^",

--- a/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
+++ b/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
@@ -61,11 +61,6 @@ const participantEndpointConfigs = [
     // },
 ]
 
-/*
-
-        '127.0.0.1:2902',
-        'http://127.0.0.1:2975',
-        */
 logger.info('multi host party starting...')
 const result = await sdk.topology?.multiHostParty(
     participantEndpointConfigs,

--- a/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
+++ b/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
@@ -50,15 +50,15 @@ const synchonizerId = synchronizers!.connectedSynchronizers![0].synchronizerId
 
 const participantEndpointConfigs = [
     {
+        adminApiUrl: '127.0.0.1:2902',
+        baseUrl: 'http://127.0.0.1:2975',
+        accessToken: adminToken.accessToken,
+    },
+    {
         adminApiUrl: '127.0.0.1:3902',
         baseUrl: 'http://127.0.0.1:3975',
         accessToken: adminToken.accessToken,
     },
-    // {
-    //     adminApiUrl: '127.0.0.1:4902',
-    //     baseUrl: 'http://127.0.0.1:4975',
-    //     accessToken: adminToken.accessToken,
-    // },
 ]
 
 logger.info('multi host party starting...')

--- a/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
+++ b/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
@@ -11,7 +11,7 @@ import { pino } from 'pino'
 import { LOCALNET_REGISTRY_API_URL, LOCALNET_SCAN_API_URL } from '../config.js'
 import { v4 } from 'uuid'
 
-const logger = pino({ name: '05-external-party-setup', level: 'info' })
+const logger = pino({ name: '06-external-party-setup', level: 'info' })
 
 // it is important to configure the SDK correctly else you might run into connectivity or authentication issues
 const sdk = new WalletSDKImpl().configure({
@@ -42,6 +42,7 @@ const alice = await sdk.topology?.prepareSignAndSubmitExternalParty(
 )
 logger.info('created single hosted party to get synchronzerId')
 sdk.userLedger?.setPartyId(alice?.partyId!)
+logger.info(alice?.partyId!, 'created single user')
 
 const synchronizers = await sdk.userLedger?.listSynchronizers()
 

--- a/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
+++ b/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
@@ -40,9 +40,8 @@ const alice = await sdk.topology?.prepareSignAndSubmitExternalParty(
     singleHostedPartyKeyPair.privateKey,
     'alice'
 )
-logger.info('created single hosted party to get synchronzerId')
+logger.info(alice?.partyId!, 'created single hosted party to get synchronzerId')
 sdk.userLedger?.setPartyId(alice?.partyId!)
-logger.info(alice?.partyId!, 'created single user')
 
 const synchronizers = await sdk.userLedger?.listSynchronizers()
 

--- a/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
+++ b/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
@@ -51,12 +51,12 @@ const synchonizerId = synchronizers!.connectedSynchronizers![0].synchronizerId
 const participantEndpointConfigs = [
     {
         adminApiUrl: '127.0.0.1:2902',
-        baseUrl: 'http://127.0.0.1:2975',
+        baseUrl: new URL('http://127.0.0.1:2975'),
         accessToken: adminToken.accessToken,
     },
     {
         adminApiUrl: '127.0.0.1:3902',
-        baseUrl: 'http://127.0.0.1:3975',
+        baseUrl: new URL('http://127.0.0.1:3975'),
         accessToken: adminToken.accessToken,
     },
 ]

--- a/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
+++ b/docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts
@@ -1,0 +1,76 @@
+import {
+    WalletSDKImpl,
+    localNetAuthDefault,
+    localNetLedgerDefault,
+    localNetTopologyDefault,
+    localNetTokenStandardDefault,
+    createKeyPair,
+    localValidatorDefault,
+} from '@canton-network/wallet-sdk'
+import { pino } from 'pino'
+import { LOCALNET_REGISTRY_API_URL, LOCALNET_SCAN_API_URL } from '../config.js'
+import { v4 } from 'uuid'
+
+const logger = pino({ name: '05-external-party-setup', level: 'info' })
+
+// it is important to configure the SDK correctly else you might run into connectivity or authentication issues
+const sdk = new WalletSDKImpl().configure({
+    logger,
+    authFactory: localNetAuthDefault,
+    ledgerFactory: localNetLedgerDefault,
+    topologyFactory: localNetTopologyDefault,
+    tokenStandardFactory: localNetTokenStandardDefault,
+    validatorFactory: localValidatorDefault,
+})
+
+logger.info('SDK initialized')
+
+await sdk.connect()
+logger.info('Connected to ledger')
+
+const multiHostedParty = createKeyPair()
+const singleHostedPartyKeyPair = createKeyPair()
+
+await sdk.connectAdmin()
+await sdk.connectTopology(LOCALNET_SCAN_API_URL)
+
+const adminToken = await sdk.auth.getAdminToken()
+
+const alice = await sdk.topology?.prepareSignAndSubmitExternalParty(
+    singleHostedPartyKeyPair.privateKey,
+    'alice'
+)
+logger.info('created single hosted party to get synchronzerId')
+sdk.userLedger?.setPartyId(alice?.partyId!)
+
+const synchronizers = await sdk.userLedger?.listSynchronizers()
+
+const synchonizerId = synchronizers!.connectedSynchronizers![0].synchronizerId
+
+const participantEndpointConfigs = [
+    {
+        adminApiUrl: '127.0.0.1:3902',
+        baseUrl: 'http://127.0.0.1:3975',
+        accessToken: adminToken.accessToken,
+    },
+    // {
+    //     adminApiUrl: '127.0.0.1:4902',
+    //     baseUrl: 'http://127.0.0.1:4975',
+    //     accessToken: adminToken.accessToken,
+    // },
+]
+
+/*
+
+        '127.0.0.1:2902',
+        'http://127.0.0.1:2975',
+        */
+logger.info('multi host party starting...')
+const result = await sdk.topology?.multiHostParty(
+    participantEndpointConfigs,
+    multiHostedParty.privateKey,
+    synchonizerId,
+    'bob'
+)
+
+logger.info('multi hosted party succeeded!')

--- a/sdk/wallet-sdk/src/index.ts
+++ b/sdk/wallet-sdk/src/index.ts
@@ -27,7 +27,10 @@ export {
     createKeyPair,
 } from '@canton-network/core-signing-lib'
 export { decodePreparedTransaction } from '@canton-network/core-tx-visualizer'
-export { PreparedTransaction } from '@canton-network/core-ledger-proto'
+export {
+    PreparedTransaction,
+    Enums_ParticipantPermission,
+} from '@canton-network/core-ledger-proto'
 import { PartyId } from '@canton-network/core-types'
 
 type AuthFactory = () => AuthController

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -165,15 +165,11 @@ export class TopologyController {
                 )
         )
 
-        console.debug(
-            `Submitting external party topology for partyId ${preparedParty.partyId}`
-        )
         await this.topologyClient.submitExternalPartyTopology(
             signedTopologyTxs,
             preparedParty.partyId
         )
 
-        console.debug(`Authorizing party ${preparedParty.partyId}`)
         if (grantUserRights) {
             await this.client.grantUserRights(
                 this.userId,
@@ -181,7 +177,6 @@ export class TopologyController {
             )
         }
 
-        console.debug(`Completed setup for party ${preparedParty.partyId}`)
         return { partyId: preparedParty.partyId }
     }
 
@@ -197,9 +192,6 @@ export class TopologyController {
         confirmingThreshold?: number,
         hostingParticipantPermissions?: Map<string, Enums_ParticipantPermission>
     ): Promise<AllocatedParty> {
-        console.debug(
-            `Preparing, signing and submitting external party topology`
-        )
         const preparedParty = await this.prepareExternalPartyTopology(
             getPublicKeyFromPrivate(privateKey),
             partyHint,
@@ -207,16 +199,10 @@ export class TopologyController {
             hostingParticipantPermissions
         )
 
-        console.debug(
-            `Prepared external party topology for partyId ${preparedParty.partyId}`
-        )
-
         const signedHash = signTransactionHash(
             preparedParty!.combinedHash,
             privateKey
         )
-
-        console.debug(`Signed transaction hash for partyId ${signedHash}`)
 
         // grant user rights automatically if the party is hosted on 1 participant
         // if hosted on multiple participants, then we need to authorize each PartyToParticipant mapping
@@ -273,8 +259,6 @@ export class TopologyController {
             hostingParticipantPermissions
         )
 
-        this.logger.info(preparedParty, 'onboarded external party')
-
         //start after first because we've already onboarded an external party and authorized the mapping
         // on the participant specified in the wallet.sdk.configure
         // now we need to authorize the party to participant transaction on the others
@@ -292,8 +276,6 @@ export class TopologyController {
                 endpoint.accessToken,
                 lc
             )
-
-            this.logger.info(endpoint, 'endpoint info')
 
             await service.authorizePartyToParticipant(preparedParty.partyId)
         }

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -218,6 +218,10 @@ export class TopologyController {
         )
     }
 
+    /** Gets a participantId for a specified participant
+     * @param participantEndpoints the config to connect to a ledger
+     * @returns A participant id
+     */
     async getParticipantId(
         participantEndpoints: MultiHostPartyParticipantConfig
     ): Promise<string> {
@@ -230,6 +234,16 @@ export class TopologyController {
         return (await lc.get('/v2/parties/participant-id')).participantId
     }
 
+    /** Prepares, signs and submits a new external party topology in one step.
+     * This will also authorize the new party to the participant and grant the user rights to the party.
+     * @param participant_endpoints List of endpoints to the respective hosting participant Admin APIs and ledger API.
+     * @param privateKey The private key of the new external party, used to sign the topology transactions.
+     * @param synchronizer_id  ID of the synchronizer on which the party will be registered.
+     * @param hostingParticipantPermissions Map of participant id and permission level for participant
+     * @param partyHint Optional hint to use for the partyId, if not provided the publicKey will be used.
+     * @param confirming_threshold Minimum number of confirmations that must be received from the confirming participants to authorize a transaction.
+     * @returns An AllocatedParty object containing the partyId of the new party.
+     */
     async prepareSignAndSubmitMultiHostExternalParty(
         participantEndpoints: MultiHostPartyParticipantConfig[],
         privateKey: string,
@@ -269,6 +283,9 @@ export class TopologyController {
 
             await service.authorizePartyToParticipant(preparedParty.partyId)
         }
+
+        // the PartyToParticipant mapping needs to be authorized on each HostingParticipant
+        // before we can grantUserRights to the party
 
         await this.client.grantUserRights(this.userId, preparedParty.partyId)
 

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -33,7 +33,7 @@ export type AllocatedParty = {
 
 export type ParticipantEndpointConfig = {
     adminApiUrl: string
-    baseUrl: string
+    baseUrl: URL
     accessToken: string
 }
 

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -259,6 +259,7 @@ export class TopologyController {
             hostingParticipantPermissions
         )
 
+        this.logger.info(preparedParty, 'created external party')
         //start after first because we've already onboarded an external party and authorized the mapping
         // on the participant specified in the wallet.sdk.configure
         // now we need to authorize the party to participant transaction on the others

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -165,18 +165,23 @@ export class TopologyController {
                 )
         )
 
-        this.logger.info('submitting external party topology')
+        console.debug(
+            `Submitting external party topology for partyId ${preparedParty.partyId}`
+        )
         await this.topologyClient.submitExternalPartyTopology(
             signedTopologyTxs,
             preparedParty.partyId
         )
 
+        console.debug(`Authorizing party ${preparedParty.partyId}`)
         if (grantUserRights) {
             await this.client.grantUserRights(
                 this.userId,
                 preparedParty.partyId
             )
         }
+
+        console.debug(`Completed setup for party ${preparedParty.partyId}`)
         return { partyId: preparedParty.partyId }
     }
 
@@ -192,6 +197,9 @@ export class TopologyController {
         confirmingThreshold?: number,
         hostingParticipantPermissions?: Map<string, Enums_ParticipantPermission>
     ): Promise<AllocatedParty> {
+        console.debug(
+            `Preparing, signing and submitting external party topology`
+        )
         const preparedParty = await this.prepareExternalPartyTopology(
             getPublicKeyFromPrivate(privateKey),
             partyHint,
@@ -199,10 +207,16 @@ export class TopologyController {
             hostingParticipantPermissions
         )
 
+        console.debug(
+            `Prepared external party topology for partyId ${preparedParty.partyId}`
+        )
+
         const signedHash = signTransactionHash(
             preparedParty!.combinedHash,
             privateKey
         )
+
+        console.debug(`Signed transaction hash for partyId ${signedHash}`)
 
         // grant user rights automatically if the party is hosted on 1 participant
         // if hosted on multiple participants, then we need to authorize each PartyToParticipant mapping

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -218,6 +218,7 @@ export class TopologyController {
         partyHint?: string,
         confirmingThreshold?: number
     ) {
+        this.logger.info('getting participant ids')
         const participantIdPromises = participantEndpoints.map(
             async (endpoint) => {
                 return await this.getParticipantId(endpoint)
@@ -225,6 +226,8 @@ export class TopologyController {
         )
 
         const participantIds = await Promise.all(participantIdPromises)
+
+        this.logger.info(participantIds, 'participantIds')
 
         //allocate initial party against participant that the sdk is connected to
         const allocatedParty = await this.prepareSignAndSubmitExternalParty(

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -31,6 +31,12 @@ export type AllocatedParty = {
     partyId: PartyId
 }
 
+type ParticipantEndpointConfig = {
+    baseUrl: string
+    accessToken: string
+    participantPermission: string
+}
+
 /**
  * TopologyController handles topology management tasks involving administrating external parties.
  * Since these parties require topology transactions to be signed by an admin user, this controller
@@ -183,7 +189,7 @@ export class TopologyController {
     }
 
     async multiHostParty(
-        participantEndpoints: string[],
+        participantEndpoints: ParticipantEndpointConfig[],
         confirmingThreshold: number,
         publicKey: string,
         privateKey: string,
@@ -193,11 +199,15 @@ export class TopologyController {
             await this.prepareSignAndSubmitExternalParty(privateKey)
 
         participantEndpoints.forEach((endpoint) => {
-            const lc = new LedgerClient(endpoint, 'token?', this.logger)
+            const lc = new LedgerClient(
+                endpoint.baseUrl,
+                endpoint.accessToken,
+                this.logger
+            )
             const service = new TopologyWriteService(
                 synchronizerId,
-                endpoint,
-                'token?',
+                endpoint.baseUrl,
+                endpoint.accessToken,
                 lc
             )
             service.authorizePartyToParticipant(allocatedParty.partyId)

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -205,6 +205,11 @@ export class TopologyController {
             confirmingThreshold
         )
 
+        this.logger.info(
+            allocatedParty,
+            'allocated multihost party on sdk connected participant'
+        )
+
         for (const endpoint of participantEndpoints) {
             const lc = new LedgerClient(
                 endpoint.baseUrl,
@@ -213,7 +218,7 @@ export class TopologyController {
             )
             const service = new TopologyWriteService(
                 synchronizerId,
-                endpoint.baseUrl,
+                endpoint.adminApiUrl,
                 endpoint.accessToken,
                 lc
             )
@@ -222,7 +227,12 @@ export class TopologyController {
             await service
                 .waitForPartyToParticipantProposal(allocatedParty.partyId)
                 .then((p) => this.logger.info(p, 'result of listing proposals'))
-                .catch((e) => this.logger.error(e))
+                .catch((e) =>
+                    this.logger.error(
+                        e,
+                        'list party to participant proposal error'
+                    )
+                )
 
             await service.authorizePartyToParticipant(allocatedParty.partyId)
         }

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -241,7 +241,7 @@ export class TopologyController {
 
         const preparedParty = await this.prepareSignAndSubmitExternalParty(
             privateKey,
-            'bob',
+            partyHint,
             confirmingThreshold,
             participantIds
         )

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -205,8 +205,7 @@ export class TopologyController {
             confirmingThreshold
         )
 
-        //for the rest of the participant configs, authorize the party to participant mapping
-        participantEndpoints.forEach((endpoint) => {
+        for (const endpoint of participantEndpoints) {
             const lc = new LedgerClient(
                 endpoint.baseUrl,
                 endpoint.accessToken,
@@ -218,8 +217,33 @@ export class TopologyController {
                 endpoint.accessToken,
                 lc
             )
-            service.authorizePartyToParticipant(allocatedParty.partyId)
-        })
+            this.logger.info(endpoint, 'endpoint info')
+
+            await service
+                .waitForPartyToParticipantProposal(allocatedParty.partyId)
+                .then((p) => this.logger.info(p, 'result of listing proposals'))
+                .catch((e) => this.logger.error(e))
+
+            await service.authorizePartyToParticipant(allocatedParty.partyId)
+        }
+
+        //for the rest of the participant configs, authorize the party to participant mapping
+        // participantEndpoints.forEach((endpoint) => {
+        //     const lc = new LedgerClient(
+        //         endpoint.baseUrl,
+        //         endpoint.accessToken,
+        //         this.logger
+        //     )
+        //     const service = new TopologyWriteService(
+        //         synchronizerId,
+        //         endpoint.baseUrl,
+        //         endpoint.accessToken,
+        //         lc
+        //     )
+        //     this.logger.info(endpoint, 'endpoint info')
+
+        //     await service.authorizePartyToParticipant(allocatedParty.partyId)
+        // })
     }
 }
 

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -239,33 +239,6 @@ export class TopologyController {
 
         const participantIds = await Promise.all(participantIdPromises)
 
-        // const preparedParty = await this.prepareExternalPartyTopology(
-        //     getPublicKeyFromPrivate(privateKey),
-        //     partyHint,
-        //     confirmingThreshold,
-        //     participantIds
-        // )
-
-        // this.logger.info(preparedParty, 'preparedTxResponse')
-
-        // const base64StringCombinedHash = Buffer.from(
-        //     preparedParty?.combinedHash,
-        //     'hex'
-        // ).toString('base64')
-
-        // const signedHash = signTransactionHash(
-        //     base64StringCombinedHash,
-        //     privateKey
-        // )
-
-        // this.logger.info(signedHash)
-
-        // const submit = await this.submitExternalPartyTopology(
-        //     signedHash,
-        //     preparedParty,
-        //     true
-        // )
-
         const preparedParty = await this.prepareSignAndSubmitExternalParty(
             privateKey,
             'bob',

--- a/sdk/wallet-sdk/src/topologyController.ts
+++ b/sdk/wallet-sdk/src/topologyController.ts
@@ -181,6 +181,28 @@ export class TopologyController {
 
         return await this.submitExternalPartyTopology(signedHash, preparedParty)
     }
+
+    async multiHostParty(
+        participantEndpoints: string[],
+        confirmingThreshold: number,
+        publicKey: string,
+        privateKey: string,
+        synchronizerId: string
+    ) {
+        const allocatedParty =
+            await this.prepareSignAndSubmitExternalParty(privateKey)
+
+        participantEndpoints.forEach((endpoint) => {
+            const lc = new LedgerClient(endpoint, 'token?', this.logger)
+            const service = new TopologyWriteService(
+                synchronizerId,
+                endpoint,
+                'token?',
+                lc
+            )
+            service.authorizePartyToParticipant(allocatedParty.partyId)
+        })
+    }
 }
 
 /**


### PR DESCRIPTION
Closes #272
Tested against localnet using the `06-multi-hosted-party.ts` script and verified that the PartyToParticipant proposal has been accepted:

<img width="780" height="267" alt="image" src="https://github.com/user-attachments/assets/bfd0a5b3-3c1a-4c10-84db-7ab3c505ba9a" />


```

{
    "results": [
        {
            "context": {
                "signed_by_fingerprints": [
                    "12203a52fe5af3b87e0696182ac668a6cb315dab4bdc30da9e5b6dda9eb728784216",
                    "12208f61e866e293515fd0d75a099767a8b6ef52b893af241853e684544842ddcd97",
                    "12208fd58a15609f1e1bd8971ca4b13d021e7770b3363ddc2d00e8abfbbfe959897e"
                ],
                "store": {
                    "synchronizer": {
                        "id": "global-domain::1220bbd000b6987573b8c09f444e4df5509af8997b839109d7e2c212d547f0af0950"
                    }
                },
                "sequenced": {
                    "seconds": "1758122195",
                    "nanos": 486849000
                },
                "valid_from": {
                    "seconds": "1758122195",
                    "nanos": 736849000
                },
                "valid_until": null,
                "operation": "TOPOLOGY_CHANGE_OP_ADD_REPLACE",
                "transaction_hash": "EiBOncCnue6NQS4SPRCDCj77/j/RznoTSsW6dXkepAk6Fg==",
                "serial": 1
            },
            "item": {
                "participants": [
                    {
                        "participant_uid": "participant::12203a52fe5af3b87e0696182ac668a6cb315dab4bdc30da9e5b6dda9eb728784216",
                        "permission": "PARTICIPANT_PERMISSION_CONFIRMATION"
                    },
                    {
                        "participant_uid": "participant::12208f61e866e293515fd0d75a099767a8b6ef52b893af241853e684544842ddcd97",
                        "permission": "PARTICIPANT_PERMISSION_CONFIRMATION"
                    }
                ],
                "party": "bob::12208fd58a15609f1e1bd8971ca4b13d021e7770b3363ddc2d00e8abfbbfe959897e",
                "threshold": 1
            }
        }
    ]
}
```

contrast with alice (single hosted) where the participants array only has 1 :

```
{
    "results": [
        {
            "context": {
                "signed_by_fingerprints": [
                    "12203a52fe5af3b87e0696182ac668a6cb315dab4bdc30da9e5b6dda9eb728784216",
                    "122075b51fb31368ff88771fda9e6c223caca6920c5689ac58144a6b786b47d54f96"
                ],
                "store": {
                    "synchronizer": {
                        "id": "global-domain::1220bbd000b6987573b8c09f444e4df5509af8997b839109d7e2c212d547f0af0950"
                    }
                },
                "sequenced": {
                    "seconds": "1758122190",
                    "nanos": 425566000
                },
                "valid_from": {
                    "seconds": "1758122190",
                    "nanos": 675566000
                },
                "valid_until": null,
                "operation": "TOPOLOGY_CHANGE_OP_ADD_REPLACE",
                "transaction_hash": "EiCsM64FuWYp1hOO572GPSjRbRI2lqLC532Gxmp375siJQ==",
                "serial": 1
            },
            "item": {
                "participants": [
                    {
                        "participant_uid": "participant::12203a52fe5af3b87e0696182ac668a6cb315dab4bdc30da9e5b6dda9eb728784216",
                        "permission": "PARTICIPANT_PERMISSION_CONFIRMATION"
                    }
                ],
                "party": "alice::122075b51fb31368ff88771fda9e6c223caca6920c5689ac58144a6b786b47d54f96",
                "threshold": 1
            }
        }
    ]
}

```