### PR TITLE
chore: add script to fix release tags automatically

### DIFF
--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -14,6 +14,8 @@ This repository is a monorepo of independently versioned Javascript packages. We
     - create new GH releases with changelogs
     - create a commit containing the version bumps in all affected package.json's
 8. Merge the version bump PR into `main`
+    - if you squash and merge, the release commit will change when merged in main, leaving the tags pointing to orphaned hashes
+    - to fix this manually, then run `yarn script:retag <newhash>` using the new commit hash found on `main` corresponding to the release
 9. Open a PR from `main` to `latest`
 10. Ensure you change "Squash and merge" to "Create a merge commit", and then merge the PR
 11. Wait for the `publish.yml` workflow to complete on `latest`. Afterwards, any updated packages should be pushed to NPM

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "script:openrpc:titles": "tsx ./scripts/src/schema-title-validation.ts",
         "script:validate:package": "tsx ./scripts/src/package-and-verify-wallet-sdk.ts",
         "script:test:examples": "tsx ./scripts/src/test-example-scripts.ts",
+        "script:retag": "tsx ./scripts/src/retag.ts",
         "full:rebuild": "yarn clean:all && yarn generate:all && yarn build:all"
     },
     "workspaces": [

--- a/scripts/src/retag.ts
+++ b/scripts/src/retag.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { exec as ex } from 'child_process'
+import { promisify } from 'util'
+import readline from 'readline'
+import { elideMiddle, mapObject, success } from './utils.js'
+import { bold, cyan } from 'yoctocolors'
+
+const exec = promisify(ex)
+
+/**
+ * This script allows someone to retag a release to a different commit on GitHub.
+ * It takes a commit SHA pointing to a release and ensures that the corresponding tags match that commit.
+ * If they don't, it deletes the old tags and creates new ones pointing to the provided commit.
+ *
+ * The script is idempotent. If the tags are already corrected, it will do nothing.
+ */
+async function main() {
+    const hash = process.argv[2]
+
+    if (!hash) {
+        console.error('Usage: yarn script:retag <commit-sha>')
+        process.exit(1)
+    }
+
+    console.log(`Retagging release tags to commit ${bold(hash)}`)
+
+    const { stdout: commitMessage } = await exec(
+        `git rev-list --format=%B --max-count=1 ${hash}`
+    )
+
+    if (!commitMessage.includes('chore(release): publish'))
+        throw new Error('Provided commit is not a release commit')
+
+    const tags = parseTagsFromCommit(commitMessage)
+
+    if (tags.length === 0)
+        throw new Error('No tags found in the provided commit message')
+
+    const preview: TagPreview = {}
+
+    for (const tag of tags) {
+        const current = await currentTagCommit(tag)
+        preview[tag] = { current, target: hash }
+    }
+
+    console.log('The following tags will be moved:')
+    console.table(
+        mapObject(preview, (k, v) => [
+            k.replace('@canton-network/', ''),
+            {
+                current: elideMiddle(v.current, 26),
+                target: elideMiddle(v.target, 26),
+            },
+        ])
+    )
+
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    })
+
+    const answer = await new Promise<string>((resolve) => {
+        rl.question(
+            'Do you want to apply new target commit to these tags? (y/N) ',
+            resolve
+        )
+    })
+
+    rl.close()
+
+    if (answer.toLowerCase() !== 'y') {
+        console.log('Aborting')
+        process.exit(0)
+    }
+
+    for (const [tag, { current, target }] of Object.entries(preview)) {
+        if (current === target) {
+            console.log(
+                `Tag ${success(tag)} is already at the target commit, skipping`
+            )
+            continue
+        }
+
+        console.log(
+            `Moving tag ${success(tag)} from ${cyan(current)} to ${success(target)}`
+        )
+
+        await exec(`git tag -f ${tag} ${target}`)
+        await exec(`git push -f origin ${tag}`)
+
+        console.log(success(`Tag ${tag} moved successfully`))
+    }
+
+    console.log('\n' + bold(success('All tags moved successfully')))
+}
+
+type TagPreview = Record<string, { current: string; target: string }>
+
+function parseTagsFromCommit(message: string): string[] {
+    return message
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith('- project:'))
+        .map((line) => line.replace('- project: ', '').trim())
+        .map((line) => line.split(' ').join('@'))
+}
+
+async function currentTagCommit(tag: string) {
+    const currentSha = (await exec(`git rev-list -n 1 ${tag}`)).stdout.trim()
+
+    if (!currentSha) {
+        throw new Error(
+            `Tag ${tag} was not found in the repo. Ensure you've ran 'git fetch --tags --force' first. Otherwise, there may have been an issue with the release.`
+        )
+    }
+
+    return currentSha
+}
+
+main()

--- a/scripts/src/utils.ts
+++ b/scripts/src/utils.ts
@@ -307,3 +307,45 @@ export function markFile(
         )
     }
 }
+
+/**
+ * Maps over the keys and values of an object, allowing transformation of both.
+ *
+ * @param obj object to map over
+ * @param mapFn mapping function, which can return either a new value directly (no key change), or a [newKey, newValue] tuple
+ * @returns a new object with the mapped keys and values
+ */
+export function mapObject<V>(
+    obj: Record<string, V>,
+    mapFn: (k: string, v: V) => V | [string, V]
+): Record<string, V> {
+    return Object.fromEntries(
+        Object.entries(obj).map(([k, v]) => {
+            const mapped = mapFn(k, v)
+            return Array.isArray(mapped) ? mapped : [k, mapped]
+        })
+    )
+}
+
+/**
+ * Elides a string by replacing the middle portion with an ellipsis.
+ *
+ * @param s string to elide
+ * @param len the length of the elided middle portion (default: 8)
+ * @returns the elided string
+ */
+export function elideMiddle(s: string, len = 8) {
+    const elider = '...'
+    const totalLen = s.length
+
+    if (totalLen <= len) return s
+    if (len <= elider.length) return s
+
+    const halfway = Math.floor(totalLen / 2)
+
+    return (
+        s.slice(0, halfway - Math.floor(len / 2)) +
+        elider +
+        s.slice(halfway + Math.floor(len / 2))
+    )
+}


### PR DESCRIPTION
does what it says: 

<img width="1034" height="609" alt="Screenshot 2025-09-19 at 9 58 40 AM" src="https://github.com/user-attachments/assets/2253258c-bda9-4c7c-8823-bcc57010c929" />

Shows a preview before applying, and automatically skips tags that are already fixed 