### PR TITLE
feat(core-ledger-client, wallet-sdk): 2step transfer reject expired withdraw

### DIFF
--- a/core/ledger-client/src/token-standard-service.ts
+++ b/core/ledger-client/src/token-standard-service.ts
@@ -160,6 +160,47 @@ export class TokenStandardService {
         }
     }
 
+    async createWithdrawTransferInstruction(
+        transferInstructionCid: string,
+        transferFactoryRegistryUrl: string
+    ): Promise<[ExerciseCommand, DisclosedContract[]]> {
+        try {
+            const client = this.getTokenStandardClient(
+                transferFactoryRegistryUrl
+            )
+
+            const choiceContext = await client.post(
+                '/registry/transfer-instruction/v1/{transferInstructionId}/choice-contexts/withdraw',
+                {},
+                {
+                    path: {
+                        transferInstructionId: transferInstructionCid,
+                    },
+                }
+            )
+
+            const exercise: ExerciseCommand = {
+                templateId: TransferInstructionInterface,
+                contractId: transferInstructionCid,
+                choice: 'TransferInstruction_Withdraw',
+                choiceArgument: {
+                    extraArgs: {
+                        context: choiceContext.choiceContextData,
+                        meta: { values: {} },
+                    },
+                },
+            }
+
+            return [exercise, choiceContext.disclosedContracts]
+        } catch (e) {
+            this.logger.error(
+                'Failed to create withdraw transfer instruction:',
+                e
+            )
+            throw e
+        }
+    }
+
     // <T> is shape of viewValue related to queried interface.
     // i.e. when querying by TransferInstruction interfaceId, <T> would be TransferInstructionView from daml codegen
     async listContractsByInterface<T = ViewValue>(

--- a/docs/wallet-integration-guide/examples/package.json
+++ b/docs/wallet-integration-guide/examples/package.json
@@ -16,7 +16,8 @@
         "run-03": "tsx ./scripts/03-ping-localnet.ts | pino-pretty",
         "run-04": "tsx ./scripts/04-token-standard-localnet.ts | pino-pretty",
         "run-05": "tsx ./scripts/05-token-standard-transfer-autoaccept.ts| pino-pretty",
-        "run-06": "tsx ./scripts/06-multi-hosted-party.ts | pino-pretty"
+        "run-06": "tsx ./scripts/06-multi-hosted-party.ts | pino-pretty",
+        "run-07": "tsx ./scripts/07-token-standard-rejected-and-expired.ts | pino-pretty"
     },
     "devDependencies": {
         "@canton-network/core-signing-lib": "workspace:^",

--- a/docs/wallet-integration-guide/examples/package.json
+++ b/docs/wallet-integration-guide/examples/package.json
@@ -17,7 +17,7 @@
         "run-04": "tsx ./scripts/04-token-standard-localnet.ts | pino-pretty",
         "run-05": "tsx ./scripts/05-token-standard-transfer-autoaccept.ts| pino-pretty",
         "run-06": "tsx ./scripts/06-multi-hosted-party.ts | pino-pretty",
-        "run-07": "tsx ./scripts/07-token-standard-rejected-and-expired.ts | pino-pretty"
+        "run-07": "tsx ./scripts/07-token-standard-reject-expire-withdraw-localnet.ts | pino-pretty"
     },
     "devDependencies": {
         "@canton-network/core-signing-lib": "workspace:^",

--- a/docs/wallet-integration-guide/examples/scripts/07-token-standard-reject-expire-withdraw-localnet.ts
+++ b/docs/wallet-integration-guide/examples/scripts/07-token-standard-reject-expire-withdraw-localnet.ts
@@ -10,7 +10,10 @@ import { pino } from 'pino'
 import { v4 } from 'uuid'
 import { LOCALNET_REGISTRY_API_URL, LOCALNET_VALIDATOR_URL } from '../config.js'
 
-const logger = pino({ name: '04-token-standard-localnet', level: 'info' })
+const logger = pino({
+    name: '07-token-standard-reject-expire-withdraw',
+    level: 'info',
+})
 
 // it is important to configure the SDK correctly else you might run into connectivity or authentication issues
 const sdk = new WalletSDKImpl().configure({
@@ -45,10 +48,6 @@ const receiver = await sdk.topology?.prepareSignAndSubmitExternalParty(
 )
 logger.info(`Created party: ${receiver!.partyId}`)
 
-const synchronizers = await sdk.userLedger?.listSynchronizers()
-
-const synchonizerId = synchronizers!.connectedSynchronizers![0].synchronizerId
-
 await sdk.userLedger
     ?.listWallets()
     .then((wallets) => {
@@ -57,8 +56,6 @@ await sdk.userLedger
     .catch((error) => {
         logger.error({ error }, 'Error listing wallets')
     })
-
-sdk.tokenStandard?.setSynchronizerId(synchonizerId)
 
 sdk.tokenStandard?.setTransferFactoryRegistryUrl(LOCALNET_REGISTRY_API_URL)
 const instrumentAdminPartyId =
@@ -85,11 +82,8 @@ const commandIdTap = await sdk.userLedger?.prepareSignAndExecuteTransaction(
 
 await sdk.userLedger?.waitForCompletion(offsetLatestTap, 5000, commandIdTap!)
 
-const utxos = await sdk.tokenStandard?.listHoldingUtxos(false)
-logger.info(utxos, 'List Available Token Standard Holding UTXOs')
-
 // Alice creates transfer to Bob
-logger.info('Creating transfer transaction')
+logger.info('Creating transfer transaction (reject)')
 const [transferCommandToReject, disclosedContracts2] =
     await sdk.tokenStandard!.createTransfer(
         sender!.partyId,
@@ -99,7 +93,7 @@ const [transferCommandToReject, disclosedContracts2] =
             instrumentId: 'Amulet',
             instrumentAdmin: instrumentAdminPartyId,
         },
-        utxos?.map((t) => t.contractId),
+        undefined,
         'memo-ref'
     )
 
@@ -112,7 +106,7 @@ const transferCommandId =
         v4(),
         disclosedContracts2
     )
-logger.info('Submitted transfer transaction')
+logger.info('Submitted transfer transaction (reject)')
 
 await sdk.userLedger?.waitForCompletion(offsetLatest, 5000, transferCommandId!)
 
@@ -130,7 +124,7 @@ const [rejectTransferCommand, disclosedContracts3] =
         'Reject'
     )
 
-await sdk.userLedger?.prepareSignAndExecuteTransaction(
+const rejectCommandId = await sdk.userLedger?.prepareSignAndExecuteTransaction(
     [{ ExerciseCommand: rejectTransferCommand }],
     keyPairReceiver.privateKey,
     v4(),
@@ -139,14 +133,21 @@ await sdk.userLedger?.prepareSignAndExecuteTransaction(
 
 logger.info('Rejected transfer instruction')
 
+// TODO await completion
+await sdk.userLedger?.waitForCompletion(
+    (await sdk.userLedger?.ledgerEnd())?.offset ?? 0,
+    5000,
+    rejectCommandId!
+)
+
 // Alice creates transfer to Bob with expiry date
 await sdk.setPartyId(sender!.partyId)
-
-const utxos2 = await sdk.tokenStandard?.listHoldingUtxos(false)
-logger.info(utxos2, 'List Available Token Standard Holding UTXOs')
+const utxosAfterRejected = await sdk.tokenStandard?.listHoldingUtxos(false)
 
 const EXPIRATION_MS = 10_000
-const expiryDate = new Date(Date.now() + EXPIRATION_MS) // 5s from now
+const expiryDate = new Date(Date.now() + EXPIRATION_MS)
+
+logger.info('Creating transfer transaction (expire)')
 const [transferCommandToExpire, disclosedContracts4] =
     await sdk.tokenStandard!.createTransfer(
         sender!.partyId,
@@ -156,7 +157,7 @@ const [transferCommandToExpire, disclosedContracts4] =
             instrumentId: 'Amulet',
             instrumentAdmin: instrumentAdminPartyId,
         },
-        utxos2?.map((t) => t.contractId),
+        undefined,
         'memo-ref',
         expiryDate
     )
@@ -170,7 +171,7 @@ const transferCommandId2 =
         v4(),
         disclosedContracts4
     )
-logger.info('Submitted transfer transaction')
+logger.info('Submitted transfer transaction (expire)')
 
 await sdk.userLedger?.waitForCompletion(
     offsetLatest2,
@@ -181,33 +182,24 @@ await sdk.userLedger?.waitForCompletion(
 const pendingInstructions2 =
     await sdk.tokenStandard?.fetchPendingTransferInstructionView()
 
-const transferCid2 = pendingInstructions2?.[0].contractId!
+const expiredTransferCid = pendingInstructions2?.[0].contractId!
 
 // Wait for transfer instruction to expire
 await new Promise((res) => setTimeout(res, EXPIRATION_MS + 5_000))
 
-// Alice withdraws the expired transfer
-const [withdrawTransferCommand, disclosedContracts5] =
-    await sdk.tokenStandard!.exerciseTransferInstructionChoice(
-        transferCid2,
-        'Withdraw'
-    )
-
-await sdk.userLedger?.prepareSignAndExecuteTransaction(
-    [{ ExerciseCommand: withdrawTransferCommand }],
-    keyPairSender.privateKey,
-    v4(),
-    disclosedContracts5
+const utxosAfterExpired = await sdk.tokenStandard?.listHoldingUtxos(false)
+const unlockedUtxo = utxosAfterExpired?.find((t) => t.interfaceViewValue.lock)
+if (!unlockedUtxo) {
+    throw new Error('Unexpected lack of unlocked UTXO after expiration')
+}
+logger.info(
+    { unlockedUtxo },
+    'UTXO used as inputHolding in expired transfer got unlocked after expiration'
 )
 
-logger.info('Withdrawn transfer instruction')
-
-await new Promise((res) => setTimeout(res, 5000))
-
-// Alice creates transfer to Bob
-const utxos3 = await sdk.tokenStandard?.listHoldingUtxos(false)
-logger.info(utxos3, 'List Available Token Standard Holding UTXOs')
-const [transferCommandToAccept, disclosedContracts6] =
+// Alice creates transfer that will be withdrawn
+logger.info('Creating transfer transaction (withdraw)')
+const [transferCommandToWithdraw, disclosedContracts5] =
     await sdk.tokenStandard!.createTransfer(
         sender!.partyId,
         receiver!.partyId,
@@ -216,7 +208,7 @@ const [transferCommandToAccept, disclosedContracts6] =
             instrumentId: 'Amulet',
             instrumentAdmin: instrumentAdminPartyId,
         },
-        utxos3?.map((t) => t.contractId),
+        undefined,
         'memo-ref'
     )
 
@@ -224,12 +216,12 @@ const offsetLatest3 = (await sdk.userLedger?.ledgerEnd())?.offset ?? 0
 
 const transferCommandId3 =
     await sdk.userLedger?.prepareSignAndExecuteTransaction(
-        [{ ExerciseCommand: transferCommandToAccept }],
+        [{ ExerciseCommand: transferCommandToWithdraw }],
         keyPairSender.privateKey,
         v4(),
-        disclosedContracts6
+        disclosedContracts5
     )
-logger.info('Submitted transfer transaction')
+logger.info('Submitted transfer transaction (withdraw)')
 
 await sdk.userLedger?.waitForCompletion(
     offsetLatest3,
@@ -237,43 +229,97 @@ await sdk.userLedger?.waitForCompletion(
     transferCommandId3!
 )
 
-// Bob accepts the transfer
-await sdk.setPartyId(receiver!.partyId)
-
 const pendingInstructions3 =
     await sdk.tokenStandard?.fetchPendingTransferInstructionView()
-const transferCid3 = pendingInstructions3?.[0].contractId!
 
-const [acceptTransferCommand, disclosedContracts7] =
+// Note that previous transfer instruction that expired is still pending until rejected or withdrawn,
+// but input holdings used in expired transfer are unlocked and can be used
+const transferCid3 = pendingInstructions3?.find(
+    (transferInstruction) =>
+        transferInstruction.contractId !== expiredTransferCid
+)!.contractId
+// Alice withdraws the transfer
+const [withdrawTransferCommand, disclosedContracts6] =
     await sdk.tokenStandard!.exerciseTransferInstructionChoice(
-        transferCid3,
-        'Accept'
+        transferCid3!,
+        'Withdraw'
     )
 
 const offsetLatest4 = (await sdk.userLedger?.ledgerEnd())?.offset ?? 0
+const withdrawCommandId =
+    await sdk.userLedger?.prepareSignAndExecuteTransaction(
+        [{ ExerciseCommand: withdrawTransferCommand }],
+        keyPairSender.privateKey,
+        v4(),
+        disclosedContracts6
+    )
+
+logger.info('Withdrawn transfer instruction')
+await sdk.userLedger?.waitForCompletion(offsetLatest4, 5000, withdrawCommandId!)
+
+const utxosAfterWithdraw = await sdk.tokenStandard?.listHoldingUtxos(false)
+
+// Alice creates transfer to Bob to accept using reclaimed holdings
+const [transferCommandToAccept, disclosedContracts7] =
+    await sdk.tokenStandard!.createTransfer(
+        sender!.partyId,
+        receiver!.partyId,
+        '100',
+        {
+            instrumentId: 'Amulet',
+            instrumentAdmin: instrumentAdminPartyId,
+        },
+        undefined,
+        'memo-ref'
+    )
+
+const offsetLatest5 = (await sdk.userLedger?.ledgerEnd())?.offset ?? 0
 
 const transferCommandId4 =
     await sdk.userLedger?.prepareSignAndExecuteTransaction(
-        [{ ExerciseCommand: acceptTransferCommand }],
-        keyPairReceiver.privateKey,
+        [{ ExerciseCommand: transferCommandToAccept }],
+        keyPairSender.privateKey,
         v4(),
         disclosedContracts7
     )
-logger.info('Accepted transfer instruction')
+logger.info('Submitted transfer transaction')
 
 await sdk.userLedger?.waitForCompletion(
-    offsetLatest4,
+    offsetLatest5,
     5000,
     transferCommandId4!
 )
 
-await new Promise((res) => setTimeout(res, 5000))
-{
-    await sdk.setPartyId(sender!.partyId)
-    const aliceHoldings = await sdk.tokenStandard?.listHoldingTransactions()
-    logger.info(aliceHoldings, '[ALICE] holding transactions')
+// Bob accepts the transfer
+await sdk.setPartyId(receiver!.partyId)
 
-    await sdk.setPartyId(receiver!.partyId)
-    const bobHoldings = await sdk.tokenStandard?.listHoldingTransactions()
-    logger.info(bobHoldings, '[BOB] holding transactions')
-}
+const pendingInstructions4 =
+    await sdk.tokenStandard?.fetchPendingTransferInstructionView()
+
+const transferCid4 = pendingInstructions4?.find(
+    (transferInstruction) =>
+        transferInstruction.contractId !== expiredTransferCid
+)!.contractId
+
+const [acceptTransferCommand, disclosedContracts8] =
+    await sdk.tokenStandard!.exerciseTransferInstructionChoice(
+        transferCid4!,
+        'Accept'
+    )
+
+const offsetLatest6 = (await sdk.userLedger?.ledgerEnd())?.offset ?? 0
+
+const transferCommandId5 =
+    await sdk.userLedger?.prepareSignAndExecuteTransaction(
+        [{ ExerciseCommand: acceptTransferCommand }],
+        keyPairReceiver.privateKey,
+        v4(),
+        disclosedContracts8
+    )
+logger.info('Accepted transfer instruction')
+
+await sdk.userLedger?.waitForCompletion(
+    offsetLatest6,
+    5000,
+    transferCommandId5!
+)

--- a/docs/wallet-integration-guide/examples/scripts/07-token-standard-rejected-and-expired.ts
+++ b/docs/wallet-integration-guide/examples/scripts/07-token-standard-rejected-and-expired.ts
@@ -191,7 +191,7 @@ logger.info({ completion2 }, 'Transfer transaction completed')
 const pendingInstructions2 =
     await sdk.tokenStandard?.fetchPendingTransferInstructionView()
 
-const transferCid2 = pendingInstructions?.[0].contractId!
+const transferCid2 = pendingInstructions2?.[0].contractId!
 // Wait for transfer instruction to expire
 await new Promise((res) => setTimeout(res, 17500))
 
@@ -203,7 +203,7 @@ const [withdrawTransferCommand, disclosedContracts5] =
 
 await sdk.userLedger?.prepareSignAndExecuteTransaction(
     [{ ExerciseCommand: withdrawTransferCommand }],
-    keyPairReceiver.privateKey,
+    keyPairSender.privateKey,
     v4(),
     disclosedContracts5
 )

--- a/docs/wallet-integration-guide/examples/scripts/07-token-standard-rejected-and-expired.ts
+++ b/docs/wallet-integration-guide/examples/scripts/07-token-standard-rejected-and-expired.ts
@@ -1,0 +1,223 @@
+import {
+    WalletSDKImpl,
+    localNetAuthDefault,
+    localNetLedgerDefault,
+    localNetTopologyDefault,
+    localNetTokenStandardDefault,
+    createKeyPair,
+} from '@canton-network/wallet-sdk'
+import { pino } from 'pino'
+import { v4 } from 'uuid'
+import { LOCALNET_REGISTRY_API_URL, LOCALNET_VALIDATOR_URL } from '../config.js'
+
+const logger = pino({ name: '04-token-standard-localnet', level: 'info' })
+
+// it is important to configure the SDK correctly else you might run into connectivity or authentication issues
+const sdk = new WalletSDKImpl().configure({
+    logger,
+    authFactory: localNetAuthDefault,
+    ledgerFactory: localNetLedgerDefault,
+    topologyFactory: localNetTopologyDefault,
+    tokenStandardFactory: localNetTokenStandardDefault,
+})
+
+logger.info('SDK initialized')
+
+await sdk.connect()
+logger.info('Connected to ledger')
+
+const keyPairSender = createKeyPair()
+const keyPairReceiver = createKeyPair()
+
+await sdk.connectAdmin()
+await sdk.connectTopology(LOCALNET_VALIDATOR_URL)
+
+const sender = await sdk.topology?.prepareSignAndSubmitExternalParty(
+    keyPairSender.privateKey,
+    'alice'
+)
+logger.info(`Created party: ${sender!.partyId}`)
+await sdk.setPartyId(sender!.partyId)
+
+const receiver = await sdk.topology?.prepareSignAndSubmitExternalParty(
+    keyPairReceiver.privateKey,
+    'bob'
+)
+logger.info(`Created party: ${receiver!.partyId}`)
+
+const synchronizers = await sdk.userLedger?.listSynchronizers()
+
+const synchonizerId = synchronizers!.connectedSynchronizers![0].synchronizerId
+
+await sdk.userLedger
+    ?.listWallets()
+    .then((wallets) => {
+        logger.info(wallets, 'Wallets:')
+    })
+    .catch((error) => {
+        logger.error({ error }, 'Error listing wallets')
+    })
+
+sdk.tokenStandard?.setSynchronizerId(synchonizerId)
+
+sdk.tokenStandard?.setTransferFactoryRegistryUrl(LOCALNET_REGISTRY_API_URL)
+const instrumentAdminPartyId =
+    (await sdk.tokenStandard?.getInstrumentAdmin()) || ''
+
+const [tapCommand, disclosedContracts] = await sdk.tokenStandard!.createTap(
+    sender!.partyId,
+    '2000000',
+    {
+        instrumentId: 'Amulet',
+        instrumentAdmin: instrumentAdminPartyId,
+    }
+)
+
+await sdk.userLedger?.prepareSignAndExecuteTransaction(
+    [{ ExerciseCommand: tapCommand }],
+    keyPairSender.privateKey,
+    v4(),
+    disclosedContracts
+)
+
+await new Promise((res) => setTimeout(res, 5000))
+
+const utxos = await sdk.tokenStandard?.listHoldingUtxos(false)
+logger.info(utxos, 'List Available Token Standard Holding UTXOs')
+
+await sdk.tokenStandard
+    ?.listHoldingTransactions()
+    .then((transactions) => {
+        logger.info(transactions, 'Token Standard Holding Transactions:')
+    })
+    .catch((error) => {
+        logger.error(
+            { error },
+            'Error listing token standard holding transactions:'
+        )
+    })
+
+logger.info('Creating transfer transaction')
+
+const [transferCommandToReject, disclosedContracts2] =
+    await sdk.tokenStandard!.createTransfer(
+        sender!.partyId,
+        receiver!.partyId,
+        '100',
+        {
+            instrumentId: 'Amulet',
+            instrumentAdmin: instrumentAdminPartyId,
+        },
+        utxos?.map((t) => t.contractId),
+        'memo-ref'
+    )
+
+const offsetLatest = (await sdk.userLedger?.ledgerEnd())?.offset ?? 0
+
+const transferCommandId =
+    await sdk.userLedger?.prepareSignAndExecuteTransaction(
+        [{ ExerciseCommand: transferCommandToReject }],
+        keyPairSender.privateKey,
+        v4(),
+        disclosedContracts2
+    )
+logger.info('Submitted transfer transaction')
+
+const completion = await sdk.userLedger?.waitForCompletion(
+    offsetLatest,
+    5000,
+    transferCommandId!
+)
+logger.info({ completion }, 'Transfer transaction completed')
+
+const pendingInstructions =
+    await sdk.tokenStandard?.fetchPendingTransferInstructionView()
+
+const transferCid = pendingInstructions?.[0].contractId!
+
+await sdk.setPartyId(receiver!.partyId)
+
+const [rejectTransferCommand, disclosedContracts3] =
+    await sdk.tokenStandard!.exerciseTransferInstructionChoice(
+        transferCid,
+        'Reject'
+    )
+
+await sdk.userLedger?.prepareSignAndExecuteTransaction(
+    [{ ExerciseCommand: rejectTransferCommand }],
+    keyPairReceiver.privateKey,
+    v4(),
+    disclosedContracts3
+)
+
+logger.info('Rejected transfer instruction')
+
+await sdk.setPartyId(sender!.partyId)
+
+const utxos2 = await sdk.tokenStandard?.listHoldingUtxos(false)
+logger.info(utxos2, 'List Available Token Standard Holding UTXOs')
+
+const expiryDate = new Date(Date.now() + 15_000) // 5s from now
+const [transferCommandToExpire, disclosedContracts4] =
+    await sdk.tokenStandard!.createTransfer(
+        sender!.partyId,
+        receiver!.partyId,
+        '100',
+        {
+            instrumentId: 'Amulet',
+            instrumentAdmin: instrumentAdminPartyId,
+        },
+        utxos2?.map((t) => t.contractId),
+        'memo-ref',
+        expiryDate
+    )
+
+const transferCommandId2 =
+    await sdk.userLedger?.prepareSignAndExecuteTransaction(
+        [{ ExerciseCommand: transferCommandToExpire }],
+        keyPairSender.privateKey,
+        v4(),
+        disclosedContracts4
+    )
+logger.info('Submitted transfer transaction')
+
+const completion2 = await sdk.userLedger?.waitForCompletion(
+    offsetLatest,
+    5000,
+    transferCommandId2!
+)
+logger.info({ completion2 }, 'Transfer transaction completed')
+// TODO check if you can find it there after expiration
+const pendingInstructions2 =
+    await sdk.tokenStandard?.fetchPendingTransferInstructionView()
+
+const transferCid2 = pendingInstructions?.[0].contractId!
+// Wait for transfer instruction to expire
+await new Promise((res) => setTimeout(res, 17500))
+
+const [withdrawTransferCommand, disclosedContracts5] =
+    await sdk.tokenStandard!.exerciseTransferInstructionChoice(
+        transferCid2,
+        'Withdraw'
+    )
+
+await sdk.userLedger?.prepareSignAndExecuteTransaction(
+    [{ ExerciseCommand: withdrawTransferCommand }],
+    keyPairReceiver.privateKey,
+    v4(),
+    disclosedContracts5
+)
+
+logger.info('Withdrawn transfer instruction')
+
+await new Promise((res) => setTimeout(res, 5000))
+
+{
+    await sdk.setPartyId(sender!.partyId)
+    const aliceHoldings = await sdk.tokenStandard?.listHoldingTransactions()
+    logger.info(aliceHoldings, '[ALICE] holding transactions')
+
+    await sdk.setPartyId(receiver!.partyId)
+    const bobHoldings = await sdk.tokenStandard?.listHoldingTransactions()
+    logger.info(bobHoldings, '[BOB] holding transactions')
+}

--- a/sdk/wallet-sdk/src/ledgerController.ts
+++ b/sdk/wallet-sdk/src/ledgerController.ts
@@ -144,7 +144,6 @@ export class LedgerController {
         return commandId
     }
 
-    // TODO fix jsdoc
     /**
      * Waits for a command to be completed by polling the completions endpoint.
      * @param ledgerEnd The offset to start polling from.

--- a/sdk/wallet-sdk/src/ledgerController.ts
+++ b/sdk/wallet-sdk/src/ledgerController.ts
@@ -144,6 +144,7 @@ export class LedgerController {
         return commandId
     }
 
+    // TODO fix jsdoc
     /**
      * Waits for a command to be completed by polling the completions endpoint.
      * @param commandId The ID of the command to wait for.

--- a/sdk/wallet-sdk/src/tokenStandardController.ts
+++ b/sdk/wallet-sdk/src/tokenStandardController.ts
@@ -20,7 +20,7 @@ import {
 } from '@canton-network/core-token-standard'
 import { PartyId } from '@canton-network/core-types'
 
-export type TransactionInstructionChoice = 'Accept' | 'Reject'
+export type TransactionInstructionChoice = 'Accept' | 'Reject' | 'Withdraw'
 
 /**
  * TokenStandardController handles token standard management tasks.
@@ -301,21 +301,29 @@ export class TokenStandardController {
         instructionChoice: TransactionInstructionChoice
     ): Promise<[Types['ExerciseCommand'], Types['DisclosedContract'][]]> {
         try {
-            if (instructionChoice === 'Accept') {
-                return await this.service.createAcceptTransferInstruction(
-                    transferInstructionCid,
-                    this.getTransferFactoryRegistryUrl().href
-                )
-            } else {
-                return await this.service.createRejectTransferInstruction(
-                    transferInstructionCid,
-                    this.getTransferFactoryRegistryUrl().href
-                )
+            switch (instructionChoice) {
+                case 'Accept':
+                    return await this.service.createAcceptTransferInstruction(
+                        transferInstructionCid,
+                        this.getTransferFactoryRegistryUrl().href
+                    )
+                case 'Reject':
+                    return await this.service.createRejectTransferInstruction(
+                        transferInstructionCid,
+                        this.getTransferFactoryRegistryUrl().href
+                    )
+                case 'Withdraw':
+                    return await this.service.createWithdrawTransferInstruction(
+                        transferInstructionCid,
+                        this.getTransferFactoryRegistryUrl().href
+                    )
+                default:
+                    throw new Error('Unexpected instruction choice')
             }
         } catch (error) {
             this.logger.error(
                 { error },
-                'Failed to accept transfer instruction'
+                'Failed to exercise transfer instruction choice'
             )
             throw error
         }


### PR DESCRIPTION
Fixes: [#500](https://github.com/hyperledger-labs/splice-wallet-kernel/issues/500) [#501](https://github.com/hyperledger-labs/splice-wallet-kernel/issues/501) 

Added method for withdrawing a transfer instruction.
Added example script that:
-Sends transfer that gets rejected
-Sends transfer that expires
-Sends transfer that is withdrawn
-Logs UTXOs before and after each action that triggers reclaiming of UTXO 
-Uses reclaimed UTXOs to create another transfer that gets accepted