### PR TITLE
chore: bump playwright CI cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
               id: playwright-cache
               with:
                   path: '~/.cache/ms-playwright'
-                  key: '${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}'
+                  key: '${{ runner.os }}-0-playwright-${{ steps.playwright-version.outputs.version }}'
                   # As a fallback, if the Playwright version has changed, try use the
                   # most recently cached version. There's a good chance that at least one
                   # of the browser binary versions haven't been updated, so Playwright can
@@ -158,7 +158,7 @@ jobs:
                   # date cache, but still let Playwright decide if it needs to download
                   # new binaries or not.
                   restore-keys: |
-                      ${{ runner.os }}-playwright-
+                      ${{ runner.os }}-0-playwright-
 
             # If the Playwright browser binaries weren't able to be restored, we tell
             # playwright to install everything for us.

--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.25.0",
-        "@playwright/test": "^1.54.2",
+        "@playwright/test": "^1.55.0",
         "@types/node": "^24.3.0",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "@nx/eslint-plugin": "^21.5.2",
         "@nx/playwright": "21.5.1",
         "@open-rpc/generator": "^2.0.0",
-        "@playwright/test": "^1.36.0",
+        "@playwright/test": "^1.55.0",
         "@protobuf-ts/plugin": "^2.11.1",
         "@swc-node/register": "^1.11.1",
         "@swc/core": "^1.13.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,7 +1876,7 @@ __metadata:
   dependencies:
     "@canton-network/dapp-sdk": "workspace:^"
     "@eslint/js": "npm:^9.25.0"
-    "@playwright/test": "npm:^1.54.2"
+    "@playwright/test": "npm:^1.55.0"
     "@types/node": "npm:^24.3.0"
     "@types/react": "npm:^19.1.2"
     "@types/react-dom": "npm:^19.1.2"
@@ -4820,7 +4820,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.36.0, @playwright/test@npm:^1.54.2":
+"@playwright/test@npm:^1.55.0":
   version: 1.55.0
   resolution: "@playwright/test@npm:1.55.0"
   dependencies:
@@ -15924,7 +15924,7 @@ __metadata:
     "@nx/js": "npm:^21.3.11"
     "@nx/playwright": "npm:21.5.1"
     "@open-rpc/generator": "npm:^2.0.0"
-    "@playwright/test": "npm:^1.36.0"
+    "@playwright/test": "npm:^1.55.0"
     "@protobuf-ts/plugin": "npm:^2.11.1"
     "@swc-node/register": "npm:^1.11.1"
     "@swc/core": "npm:^1.13.4"


### PR DESCRIPTION
changing the cache key to see if redownloading the browsers fixes 

```
Error: browserType.launch: ENOENT: no such file or directory, stat '/home/runner/.cache/ms-playwright/firefox-1490/firefox/lock'
```