### PR TITLE
chore: ignore core/rpc-generator

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,7 +6,7 @@
         "sharedGlobals": []
     },
     "release": {
-        "projects": ["core/*", "sdk/*"],
+        "projects": ["core/*", "sdk/*", "!core/rpc-generator"],
         "projectsRelationship": "independent",
         "version": {
             "conventionalCommits": true,


### PR DESCRIPTION
When running the release, we were running into the following error (even though the private = true in the package.json):

```
rukminibasu@rukminibasufj726c splice-wallet-kernel % yarn nx release --skip-publish --dry-run
?
Warning: Unable to resolve the current version for "@canton-network/core-rpc-generator" from git tag using pattern "{projectName}@{version}" and there is no version on disk to fall back to. This is invalid with conventional-commits because the new version is determined by relatively bumping the current version.

To resolve this, you should set an initial git tag on a relevant commit, or set an appropriate version in a supported manifest file such as package.json.

```