### PR TITLE
build(clients-remote): tsx watch command fix

### DIFF
--- a/clients/remote/package.json
+++ b/clients/remote/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "tsc -b; tsc -b tsconfig.frontend.json && yarn db:migrate:reset && yarn db:bootstrap",
         "clean": "tsc -b --clean && rm -rf ./dist && rm ./store.sqlite || true",
-        "dev": "tsx watch src/index.ts | pino-pretty",
+        "dev": "tsx watch src --include *.config.ts --include *.json src/index.ts | pino-pretty",
         "test": "yarn node --experimental-vm-modules $(yarn bin jest)",
         "start": "yarn node dist/index.js",
         "db:bootstrap": "tsx ./src/scripts/db.ts bootstrap",


### PR DESCRIPTION
- Watch command would include the top level project directory, thus it would go into a recursion by mis-firing each time a vite .mjs file would be generated.