### PR TITLE
feat(core-ledger-client, wallet-sdk): self-issue a FeaturedAppRight

### DIFF
--- a/core/ledger-client/src/token-standard-service.ts
+++ b/core/ledger-client/src/token-standard-service.ts
@@ -83,6 +83,19 @@ export class TokenStandardService {
         return transfer_preapproval
     }
 
+    async getFeaturedAppsByParty(partyId: PartyId) {
+        const { featured_app_right } = await this.scanProxyClient.get(
+            '/v0/scan-proxy/featured-apps/{provider_party_id}',
+            {
+                path: {
+                    provider_party_id: partyId,
+                },
+            }
+        )
+
+        return featured_app_right
+    }
+
     async getInstrumentById(
         transferFactoryRegistryUrl: string,
         instrumentId: string
@@ -555,6 +568,31 @@ export class TokenStandardService {
                 },
             },
             disclosedContracts,
+        ]
+    }
+
+    async selfGrantFeatureAppRight(
+        providerPartyId: PartyId,
+        synchronizerId: string
+    ): Promise<[ExerciseCommand, DisclosedContract[]]> {
+        const amuletRules = await this.scanProxyClient.getAmuletRules()
+        const disclosedContracts = {
+            templateId: amuletRules.template_id,
+            contractId: amuletRules.contract_id,
+            createdEventBlob: amuletRules.created_event_blob,
+            synchronizerId: synchronizerId,
+        }
+
+        return [
+            {
+                templateId: amuletRules.template_id,
+                contractId: amuletRules.contract_id,
+                choice: 'AmuletRules_DevNet_FeatureApp',
+                choiceArgument: {
+                    provider: providerPartyId,
+                },
+            },
+            [disclosedContracts],
         ]
     }
 

--- a/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
+++ b/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
@@ -51,14 +51,14 @@ const synchronizers = await sdk.userLedger?.listSynchronizers()
 
 const synchonizerId = synchronizers!.connectedSynchronizers![0].synchronizerId
 
-// await sdk.userLedger
-//     ?.listWallets()
-//     .then((wallets) => {
-//         logger.info(wallets, 'Wallets:')
-//     })
-//     .catch((error) => {
-//         logger.error({ error }, 'Error listing wallets')
-//     })
+await sdk.userLedger
+    ?.listWallets()
+    .then((wallets) => {
+        logger.info(wallets, 'Wallets:')
+    })
+    .catch((error) => {
+        logger.error({ error }, 'Error listing wallets')
+    })
 
 sdk.tokenStandard?.setSynchronizerId(synchonizerId)
 
@@ -110,19 +110,6 @@ await sdk.userLedger?.prepareSignExecuteAndWaitFor(
     disclosedContracts
 )
 
-const [featuredAppCommand, disclosedContractsApp] =
-    await sdk.tokenStandard!.selfGrantRights()
-
-await sdk.userLedger?.prepareSignExecuteAndWaitFor(
-    featuredAppCommand,
-    keyPairSender.privateKey,
-    v4(),
-    disclosedContractsApp
-)
-
-const featuredApps = await sdk.tokenStandard!.lookupFeaturedApps()
-logger.info(featuredApps, `Look up featured app rights`)
-
 const utxos = await sdk.tokenStandard?.listHoldingUtxos()
 logger.info(utxos, 'List Token Standard Holding UTXOs')
 
@@ -160,6 +147,16 @@ await sdk.userLedger?.prepareSignExecuteAndWaitFor(
     disclosedContracts2
 )
 logger.info('Submitted transfer transaction')
+
+await sdk.setPartyId(validatorOperatorParty!)
+
+const validatorFeatureAppRights =
+    await sdk.tokenStandard!.grantFeatureAppRightsForInternalParty()
+
+logger.info(
+    validatorFeatureAppRights,
+    `Featured App Rights for validator ${validatorOperatorParty}`
+)
 
 {
     await sdk.setPartyId(sender!.partyId)

--- a/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
+++ b/docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts
@@ -51,14 +51,14 @@ const synchronizers = await sdk.userLedger?.listSynchronizers()
 
 const synchonizerId = synchronizers!.connectedSynchronizers![0].synchronizerId
 
-await sdk.userLedger
-    ?.listWallets()
-    .then((wallets) => {
-        logger.info(wallets, 'Wallets:')
-    })
-    .catch((error) => {
-        logger.error({ error }, 'Error listing wallets')
-    })
+// await sdk.userLedger
+//     ?.listWallets()
+//     .then((wallets) => {
+//         logger.info(wallets, 'Wallets:')
+//     })
+//     .catch((error) => {
+//         logger.error({ error }, 'Error listing wallets')
+//     })
 
 sdk.tokenStandard?.setSynchronizerId(synchonizerId)
 
@@ -109,6 +109,19 @@ await sdk.userLedger?.prepareSignExecuteAndWaitFor(
     v4(),
     disclosedContracts
 )
+
+const [featuredAppCommand, disclosedContractsApp] =
+    await sdk.tokenStandard!.selfGrantRights()
+
+await sdk.userLedger?.prepareSignExecuteAndWaitFor(
+    featuredAppCommand,
+    keyPairSender.privateKey,
+    v4(),
+    disclosedContractsApp
+)
+
+const featuredApps = await sdk.tokenStandard!.lookupFeaturedApps()
+logger.info(featuredApps, `Look up featured app rights`)
 
 const utxos = await sdk.tokenStandard?.listHoldingUtxos()
 logger.info(utxos, 'List Token Standard Holding UTXOs')

--- a/sdk/wallet-sdk/src/tokenStandardController.ts
+++ b/sdk/wallet-sdk/src/tokenStandardController.ts
@@ -285,7 +285,7 @@ export class TokenStandardController {
      * Creates ExerciseCommand for granting featured app rights.
      * @returns AmuletRules_DevNet_FeatureApp command and disclosed contracts.
      */
-    async selfGrantRights(): Promise<
+    async selfGrantFeatureAppRights(): Promise<
         [WrappedCommand<'ExerciseCommand'>, Types['DisclosedContract'][]]
     > {
         const [featuredAppCommand, disclosedContracts] =
@@ -307,6 +307,7 @@ export class TokenStandardController {
 
     /**
      * Submits a command to grant feature app rights for an internal party such as the validator operator user
+     * For external parties, use prepareSignAndExecuteTransaction in LedgerController
      * @returns A contract of Daml template `Splice.Amulet.FeaturedAppRight`.
      */
     async grantFeatureAppRightsForInternalParty() {
@@ -317,7 +318,7 @@ export class TokenStandardController {
         }
 
         const [featuredAppCommand, disclosedContractsApp] =
-            await this.selfGrantRights()
+            await this.selfGrantFeatureAppRights()
 
         const request = {
             commands: [featuredAppCommand],

--- a/sdk/wallet-sdk/src/tokenStandardController.ts
+++ b/sdk/wallet-sdk/src/tokenStandardController.ts
@@ -281,6 +281,30 @@ export class TokenStandardController {
     }
 
     /**
+     * Creates ExerciseCommand for granting featured app rights.
+     * @returns AmuletRules_DevNet_FeatureApp command and disclosed contracts.
+     */
+    async selfGrantRights(): Promise<
+        [WrappedCommand<'ExerciseCommand'>, Types['DisclosedContract'][]]
+    > {
+        const [featuredAppCommand, disclosedContracts] =
+            await this.service.selfGrantFeatureAppRight(
+                this.getPartyId(),
+                this.getSynchronizerId()
+            )
+
+        return [{ ExerciseCommand: featuredAppCommand }, disclosedContracts]
+    }
+
+    /**
+     * Looks up if a party has FeaturedAppRight.
+     * @returns If defined, a contract of Daml template `Splice.Amulet.FeaturedAppRight`.
+     */
+    async lookupFeaturedApps() {
+        return this.service.getFeaturedAppsByParty(this.getPartyId())
+    }
+
+    /**
      * Creates a new transfer for the specified sender, receiver, amount, and instrument.
      * @param sender The party of the sender.
      * @param receiver The party of the receiver.


### PR DESCRIPTION
Related to https://github.com/hyperledger-labs/splice-wallet-kernel/issues/492

This sets up the featured exchange party. As per the[ doc recommendations](https://docs.digitalasset.com/integrate/devnet/exchange-integration/node-operations.html#reward-minting-and-traffic-funding), I've added a command to create it for an internal party (the validator user), but we can also self grant the rights for an external party.