### PR TITLE
fix: use app provider validator url

### DIFF
--- a/docs/wallet-integration-guide/examples/scripts/exchange-integration/01-one-step-deposit.ts
+++ b/docs/wallet-integration-guide/examples/scripts/exchange-integration/01-one-step-deposit.ts
@@ -10,6 +10,7 @@ const logger = pino({ name: '01-one-step-deposit', level: 'info' })
 
 const { treasuryParty, exchangeSdk } = await setupExchange({
     transferPreapproval: true,
+    grantFeatureAppRights: true,
 })
 
 const { customerParty, customerKeyPair, customerSdk } =

--- a/docs/wallet-integration-guide/examples/scripts/exchange-integration/setup-exchange.ts
+++ b/docs/wallet-integration-guide/examples/scripts/exchange-integration/setup-exchange.ts
@@ -58,7 +58,6 @@ export async function setupExchange(options?: {
     const exchangeParty = await exchangeSdk.validator!.getValidatorUser()!
 
     if (options?.transferPreapproval) {
-        //TODO(#537): Tap exchange party to ensure they have funds to setup the pre-approval
         const instrumentAdminPartyId =
             (await exchangeSdk.tokenStandard?.getInstrumentAdmin()) || ''
 

--- a/docs/wallet-integration-guide/examples/scripts/exchange-integration/setup-exchange.ts
+++ b/docs/wallet-integration-guide/examples/scripts/exchange-integration/setup-exchange.ts
@@ -72,8 +72,6 @@ export async function setupExchange(options?: {
             }
         )
 
-        await new Promise((res) => setTimeout(res, 5000))
-
         await exchangeSdk.setPartyId(treasuryParty)
 
         // Setup preapproval

--- a/docs/wallet-integration-guide/examples/scripts/exchange-integration/setup-exchange.ts
+++ b/docs/wallet-integration-guide/examples/scripts/exchange-integration/setup-exchange.ts
@@ -7,6 +7,7 @@ import {
     localNetTopologyAppProvider,
     localValidatorDefault,
     localNetStaticConfig,
+    localValidatorDefaultAppProvider,
 } from '@canton-network/wallet-sdk'
 import { pino } from 'pino'
 import { v4 } from 'uuid'
@@ -24,7 +25,7 @@ export async function setupExchange(options?: {
         ledgerFactory: localNetLedgerAppProvider,
         topologyFactory: localNetTopologyAppProvider,
         tokenStandardFactory: localNetTokenStandardAppProvider,
-        validatorFactory: localValidatorDefault,
+        validatorFactory: localValidatorDefaultAppProvider,
     })
 
     logger.info('Setup exchange SDK')
@@ -60,6 +61,21 @@ export async function setupExchange(options?: {
         //TODO(#537): Tap exchange party to ensure they have funds to setup the pre-approval
         const instrumentAdminPartyId =
             (await exchangeSdk.tokenStandard?.getInstrumentAdmin()) || ''
+
+        await exchangeSdk.setPartyId(exchangeParty)
+
+        await exchangeSdk.tokenStandard?.createAndSubmitTapInternal(
+            exchangeParty,
+            '20000000',
+            {
+                instrumentId: 'Amulet',
+                instrumentAdmin: instrumentAdminPartyId,
+            }
+        )
+
+        await new Promise((res) => setTimeout(res, 5000))
+
+        await exchangeSdk.setPartyId(treasuryParty)
 
         // Setup preapproval
         const cmd =

--- a/sdk/wallet-sdk/src/validatorController.ts
+++ b/sdk/wallet-sdk/src/validatorController.ts
@@ -255,3 +255,18 @@ export const localValidatorDefault = (
         token
     )
 }
+
+/**
+ * A default factory function used for running against a local validator node.
+ * This uses mock-auth and is started with the 'yarn start:canton'
+ */
+export const localValidatorDefaultAppProvider = (
+    userId: string,
+    token: string
+): ValidatorController => {
+    return new ValidatorController(
+        userId,
+        new URL('http://wallet.localhost:3000/api/validator'),
+        token
+    )
+}

--- a/sdk/wallet-sdk/src/validatorController.ts
+++ b/sdk/wallet-sdk/src/validatorController.ts
@@ -243,7 +243,7 @@ export class ValidatorController {
 
 /**
  * A default factory function used for running against a local validator node.
- * This uses mock-auth and is started with the 'yarn start:canton'
+ * This uses the user validator and is started with 'yarn start:localnet`
  */
 export const localValidatorDefault = (
     userId: string,
@@ -258,7 +258,7 @@ export const localValidatorDefault = (
 
 /**
  * A default factory function used for running against a local validator node.
- * This uses mock-auth and is started with the 'yarn start:canton'
+ * This uses the app provider validator and is started with 'yarn start:localnet`
  */
 export const localValidatorDefaultAppProvider = (
     userId: string,


### PR DESCRIPTION
Fixes https://github.com/hyperledger-labs/splice-wallet-kernel/issues/616


This fixes the `setup-exchange.ts` so it uses the app provider validator url rather than the app user validator url to align with the app provider participant configs. Additionally, this allows us to tap the exchange party to ensure there are enough funds to setup the transfer pre approval.