### PR TITLE
fix(wallet-sdk): catch ledger controller init error in wallet constructor

### DIFF
--- a/sdk/wallet-sdk/src/ledgerController.ts
+++ b/sdk/wallet-sdk/src/ledgerController.ts
@@ -58,7 +58,9 @@ export class LedgerController {
      */
     constructor(userId: string, baseUrl: URL, token: string, isAdmin: boolean) {
         this.client = new LedgerClient(baseUrl, token, this.logger)
-        this.client.init()
+        this.client.init().catch((error) => {
+            this.logger.error('LedgerClient initialization error:', error)
+        })
         this.userId = userId
         this.isAdmin = isAdmin
         return this


### PR DESCRIPTION
The `LedgerController` has an un-awaited promise that will crash a running process with an unhandled exception if one is thrown during the ledger client init process.