### PR TITLE
fix: add missing admin field

### DIFF
--- a/wallet-gateway/remote/src/user-api/controller.ts
+++ b/wallet-gateway/remote/src/user-api/controller.ts
@@ -73,6 +73,7 @@ export const userController = (
                     audience: network.auth.audience ?? '',
                     scope: network.auth.scope ?? '',
                     clientId: network.auth.clientId ?? '',
+                    admin: network.auth.admin ?? {},
                 }
             } else {
                 auth = {
@@ -85,6 +86,7 @@ export const userController = (
                     scope: network.auth.scope ?? '',
                     clientId: network.auth.clientId ?? '',
                     audience: network.auth.audience ?? '',
+                    admin: network.auth.admin ?? {},
                 }
             }
 


### PR DESCRIPTION
related to issue #747 

When adding or updating the network, the network.auth.admin field was omitted — this field is responsible for the admin clientId/Secret.