### PR TITLE
feat(wallet-gateway-remote): rename chainId to networkId

### DIFF
--- a/api-specs/openrpc-dapp-api.json
+++ b/api-specs/openrpc-dapp-api.json
@@ -38,7 +38,7 @@
                     "required": ["status", "sessionToken"]
                 }
             },
-            "description": "Ensures ledger connectivity and returns the connected network information along with the user access token. ChainId should follow CAIP-2 and represent the synchronizerId."
+            "description": "Ensures ledger connectivity and returns the connected network information along with the user access token. Network ID should follow CAIP-2 and represent the synchronizerId."
         },
         {
             "name": "disconnect",
@@ -449,8 +449,8 @@
                         "type": "boolean",
                         "description": "Whether or not a connection to a network is established."
                     },
-                    "chainId": {
-                        "title": "chainId",
+                    "networkId": {
+                        "title": "networkId",
                         "type": "string",
                         "description": "A CAIP-2 compliant chain ID, e.g. 'canton:da-mainnet'."
                     }

--- a/api-specs/openrpc-dapp-remote-api.json
+++ b/api-specs/openrpc-dapp-remote-api.json
@@ -38,7 +38,7 @@
                     "required": ["status", "sessionToken"]
                 }
             },
-            "description": "Ensures ledger connectivity and returns the connected network information along with the user access token. ChainId should follow CAIP-2 and represent the synchronizerId."
+            "description": "Ensures ledger connectivity and returns the connected network information along with the user access token. NetworkId should follow CAIP-2 and represent the synchronizerId."
         },
         {
             "name": "disconnect",
@@ -184,10 +184,10 @@
                         "kernel": {
                             "$ref": "#/components/schemas/KernelInfo"
                         },
-                        "chainId": {
-                            "title": "chainId",
+                        "networkId": {
+                            "title": "networkId",
                             "type": "string",
-                            "description": "A CAIP-2 compliant chain ID, e.g. 'canton:da-mainnet'."
+                            "description": "A CAIP-2 compliant network ID, e.g. 'canton:da-mainnet'."
                         },
                         "sessionToken": {
                             "title": "sessionToken",
@@ -195,7 +195,7 @@
                             "description": "JWT authentication token (if applicable)."
                         }
                     },
-                    "required": ["kernel", "chainId"]
+                    "required": ["kernel", "networkId"]
                 }
             },
             "description": "Informs when the user connects to a network."
@@ -483,10 +483,10 @@
                         "type": "boolean",
                         "description": "Whether or not a connection to a network is established."
                     },
-                    "chainId": {
-                        "title": "chainId",
+                    "networkId": {
+                        "title": "networkId",
                         "type": "string",
-                        "description": "A CAIP-2 compliant chain ID, e.g. 'canton:da-mainnet'."
+                        "description": "A CAIP-2 compliant network ID, e.g. 'canton:da-mainnet'."
                     }
                 },
                 "required": ["kernel", "isConnected"]

--- a/api-specs/openrpc-user-api.json
+++ b/api-specs/openrpc-user-api.json
@@ -77,8 +77,8 @@
                                 "type": "string",
                                 "description": "The party hint and name of the wallet."
                             },
-                            "chainId": {
-                                "title": "chainId",
+                            "networkId": {
+                                "title": "networkId",
                                 "type": "string",
                                 "description": "The network ID the wallet corresponds to."
                             },
@@ -90,7 +90,7 @@
                         },
                         "required": [
                             "partyHint",
-                            "chainId",
+                            "networkId",
                             "signingProviderId"
                         ]
                     }
@@ -366,13 +366,13 @@
                         "title": "AddSessionParams",
                         "type": "object",
                         "properties": {
-                            "chainId": {
-                                "title": "chainId",
+                            "networkId": {
+                                "title": "networkId",
                                 "type": "string",
                                 "description": "Network Id"
                             }
                         },
-                        "required": ["chainId"]
+                        "required": ["networkId"]
                     }
                 }
             ],
@@ -419,6 +419,11 @@
                 "type": "object",
                 "description": "Structure representing the Networks",
                 "properties": {
+                    "id": {
+                        "title": "networkId",
+                        "type": "string",
+                        "description": "Network ID"
+                    },
                     "name": {
                         "title": "name",
                         "type": "string",
@@ -434,11 +439,6 @@
                         "type": "string",
                         "description": "Synchronizer ID"
                     },
-                    "chainId": {
-                        "title": "chainId",
-                        "type": "string",
-                        "description": "Network Id"
-                    },
                     "auth": {
                         "$ref": "#/components/schemas/Auth"
                     },
@@ -449,9 +449,9 @@
                     }
                 },
                 "required": [
+                    "id",
                     "name",
                     "description",
-                    "chainId",
                     "synchronizerId",
                     "auth",
                     "ledgerApi"
@@ -556,8 +556,8 @@
                         "type": "string",
                         "description": "The namespace of the party."
                     },
-                    "chainId": {
-                        "title": "chainId",
+                    "networkId": {
+                        "title": "networkId",
                         "type": "string",
                         "description": "The network ID the wallet corresponds to."
                     },
@@ -573,7 +573,7 @@
                     "hint",
                     "publicKey",
                     "namespace",
-                    "chainId",
+                    "networkId",
                     "signingProviderId"
                 ]
             },
@@ -582,12 +582,12 @@
                 "type": "object",
                 "description": "Filter for wallets",
                 "properties": {
-                    "chainIds": {
-                        "title": "chainIds",
+                    "networkIds": {
+                        "title": "networkIds",
                         "type": "array",
                         "description": "Filter wallets by network IDs.",
                         "items": {
-                            "title": "chainId",
+                            "title": "networkId",
                             "type": "string"
                         }
                     },

--- a/core/splice-provider/src/SpliceProviderHttp.ts
+++ b/core/splice-provider/src/SpliceProviderHttp.ts
@@ -72,11 +72,11 @@ export class SpliceProviderHttp extends SpliceProviderBase {
                     .then((status) => {
                         const statusResult = status as {
                             kernel: unknown
-                            chainId?: unknown
+                            networkId?: unknown
                         }
                         this.emit('onConnected', {
                             kernel: statusResult.kernel,
-                            chainId: statusResult.chainId,
+                            networkId: statusResult.networkId,
                             sessionToken: this.sessionToken,
                         })
                     })

--- a/core/wallet-dapp-remote-rpc-client/src/index.ts
+++ b/core/wallet-dapp-remote-rpc-client/src/index.ts
@@ -54,11 +54,11 @@ export type IsConnected = boolean
  * The network ID the wallet corresponds to.
  *
  */
-export type ChainId = string
+export type NetworkId = string
 export interface StatusEvent {
     kernel: KernelInfo
     isConnected: IsConnected
-    chainId?: ChainId
+    networkId?: NetworkId
     [k: string]: any
 }
 /**
@@ -145,7 +145,7 @@ export interface Wallet {
     hint: Hint
     publicKey: PublicKey
     namespace: Namespace
-    chainId: ChainId
+    networkId: NetworkId
     signingProviderId: SigningProviderId
     [k: string]: any
 }
@@ -306,7 +306,7 @@ export interface LedgerApiResult {
 }
 export interface OnConnectedEvent {
     kernel: KernelInfo
-    chainId: ChainId
+    networkId: NetworkId
     sessionToken?: SessionToken
     [k: string]: any
 }

--- a/core/wallet-dapp-remote-rpc-client/src/openrpc.json
+++ b/core/wallet-dapp-remote-rpc-client/src/openrpc.json
@@ -38,7 +38,7 @@
                     "required": ["status", "sessionToken"]
                 }
             },
-            "description": "Ensures ledger connectivity and returns the connected network information along with the user access token. ChainId should follow CAIP-2 and represent the synchronizerId."
+            "description": "Ensures ledger connectivity and returns the connected network information along with the user access token. NetworkId should follow CAIP-2 and represent the synchronizerId."
         },
         {
             "name": "disconnect",
@@ -184,10 +184,10 @@
                         "kernel": {
                             "$ref": "#/components/schemas/KernelInfo"
                         },
-                        "chainId": {
-                            "title": "chainId",
+                        "networkId": {
+                            "title": "networkId",
                             "type": "string",
-                            "description": "A CAIP-2 compliant chain ID, e.g. 'canton:da-mainnet'."
+                            "description": "A CAIP-2 compliant network ID, e.g. 'canton:da-mainnet'."
                         },
                         "sessionToken": {
                             "title": "sessionToken",
@@ -195,7 +195,7 @@
                             "description": "JWT authentication token (if applicable)."
                         }
                     },
-                    "required": ["kernel", "chainId"]
+                    "required": ["kernel", "networkId"]
                 }
             },
             "description": "Informs when the user connects to a network."
@@ -483,10 +483,10 @@
                         "type": "boolean",
                         "description": "Whether or not a connection to a network is established."
                     },
-                    "chainId": {
-                        "title": "chainId",
+                    "networkId": {
+                        "title": "networkId",
                         "type": "string",
-                        "description": "A CAIP-2 compliant chain ID, e.g. 'canton:da-mainnet'."
+                        "description": "A CAIP-2 compliant network ID, e.g. 'canton:da-mainnet'."
                     }
                 },
                 "required": ["kernel", "isConnected"]

--- a/core/wallet-dapp-rpc-client/src/index.ts
+++ b/core/wallet-dapp-rpc-client/src/index.ts
@@ -61,11 +61,11 @@ export type IsConnected = boolean
  * The network ID the wallet corresponds to.
  *
  */
-export type ChainId = string
+export type NetworkId = string
 export interface StatusEvent {
     kernel: KernelInfo
     isConnected: IsConnected
-    chainId?: ChainId
+    networkId?: NetworkId
     [k: string]: any
 }
 /**
@@ -184,7 +184,7 @@ export interface Wallet {
     hint: Hint
     publicKey: PublicKey
     namespace: Namespace
-    chainId: ChainId
+    networkId: NetworkId
     signingProviderId: SigningProviderId
     [k: string]: any
 }

--- a/core/wallet-dapp-rpc-client/src/openrpc.json
+++ b/core/wallet-dapp-rpc-client/src/openrpc.json
@@ -38,7 +38,7 @@
                     "required": ["status", "sessionToken"]
                 }
             },
-            "description": "Ensures ledger connectivity and returns the connected network information along with the user access token. ChainId should follow CAIP-2 and represent the synchronizerId."
+            "description": "Ensures ledger connectivity and returns the connected network information along with the user access token. Network ID should follow CAIP-2 and represent the synchronizerId."
         },
         {
             "name": "disconnect",
@@ -449,8 +449,8 @@
                         "type": "boolean",
                         "description": "Whether or not a connection to a network is established."
                     },
-                    "chainId": {
-                        "title": "chainId",
+                    "networkId": {
+                        "title": "networkId",
                         "type": "string",
                         "description": "A CAIP-2 compliant chain ID, e.g. 'canton:da-mainnet'."
                     }

--- a/core/wallet-store-inmemory/src/Store.test.ts
+++ b/core/wallet-store-inmemory/src/Store.test.ts
@@ -50,7 +50,7 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network1',
+                networkId: 'network1',
             }
             await store.addWallet(wallet)
             const wallets = await store.getWallets()
@@ -65,7 +65,7 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal1',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network1',
+                networkId: 'network1',
             }
             const wallet2: Wallet = {
                 primary: false,
@@ -74,7 +74,7 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal2',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network1',
+                networkId: 'network1',
             }
             const wallet3: Wallet = {
                 primary: false,
@@ -83,27 +83,27 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal2',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network2',
+                networkId: 'network2',
             }
             await store.addWallet(wallet1)
             await store.addWallet(wallet2)
             await store.addWallet(wallet3)
             const getAllWallets = await store.getWallets()
-            const getWalletsByChainId = await store.getWallets({
-                chainIds: ['network1'],
+            const getWalletsByNetworkId = await store.getWallets({
+                networkIds: ['network1'],
             })
             const getWalletsBySigningProviderId = await store.getWallets({
                 signingProviderIds: ['internal2'],
             })
-            const getWalletsByChainIdAndSigningProviderId =
+            const getWalletsByNetworkIdAndSigningProviderId =
                 await store.getWallets({
-                    chainIds: ['network1'],
+                    networkIds: ['network1'],
                     signingProviderIds: ['internal2'],
                 })
             expect(getAllWallets).toHaveLength(3)
-            expect(getWalletsByChainId).toHaveLength(2)
+            expect(getWalletsByNetworkId).toHaveLength(2)
             expect(getWalletsBySigningProviderId).toHaveLength(2)
-            expect(getWalletsByChainIdAndSigningProviderId).toHaveLength(1)
+            expect(getWalletsByNetworkIdAndSigningProviderId).toHaveLength(1)
         })
 
         test('should set and get primary wallet', async () => {
@@ -114,7 +114,7 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network1',
+                networkId: 'network1',
             }
             const wallet2: Wallet = {
                 primary: false,
@@ -123,7 +123,7 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network1',
+                networkId: 'network1',
             }
             await store.addWallet(wallet1)
             await store.addWallet(wallet2)
@@ -159,8 +159,8 @@ implementations.forEach(([name, StoreImpl]) => {
                 audience: 'aud',
             }
             const network: Network = {
+                id: 'network1',
                 name: 'testnet',
-                chainId: 'network1',
                 synchronizerId: 'sync1::fingerprint',
                 description: 'Test Network',
                 ledgerApi,

--- a/core/wallet-store-sql/src/migrations/001-init.ts
+++ b/core/wallet-store-sql/src/migrations/001-init.ts
@@ -27,7 +27,7 @@ export async function up(db: Kysely<DB>): Promise<void> {
     await db.schema
         .createTable('networks')
         .ifNotExists()
-        .addColumn('chain_id', 'text', (col) => col.primaryKey())
+        .addColumn('id', 'text', (col) => col.primaryKey())
         .addColumn('name', 'text', (col) => col.notNull())
         .addColumn('synchronizer_id', 'text', (col) => col.notNull())
         .addColumn('description', 'text')
@@ -50,8 +50,8 @@ export async function up(db: Kysely<DB>): Promise<void> {
         .addColumn('public_key', 'text', (col) => col.notNull())
         .addColumn('namespace', 'text', (col) => col.notNull())
         .addColumn('user_id', 'text', (col) => col.notNull())
-        .addColumn('chain_id', 'text', (col) =>
-            col.references('networks.chain_id').onDelete('cascade')
+        .addColumn('network_id', 'text', (col) =>
+            col.references('networks.id').onDelete('cascade')
         )
         .addColumn('signing_provider_id', 'text', (col) => col.notNull())
         .execute()

--- a/core/wallet-store-sql/src/schema.ts
+++ b/core/wallet-store-sql/src/schema.ts
@@ -30,8 +30,8 @@ interface IdpTable {
 }
 
 interface NetworkTable {
+    id: string
     name: string
-    chainId: string
     synchronizerId: string
     description: string
     ledgerApiBaseUrl: string
@@ -45,7 +45,7 @@ interface WalletTable {
     hint: string
     publicKey: string
     namespace: string
-    chainId: string
+    networkId: string
     signingProviderId: string
     userId: UserId
 }
@@ -212,7 +212,7 @@ export const toNetwork = (
     }
     return {
         name: table.name,
-        chainId: table.chainId,
+        id: table.id,
         synchronizerId: table.synchronizerId,
         description: table.description,
         ledgerApi: {
@@ -228,7 +228,7 @@ export const fromNetwork = (
 ): NetworkTable => {
     return {
         name: network.name,
-        chainId: network.chainId,
+        id: network.id,
         synchronizerId: network.synchronizerId,
         description: network.description,
         ledgerApiBaseUrl: network.ledgerApi.baseUrl,

--- a/core/wallet-store-sql/src/store-sql.test.ts
+++ b/core/wallet-store-sql/src/store-sql.test.ts
@@ -53,7 +53,7 @@ const auth: PasswordAuth = {
 }
 const network: Network = {
     name: 'testnet',
-    chainId: 'network1',
+    id: 'network1',
     synchronizerId: 'sync1::fingerprint',
     description: 'Test Network',
     ledgerApi,
@@ -82,7 +82,7 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network1',
+                networkId: 'network1',
             }
             const store = new StoreImpl(db, pino(sink()), authContextMock)
             await store.addNetwork(network)
@@ -105,7 +105,7 @@ implementations.forEach(([name, StoreImpl]) => {
             }
             const network2: Network = {
                 name: 'testnet',
-                chainId: 'network2',
+                id: 'network2',
                 synchronizerId: 'sync1::fingerprint',
                 description: 'Test Network',
                 ledgerApi,
@@ -118,7 +118,7 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network1',
+                networkId: 'network1',
             }
             const wallet2: Wallet = {
                 primary: false,
@@ -127,7 +127,7 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network1',
+                networkId: 'network1',
             }
             const wallet3: Wallet = {
                 primary: false,
@@ -136,7 +136,7 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network2',
+                networkId: 'network2',
             }
             const store = new StoreImpl(db, pino(sink()), authContextMock)
             await store.addNetwork(network)
@@ -145,21 +145,21 @@ implementations.forEach(([name, StoreImpl]) => {
             await store.addWallet(wallet2)
             await store.addWallet(wallet3)
             const getAllWallets = await store.getWallets()
-            const getWalletsByChainId = await store.getWallets({
-                chainIds: ['network1'],
+            const getWalletsByNetworkId = await store.getWallets({
+                networkIds: ['network1'],
             })
             const getWalletsBySigningProviderId = await store.getWallets({
                 signingProviderIds: ['internal'],
             })
-            const getWalletsByChainIdAndSigningProviderId =
+            const getWalletsByNetworkIdAndSigningProviderId =
                 await store.getWallets({
-                    chainIds: ['network1'],
+                    networkIds: ['network1'],
                     signingProviderIds: ['internal'],
                 })
             expect(getAllWallets).toHaveLength(3)
-            expect(getWalletsByChainId).toHaveLength(2)
+            expect(getWalletsByNetworkId).toHaveLength(2)
             expect(getWalletsBySigningProviderId).toHaveLength(3)
-            expect(getWalletsByChainIdAndSigningProviderId).toHaveLength(2)
+            expect(getWalletsByNetworkIdAndSigningProviderId).toHaveLength(2)
         })
 
         test('should set and get primary wallet', async () => {
@@ -170,7 +170,7 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network1',
+                networkId: 'network1',
             }
             const wallet2: Wallet = {
                 primary: false,
@@ -179,7 +179,7 @@ implementations.forEach(([name, StoreImpl]) => {
                 signingProviderId: 'internal',
                 publicKey: 'publicKey',
                 namespace: 'namespace',
-                chainId: 'network1',
+                networkId: 'network1',
             }
             const store = new StoreImpl(db, pino(sink()), authContextMock)
             await store.addNetwork(network)

--- a/core/wallet-store-sql/src/store-sql.ts
+++ b/core/wallet-store-sql/src/store-sql.ts
@@ -57,8 +57,8 @@ export class StoreSql implements BaseStore, AuthAware<StoreSql> {
 
     async getWallets(filter: WalletFilter = {}): Promise<Array<Wallet>> {
         const userId = this.assertConnected()
-        const { chainIds, signingProviderIds } = filter
-        const chainIdSet = chainIds ? new Set(chainIds) : null
+        const { networkIds, signingProviderIds } = filter
+        const networkIdSet = networkIds ? new Set(networkIds) : null
         const signingProviderIdSet = signingProviderIds
             ? new Set(signingProviderIds)
             : null
@@ -71,13 +71,13 @@ export class StoreSql implements BaseStore, AuthAware<StoreSql> {
 
         return wallets
             .filter((wallet) => {
-                const matchedChainIds = chainIdSet
-                    ? chainIdSet.has(wallet.chainId)
+                const matchedNetworkIds = networkIdSet
+                    ? networkIdSet.has(wallet.networkId)
                     : true
-                const matchedStorageProviderIdS = signingProviderIdSet
+                const matchedSigningProviderIds = signingProviderIdSet
                     ? signingProviderIdSet.has(wallet.signingProviderId)
                     : true
-                return matchedChainIds && matchedStorageProviderIdS
+                return matchedNetworkIds && matchedSigningProviderIds
             })
             .map((table) => toWallet(table))
     }
@@ -180,14 +180,14 @@ export class StoreSql implements BaseStore, AuthAware<StoreSql> {
     }
 
     // Network methods
-    async getNetwork(chainId: string): Promise<Network> {
+    async getNetwork(networkId: string): Promise<Network> {
         this.assertConnected()
 
         const networks = await this.listNetworks()
         if (!networks) throw new Error('No networks available')
 
-        const network = networks.find((n) => n.chainId === chainId)
-        if (!network) throw new Error(`Network "${chainId}" not found`)
+        const network = networks.find((n) => n.id === networkId)
+        if (!network) throw new Error(`Network "${networkId}" not found`)
         return network
     }
 
@@ -196,15 +196,15 @@ export class StoreSql implements BaseStore, AuthAware<StoreSql> {
         if (!session) {
             throw new Error('No session found')
         }
-        const chainId = session.network
-        if (!chainId) {
+        const networkId = session.network
+        if (!networkId) {
             throw new Error('No current network set in session')
         }
 
         const networks = await this.listNetworks()
-        const network = networks.find((n) => n.chainId === chainId)
+        const network = networks.find((n) => n.id === networkId)
         if (!network) {
-            throw new Error(`Network "${chainId}" not found`)
+            throw new Error(`Network "${networkId}" not found`)
         }
         return network
     }
@@ -241,7 +241,7 @@ export class StoreSql implements BaseStore, AuthAware<StoreSql> {
             await trx
                 .updateTable('networks')
                 .set(networkEntry)
-                .where('chainId', '=', network.chainId)
+                .where('id', '=', network.id)
                 .execute()
 
             const authEntry = fromAuth(network.auth)
@@ -264,10 +264,10 @@ export class StoreSql implements BaseStore, AuthAware<StoreSql> {
             const networkAlreadyExists = await trx
                 .selectFrom('networks')
                 .selectAll()
-                .where('chainId', '=', network.chainId)
+                .where('id', '=', network.id)
                 .executeTakeFirst()
             if (networkAlreadyExists) {
-                throw new Error(`Network ${network.chainId} already exists`)
+                throw new Error(`Network ${network.id} already exists`)
             } else {
                 await trx
                     .insertInto('idps')
@@ -281,25 +281,25 @@ export class StoreSql implements BaseStore, AuthAware<StoreSql> {
         })
     }
 
-    async removeNetwork(chainId: string): Promise<void> {
+    async removeNetwork(networkId: string): Promise<void> {
         const userId = this.assertConnected()
         await this.db.transaction().execute(async (trx) => {
             const network = await trx
                 .selectFrom('networks')
                 .selectAll()
-                .where('chainId', '=', chainId)
+                .where('id', '=', networkId)
                 .executeTakeFirst()
             if (!network) {
-                throw new Error(`Network ${chainId} does not exists`)
+                throw new Error(`Network ${networkId} does not exists`)
             }
             if (network.userId !== userId) {
                 throw new Error(
-                    `Network ${chainId} is not owned by user ${userId}`
+                    `Network ${networkId} is not owned by user ${userId}`
                 )
             }
             await trx
                 .deleteFrom('networks')
-                .where('chainId', '=', chainId)
+                .where('id', '=', networkId)
                 .execute()
             await trx
                 .deleteFrom('idps')

--- a/core/wallet-store/src/Store.ts
+++ b/core/wallet-store/src/Store.ts
@@ -22,7 +22,7 @@ export interface SigningProvider {
 }
 
 export interface WalletFilter {
-    chainIds?: string[]
+    networkIds?: string[]
     signingProviderIds?: string[]
 }
 
@@ -32,7 +32,7 @@ export interface Wallet {
     hint: string
     publicKey: string
     namespace: string
-    chainId: string
+    networkId: string
     signingProviderId: string
     // hosted: [network]
 }
@@ -68,12 +68,12 @@ export interface Store {
     removeSession(): Promise<void>
 
     // Network methods
-    getNetwork(chainId: string): Promise<Network>
+    getNetwork(networkId: string): Promise<Network>
     getCurrentNetwork(): Promise<Network>
     listNetworks(): Promise<Array<Network>>
     updateNetwork(network: Network): Promise<void>
     addNetwork(network: Network): Promise<void>
-    removeNetwork(chainId: string): Promise<void>
+    removeNetwork(networkId: string): Promise<void>
 
     // Transaction methods
     setTransaction(tx: Transaction): Promise<void>

--- a/core/wallet-store/src/config/schema.ts
+++ b/core/wallet-store/src/config/schema.ts
@@ -9,8 +9,8 @@ export const ledgerApiSchema = z.object({
 })
 
 export const networkSchema = z.object({
+    id: z.string(),
     name: z.string(),
-    chainId: z.string(),
     synchronizerId: z.string(),
     description: z.string(),
     ledgerApi: ledgerApiSchema,

--- a/core/wallet-ui-components/src/components/NetworkCard.ts
+++ b/core/wallet-ui-components/src/components/NetworkCard.ts
@@ -68,7 +68,7 @@ export class NetworkCard extends BaseElement {
                     </h6>
                     <div class="network-meta">
                         <strong>ID:</strong>
-                        ${this.network.chainId}<br />
+                        ${this.network.id}<br />
                         <strong>Auth:</strong> ${this.network.auth.type}<br />
                         <strong>Synchronizer:</strong>
                         ${this.network.synchronizerId}

--- a/core/wallet-ui-components/src/components/NetworkForm.stories.ts
+++ b/core/wallet-ui-components/src/components/NetworkForm.stories.ts
@@ -25,7 +25,7 @@ export const Default: StoryObj = {
 
 const sampleNetworkImplicit: Network = {
     name: 'Local (OAuth IDP)',
-    chainId: 'canton:local-oauth',
+    id: 'canton:local-oauth',
     synchronizerId:
         'wallet::1220e7b23ea52eb5c672fb0b1cdbc916922ffed3dd7676c223a605664315e2d43edd',
     description: 'Mock OAuth IDP',
@@ -60,7 +60,7 @@ export const PopulatedImplicitAuth: StoryObj = {
 
 const sampleNetworkPassword: Network = {
     name: 'Local (password IDP)',
-    chainId: 'canton:local-password',
+    id: 'canton:local-password',
     synchronizerId:
         'wallet::1220e7b23ea52eb5c672fb0b1cdbc916922ffed3dd7676c223a605664315e2d43edd',
     description: 'Unimplemented Password Auth',

--- a/core/wallet-ui-components/src/components/NetworkForm.ts
+++ b/core/wallet-ui-components/src/components/NetworkForm.ts
@@ -338,8 +338,8 @@ export class NetworkForm extends BaseElement {
                 <network-form-input
                     required
                     label="Network Id"
-                    .value=${this.network.chainId ?? ''}
-                    @network-input-change=${this.setNetwork('chainId')}
+                    .value=${this.network.id ?? ''}
+                    @network-input-change=${this.setNetwork('id')}
                 ></network-form-input>
 
                 <network-form-input

--- a/core/wallet-ui-components/src/components/NetworkTable.stories.ts
+++ b/core/wallet-ui-components/src/components/NetworkTable.stories.ts
@@ -16,7 +16,7 @@ export default meta
 const networks: Network[] = [
     {
         name: 'Local (password IDP)',
-        chainId: 'canton:local-password',
+        id: 'canton:local-password',
         synchronizerId:
             'wallet::1220e7b23ea52eb5c672fb0b1cdbc916922ffed3dd7676c223a605664315e2d43edd',
         description: 'Unimplemented Password Auth',

--- a/core/wallet-user-rpc-client/src/index.ts
+++ b/core/wallet-user-rpc-client/src/index.ts
@@ -5,6 +5,12 @@ import { RequestPayload, RpcTransport } from '@canton-network/core-types'
 
 /**
  *
+ * Network ID
+ *
+ */
+export type NetworkId = string
+/**
+ *
  * Name of network
  *
  */
@@ -21,12 +27,6 @@ export type Description = string
  *
  */
 export type SynchronizerId = string
-/**
- *
- * Network Id
- *
- */
-export type ChainId = string
 export type Type = string
 export type IdentityProviderId = string
 export type TokenUrl = string
@@ -73,10 +73,10 @@ export type LedgerApi = string
  *
  */
 export interface Network {
+    id: NetworkId
     name: Name
     description: Description
     synchronizerId: SynchronizerId
-    chainId: ChainId
     auth: Auth
     ledgerApi: LedgerApi
 }
@@ -110,7 +110,7 @@ export type PartyId = string
  * Filter wallets by network IDs.
  *
  */
-export type ChainIds = ChainId[]
+export type NetworkIds = NetworkId[]
 /**
  *
  * Filter wallets by signing provider IDs.
@@ -123,7 +123,7 @@ export type SigningProviderIds = SigningProviderId[]
  *
  */
 export interface WalletFilter {
-    chainIds?: ChainIds
+    networkIds?: NetworkIds
     signingProviderIds?: SigningProviderIds
     [k: string]: any
 }
@@ -166,7 +166,7 @@ export interface Wallet {
     hint: Hint
     publicKey: PublicKey
     namespace: Namespace
-    chainId: ChainId
+    networkId: NetworkId
     signingProviderId: SigningProviderId
     [k: string]: any
 }
@@ -202,7 +202,7 @@ export interface RemoveNetworkParams {
 export interface CreateWalletParams {
     primary?: Primary
     partyHint: PartyHint
-    chainId: ChainId
+    networkId: NetworkId
     signingProviderId: SigningProviderId
     [k: string]: any
 }
@@ -233,7 +233,7 @@ export interface ExecuteParams {
     [k: string]: any
 }
 export interface AddSessionParams {
-    chainId: ChainId
+    networkId: NetworkId
     [k: string]: any
 }
 /**

--- a/core/wallet-user-rpc-client/src/openrpc.json
+++ b/core/wallet-user-rpc-client/src/openrpc.json
@@ -77,8 +77,8 @@
                                 "type": "string",
                                 "description": "The party hint and name of the wallet."
                             },
-                            "chainId": {
-                                "title": "chainId",
+                            "networkId": {
+                                "title": "networkId",
                                 "type": "string",
                                 "description": "The network ID the wallet corresponds to."
                             },
@@ -90,7 +90,7 @@
                         },
                         "required": [
                             "partyHint",
-                            "chainId",
+                            "networkId",
                             "signingProviderId"
                         ]
                     }
@@ -366,13 +366,13 @@
                         "title": "AddSessionParams",
                         "type": "object",
                         "properties": {
-                            "chainId": {
-                                "title": "chainId",
+                            "networkId": {
+                                "title": "networkId",
                                 "type": "string",
                                 "description": "Network Id"
                             }
                         },
-                        "required": ["chainId"]
+                        "required": ["networkId"]
                     }
                 }
             ],
@@ -419,6 +419,11 @@
                 "type": "object",
                 "description": "Structure representing the Networks",
                 "properties": {
+                    "id": {
+                        "title": "networkId",
+                        "type": "string",
+                        "description": "Network ID"
+                    },
                     "name": {
                         "title": "name",
                         "type": "string",
@@ -434,11 +439,6 @@
                         "type": "string",
                         "description": "Synchronizer ID"
                     },
-                    "chainId": {
-                        "title": "chainId",
-                        "type": "string",
-                        "description": "Network Id"
-                    },
                     "auth": {
                         "$ref": "#/components/schemas/Auth"
                     },
@@ -449,9 +449,9 @@
                     }
                 },
                 "required": [
+                    "id",
                     "name",
                     "description",
-                    "chainId",
                     "synchronizerId",
                     "auth",
                     "ledgerApi"
@@ -556,8 +556,8 @@
                         "type": "string",
                         "description": "The namespace of the party."
                     },
-                    "chainId": {
-                        "title": "chainId",
+                    "networkId": {
+                        "title": "networkId",
                         "type": "string",
                         "description": "The network ID the wallet corresponds to."
                     },
@@ -573,7 +573,7 @@
                     "hint",
                     "publicKey",
                     "namespace",
-                    "chainId",
+                    "networkId",
                     "signingProviderId"
                 ]
             },
@@ -582,12 +582,12 @@
                 "type": "object",
                 "description": "Filter for wallets",
                 "properties": {
-                    "chainIds": {
-                        "title": "chainIds",
+                    "networkIds": {
+                        "title": "networkIds",
                         "type": "array",
                         "description": "Filter wallets by network IDs.",
                         "items": {
-                            "title": "chainId",
+                            "title": "networkId",
                             "type": "string"
                         }
                     },

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,7 +10,7 @@ function statusInfo(status?: sdk.dappAPI.StatusEvent) {
 
     return `Wallet Gateway: ${status.kernel.id}, status: ${
         status.isConnected ? '🟢 connected' : '🔴 disconnected'
-    }, chain: ${status.chainId}`
+    }, network: ${status.networkId}`
 }
 
 function App() {

--- a/sdk/dapp-sdk/src/dapp-api/rpc-gen/typings.ts
+++ b/sdk/dapp-sdk/src/dapp-api/rpc-gen/typings.ts
@@ -61,11 +61,11 @@ export type IsConnected = boolean
  * The network ID the wallet corresponds to.
  *
  */
-export type ChainId = string
+export type NetworkId = string
 export interface StatusEvent {
     kernel: KernelInfo
     isConnected: IsConnected
-    chainId?: ChainId
+    networkId?: NetworkId
     [k: string]: any
 }
 /**
@@ -184,7 +184,7 @@ export interface Wallet {
     hint: Hint
     publicKey: PublicKey
     namespace: Namespace
-    chainId: ChainId
+    networkId: NetworkId
     signingProviderId: SigningProviderId
     [k: string]: any
 }

--- a/wallet-gateway/extension/src/dapp-api/controller.ts
+++ b/wallet-gateway/extension/src/dapp-api/controller.ts
@@ -28,7 +28,7 @@ export const dappController = (store?: Store) =>
                 status: {
                     kernel: kernelInfo,
                     isConnected: false,
-                    chainId: 'default-chain-id',
+                    networkId: 'default-network-id',
                     userUrl: Browser.runtime.getURL('pages/user.html'),
                 },
                 sessionToken: 'default-session-token',

--- a/wallet-gateway/extension/src/dapp-api/rpc-gen/typings.ts
+++ b/wallet-gateway/extension/src/dapp-api/rpc-gen/typings.ts
@@ -61,11 +61,11 @@ export type IsConnected = boolean
  * The network ID the wallet corresponds to.
  *
  */
-export type ChainId = string
+export type NetworkId = string
 export interface StatusEvent {
     kernel: KernelInfo
     isConnected: IsConnected
-    chainId?: ChainId
+    networkId?: NetworkId
     [k: string]: any
 }
 /**
@@ -184,7 +184,7 @@ export interface Wallet {
     hint: Hint
     publicKey: PublicKey
     namespace: Namespace
-    chainId: ChainId
+    networkId: NetworkId
     signingProviderId: SigningProviderId
     [k: string]: any
 }

--- a/wallet-gateway/remote/src/dapp-api/controller.ts
+++ b/wallet-gateway/remote/src/dapp-api/controller.ts
@@ -199,7 +199,7 @@ export const dappController = (
                 return {
                     kernel: kernelInfo,
                     isConnected: true,
-                    chainId: (await store.getCurrentNetwork()).chainId,
+                    networkId: (await store.getCurrentNetwork()).id,
                 }
             }
         },

--- a/wallet-gateway/remote/src/dapp-api/rpc-gen/typings.ts
+++ b/wallet-gateway/remote/src/dapp-api/rpc-gen/typings.ts
@@ -54,11 +54,11 @@ export type IsConnected = boolean
  * The network ID the wallet corresponds to.
  *
  */
-export type ChainId = string
+export type NetworkId = string
 export interface StatusEvent {
     kernel: KernelInfo
     isConnected: IsConnected
-    chainId?: ChainId
+    networkId?: NetworkId
     [k: string]: any
 }
 /**
@@ -145,7 +145,7 @@ export interface Wallet {
     hint: Hint
     publicKey: PublicKey
     namespace: Namespace
-    chainId: ChainId
+    networkId: NetworkId
     signingProviderId: SigningProviderId
     [k: string]: any
 }
@@ -306,7 +306,7 @@ export interface LedgerApiResult {
 }
 export interface OnConnectedEvent {
     kernel: KernelInfo
-    chainId: ChainId
+    networkId: NetworkId
     sessionToken?: SessionToken
     [k: string]: any
 }

--- a/wallet-gateway/remote/src/ledger/party-allocation-service.test.ts
+++ b/wallet-gateway/remote/src/ledger/party-allocation-service.test.ts
@@ -49,7 +49,7 @@ jest.unstable_mockModule('@canton-network/core-ledger-client', () => ({
 describe('PartyAllocationService', () => {
     const network: Network = {
         name: 'test',
-        chainId: 'chain-id',
+        id: 'network-id',
         synchronizerId: 'sync-id',
         description: 'desc',
         ledgerApi: {

--- a/wallet-gateway/remote/src/ledger/wallet-sync-service.ts
+++ b/wallet-gateway/remote/src/ledger/wallet-sync-service.ts
@@ -95,7 +95,7 @@ export class WalletSyncService {
                             hint: hint,
                             publicKey: namespace,
                             namespace: namespace,
-                            chainId: network.chainId,
+                            networkId: network.id,
                             signingProviderId: 'participant', // todo: determine based on partyDetails.isLocal
                         }
                     }) || []

--- a/wallet-gateway/remote/src/user-api/controller.ts
+++ b/wallet-gateway/remote/src/user-api/controller.ts
@@ -125,7 +125,7 @@ export const userController = (
 
             const newNetwork: Network = {
                 name: network.name,
-                chainId: network.chainId,
+                id: network.id,
                 description: network.description,
                 synchronizerId: network.synchronizerId,
                 auth,
@@ -134,9 +134,7 @@ export const userController = (
 
             // TODO: Add an explicit updateNetwork method to the User API spec and controller
             const existingNetworks = await store.listNetworks()
-            if (
-                existingNetworks.find((n) => n.chainId === newNetwork.chainId)
-            ) {
+            if (existingNetworks.find((n) => n.id === newNetwork.id)) {
                 await store.updateNetwork(newNetwork)
             } else {
                 await store.addNetwork(newNetwork)
@@ -151,7 +149,7 @@ export const userController = (
         createWallet: async (params: {
             primary?: boolean
             partyHint: string
-            chainId: string
+            networkId: string
             signingProviderId: string
         }) => {
             logger.info(
@@ -225,7 +223,7 @@ export const userController = (
 
             const wallet = {
                 signingProviderId: params.signingProviderId,
-                chainId: params.chainId,
+                networkId: params.networkId,
                 primary: params.primary ?? false,
                 publicKey: publicKey || party.namespace,
                 ...party,
@@ -249,7 +247,7 @@ export const userController = (
         removeWallet: async (params: { partyId: string }) =>
             Promise.resolve({}),
         listWallets: async (params: {
-            filter?: { chainIds?: string[]; signingProviderIds?: string[] }
+            filter?: { networkIds?: string[]; signingProviderIds?: string[] }
         }) => {
             // TODO: support filters
             return store.getWallets()
@@ -458,7 +456,7 @@ export const userController = (
         ): Promise<AddSessionResult> {
             try {
                 await store.setSession({
-                    network: params.chainId,
+                    network: params.networkId,
                     accessToken: authContext?.accessToken || '',
                 })
                 const network = await store.getCurrentNetwork()
@@ -470,20 +468,13 @@ export const userController = (
                 notifier.emit('onConnected', {
                     kernel: kernelInfo,
                     sessionToken: accessToken,
-                    chainId: network.chainId,
+                    networkId: network.id,
                 })
 
                 return Promise.resolve({
                     accessToken,
+                    network,
                     status: 'connected',
-                    network: {
-                        name: network.name,
-                        chainId: network.chainId,
-                        synchronizerId: network.synchronizerId,
-                        description: network.description,
-                        ledgerApi: network.ledgerApi,
-                        auth: network.auth,
-                    },
                 })
             } catch (error) {
                 logger.error(`Failed to add session: ${error}`)
@@ -499,16 +490,9 @@ export const userController = (
             return {
                 sessions: [
                     {
+                        network,
                         accessToken: authContext!.accessToken,
                         status: 'connected',
-                        network: {
-                            name: network.name,
-                            chainId: network.chainId,
-                            synchronizerId: network.synchronizerId,
-                            description: network.description,
-                            ledgerApi: network.ledgerApi,
-                            auth: network.auth,
-                        },
                     },
                 ],
             }

--- a/wallet-gateway/remote/src/user-api/rpc-gen/typings.ts
+++ b/wallet-gateway/remote/src/user-api/rpc-gen/typings.ts
@@ -5,6 +5,12 @@
 
 /**
  *
+ * Network ID
+ *
+ */
+export type NetworkId = string
+/**
+ *
  * Name of network
  *
  */
@@ -21,12 +27,6 @@ export type Description = string
  *
  */
 export type SynchronizerId = string
-/**
- *
- * Network Id
- *
- */
-export type ChainId = string
 export type Type = string
 export type IdentityProviderId = string
 export type TokenUrl = string
@@ -73,10 +73,10 @@ export type LedgerApi = string
  *
  */
 export interface Network {
+    id: NetworkId
     name: Name
     description: Description
     synchronizerId: SynchronizerId
-    chainId: ChainId
     auth: Auth
     ledgerApi: LedgerApi
 }
@@ -110,7 +110,7 @@ export type PartyId = string
  * Filter wallets by network IDs.
  *
  */
-export type ChainIds = ChainId[]
+export type NetworkIds = NetworkId[]
 /**
  *
  * Filter wallets by signing provider IDs.
@@ -123,7 +123,7 @@ export type SigningProviderIds = SigningProviderId[]
  *
  */
 export interface WalletFilter {
-    chainIds?: ChainIds
+    networkIds?: NetworkIds
     signingProviderIds?: SigningProviderIds
     [k: string]: any
 }
@@ -166,7 +166,7 @@ export interface Wallet {
     hint: Hint
     publicKey: PublicKey
     namespace: Namespace
-    chainId: ChainId
+    networkId: NetworkId
     signingProviderId: SigningProviderId
     [k: string]: any
 }
@@ -202,7 +202,7 @@ export interface RemoveNetworkParams {
 export interface CreateWalletParams {
     primary?: Primary
     partyHint: PartyHint
-    chainId: ChainId
+    networkId: NetworkId
     signingProviderId: SigningProviderId
     [k: string]: any
 }
@@ -233,7 +233,7 @@ export interface ExecuteParams {
     [k: string]: any
 }
 export interface AddSessionParams {
-    chainId: ChainId
+    networkId: NetworkId
     [k: string]: any
 }
 /**

--- a/wallet-gateway/remote/src/web/frontend/callback/login-callback.ts
+++ b/wallet-gateway/remote/src/web/frontend/callback/login-callback.ts
@@ -57,7 +57,7 @@ export class LoginCallback extends LitElement {
 
                 authenticate(
                     tokenResponse.access_token,
-                    stateManager.chainId.get() || ''
+                    stateManager.networkId.get() || ''
                 ).then(() => {
                     window.location.replace('/')
                 })

--- a/wallet-gateway/remote/src/web/frontend/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/index.ts
@@ -55,13 +55,13 @@ export class UserUIAuthRedirect extends LitElement {
 
         const accessToken = stateManager.accessToken.get()
         if (accessToken && isLoginPage) {
-            const chainId = stateManager.chainId.get()
+            const networkId = stateManager.networkId.get()
 
-            if (!chainId) {
-                throw new Error('missing chainId in state manager')
+            if (!networkId) {
+                throw new Error('missing networkId in state manager')
             }
 
-            authenticate(accessToken, chainId)
+            authenticate(accessToken, networkId)
 
             window.location.href = DEFAULT_PAGE_REDIRECT
         }
@@ -70,11 +70,11 @@ export class UserUIAuthRedirect extends LitElement {
 
 export const authenticate = async (
     accessToken: string,
-    chainId: string
+    networkId: string
 ): Promise<void> => {
     const authenticatedUserClient = createUserClient(accessToken)
     await authenticatedUserClient.request('addSession', {
-        chainId,
+        networkId,
     })
 
     if (window.opener && !window.opener.closed) {

--- a/wallet-gateway/remote/src/web/frontend/login/login.ts
+++ b/wallet-gateway/remote/src/web/frontend/login/login.ts
@@ -193,7 +193,7 @@ export class LoginUI extends LitElement {
             return
         }
 
-        stateManager.chainId.set(this.selectedNetwork.chainId)
+        stateManager.networkId.set(this.selectedNetwork.id)
         const redirectUri = `${window.origin}/callback/`
 
         if (this.selectedNetwork.auth.type === 'implicit') {
@@ -265,7 +265,7 @@ export class LoginUI extends LitElement {
         const authenticatedUserClient = createUserClient(access_token)
 
         await authenticatedUserClient.request('addSession', {
-            chainId: stateManager.chainId.get() || '',
+            networkId: stateManager.networkId.get() || '',
         })
     }
 

--- a/wallet-gateway/remote/src/web/frontend/networks/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/networks/index.ts
@@ -205,9 +205,8 @@ export class UserUiNetworks extends LitElement {
     private async handleDelete(e: NetworkCardDeleteEvent) {
         if (!confirm(`Delete network "${e.network.name}"?`)) return
         try {
-            // TODO: rename parameter to chainId in User API
             const params: RemoveNetworkParams = {
-                networkName: e.network.chainId,
+                networkName: e.network.id,
             }
             const userClient = createUserClient(stateManager.accessToken.get())
             await userClient.request('removeNetwork', params)
@@ -326,7 +325,7 @@ export class UserUiNetworks extends LitElement {
                         ${this.sessions.map(
                             (session) => html`
                                 <tr>
-                                    <td>${session.network.chainId}</td>
+                                    <td>${session.network.id}</td>
                                     <td>${session.status}</td>
                                     <td>
                                         <button

--- a/wallet-gateway/remote/src/web/frontend/state-manager.ts
+++ b/wallet-gateway/remote/src/web/frontend/state-manager.ts
@@ -39,10 +39,10 @@ class StateManager {
         clear: () => this.clearWithStorage('accessToken'),
     }
 
-    chainId = {
-        get: () => this.getWithStorage('chainId'),
-        set: (chainId: string) => this.setWithStorage('chainId', chainId),
-        clear: () => this.clearWithStorage('chainId'),
+    networkId = {
+        get: () => this.getWithStorage('networkId'),
+        set: (networkId: string) => this.setWithStorage('networkId', networkId),
+        clear: () => this.clearWithStorage('networkId'),
     }
 
     expirationDate = {

--- a/wallet-gateway/remote/src/web/frontend/wallets/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/wallets/index.ts
@@ -254,7 +254,7 @@ export class UserUiWallets extends LitElement {
                                 <strong>Party ID:</strong>
                                 ${wallet.partyId}<br />
                                 <strong>Network:</strong>
-                                ${wallet.chainId}<br />
+                                ${wallet.networkId}<br />
                                 <strong>Signing Provider:</strong>
                                 ${wallet.signingProviderId}
                             </div>
@@ -289,7 +289,7 @@ export class UserUiWallets extends LitElement {
     private async updateNetworks() {
         const userClient = createUserClient(stateManager.accessToken.get())
         userClient.request('listNetworks').then(({ networks }) => {
-            this.networks = networks.map((network) => network.chainId)
+            this.networks = networks.map((network) => network.id)
         })
     }
 
@@ -319,13 +319,13 @@ export class UserUiWallets extends LitElement {
         const partyHint = this._partyHintInput?.value || ''
         const primary = this._primaryCheckbox?.checked || false
         const signingProviderId = this._signingProviderSelect?.value || ''
-        const chainId = this._networkSelect?.value || ''
+        const networkId = this._networkSelect?.value || ''
 
         try {
             const body: CreateWalletParams = {
                 primary,
                 partyHint,
-                chainId,
+                networkId,
                 signingProviderId,
             }
 

--- a/wallet-gateway/test/config.json
+++ b/wallet-gateway/test/config.json
@@ -12,8 +12,8 @@
         },
         "networks": [
             {
+                "id": "canton:local-password",
                 "name": "Local (password IDP)",
-                "chainId": "canton:local-password",
                 "synchronizerId": "wallet::1220e7b23ea52eb5c672fb0b1cdbc916922ffed3dd7676c223a605664315e2d43edd",
                 "description": "Unimplemented Password Auth",
                 "ledgerApi": {
@@ -36,8 +36,8 @@
                 }
             },
             {
+                "id": "canton:local-oauth",
                 "name": "Local (OAuth IDP)",
-                "chainId": "canton:local-oauth",
                 "synchronizerId": "wallet::1220e7b23ea52eb5c672fb0b1cdbc916922ffed3dd7676c223a605664315e2d43edd",
                 "description": "Mock OAuth IDP",
                 "ledgerApi": {
@@ -58,8 +58,8 @@
                 }
             },
             {
+                "id": "canton:local-oauth-client-credentials",
                 "name": "Local (OAuth IDP - Client Credentials)",
-                "chainId": "canton:local-oauth-client-credentials",
                 "synchronizerId": "wallet::1220e7b23ea52eb5c672fb0b1cdbc916922ffed3dd7676c223a605664315e2d43edd",
                 "description": "Mock OAuth IDP (Client Credentials)",
                 "ledgerApi": {
@@ -82,8 +82,8 @@
                 }
             },
             {
+                "id": "canton:local-self-signed",
                 "name": "Local (Self signed)",
-                "chainId": "canton:local-self-signed",
                 "synchronizerId": "wallet::1220e7b23ea52eb5c672fb0b1cdbc916922ffed3dd7676c223a605664315e2d43edd",
                 "description": "Mock OAuth IDP",
                 "ledgerApi": {
@@ -104,8 +104,8 @@
                 }
             },
             {
+                "id": "canton:devnet-auth0",
                 "name": "Devnet (Auth0)",
-                "chainId": "canton:devnet-auth0",
                 "synchronizerId": "global-domain::1220be58c29e65de40bf273be1dc2b266d43a9a002ea5b18955aeef7aac881bb471a",
                 "description": "devnet configuration pointing to CNU's lab-operator",
                 "ledgerApi": {


### PR DESCRIPTION
For Network resource models themselves, I changed `chainId` to simply `id`. (This way we have `network.id` not `network.networkId` everywhere)

Outside of that, it is `networkId`  