### PR TITLE
fix(core-wallet-store-sql): do not set userId when updating networks

### DIFF
--- a/core/wallet-store-sql/src/store-sql.ts
+++ b/core/wallet-store-sql/src/store-sql.ts
@@ -237,10 +237,10 @@ export class StoreSql implements BaseStore, AuthAware<StoreSql> {
     }
 
     async updateNetwork(network: Network): Promise<void> {
-        const userId = this.assertConnected()
-        // todo: check and compare userid of existing network
+        this.assertConnected()
         await this.db.transaction().execute(async (trx) => {
-            const networkEntry = fromNetwork(network, userId)
+            // we do not set a userId for now and leave all networks global when updating
+            const networkEntry = fromNetwork(network, undefined)
             this.logger.info(networkEntry, 'Updating network table')
             await trx
                 .updateTable('networks')


### PR DESCRIPTION
Closes #747 for now