### PR TITLE
fix(dapp-sdk): always getting timeout when prepareExecute

### DIFF
--- a/sdk/dapp-sdk/src/provider.ts
+++ b/sdk/dapp-sdk/src/provider.ts
@@ -210,7 +210,7 @@ export const dappController = (provider: SpliceProvider) =>
                 (resolve, reject) => {
                     const timeout = withTimeout(reject)
                     provider.on<dappRemoteAPI.TxChangedEvent>(
-                        'onTxChanged',
+                        'txChanged',
                         (event) => {
                             console.log('SDK: TxChangedEvent', event)
                             clearTimeout(timeout)


### PR DESCRIPTION
prepareExecute looks for events at 'onTxChanged', however the real one is called 'txChanged', which resulted in timeout every time