### PR TITLE
fix(core-splice-provider): sockets can't be serialized

### DIFF
--- a/core/splice-provider/src/SpliceProviderHttp.ts
+++ b/core/splice-provider/src/SpliceProviderHttp.ts
@@ -53,7 +53,7 @@ export class SpliceProviderHttp extends SpliceProviderBase {
 
         // Prevent serialization of the socket
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ;(this.socket as any).toJson = () => ({})
+        ;(this.socket as any).toJSON = () => ({})
 
         // Listen for the auth success event sent from the WK UI popup to the SDK running in the parent window.
         window.addEventListener('message', async (event) => {


### PR DESCRIPTION
This allows one to json serialize the provider (for instance as part of a log statement) without getting a nasty error.