### PR TITLE
feat: connect to localnet (easily)

### DIFF
--- a/api-specs/openrpc-user-api.json
+++ b/api-specs/openrpc-user-api.json
@@ -538,7 +538,6 @@
                     "id",
                     "name",
                     "description",
-                    "synchronizerId",
                     "identityProviderId",
                     "auth",
                     "ledgerApi"

--- a/core/wallet-store-sql/src/migrations/001-init.ts
+++ b/core/wallet-store-sql/src/migrations/001-init.ts
@@ -21,7 +21,7 @@ export async function up(db: Kysely<DB>): Promise<void> {
         .ifNotExists()
         .addColumn('id', 'text', (col) => col.primaryKey())
         .addColumn('name', 'text', (col) => col.notNull())
-        .addColumn('synchronizer_id', 'text', (col) => col.notNull())
+        .addColumn('synchronizer_id', 'text')
         .addColumn('description', 'text')
         .addColumn('ledger_api_base_url', 'text', (col) => col.notNull())
         .addColumn('user_id', 'text') // optional/global if null

--- a/core/wallet-store-sql/src/schema.ts
+++ b/core/wallet-store-sql/src/schema.ts
@@ -25,7 +25,7 @@ interface IdpTable {
 interface NetworkTable {
     id: string
     name: string
-    synchronizerId: string
+    synchronizerId: string | null // retrieved at runtime if null
     description: string
     ledgerApiBaseUrl: string
     identityProviderId: string
@@ -117,7 +117,7 @@ export const toNetwork = (table: NetworkTable): Network => {
     return {
         name: table.name,
         id: table.id,
-        synchronizerId: table.synchronizerId,
+        synchronizerId: table.synchronizerId ?? undefined,
         identityProviderId: table.identityProviderId,
         description: table.description,
         ledgerApi: {
@@ -137,7 +137,7 @@ export const fromNetwork = (
     return {
         name: network.name,
         id: network.id,
-        synchronizerId: network.synchronizerId,
+        synchronizerId: network.synchronizerId ?? null,
         description: network.description,
         ledgerApiBaseUrl: network.ledgerApi.baseUrl,
         userId: userId,

--- a/core/wallet-store/src/config/schema.ts
+++ b/core/wallet-store/src/config/schema.ts
@@ -12,7 +12,7 @@ export const networkSchema = z.object({
     id: z.string(),
     name: z.string(),
     description: z.string(),
-    synchronizerId: z.string(),
+    synchronizerId: z.string().optional(),
     identityProviderId: z.string(),
     ledgerApi: ledgerApiSchema,
     auth: authSchema,

--- a/core/wallet-ui-components/src/components/NetworkForm.ts
+++ b/core/wallet-ui-components/src/components/NetworkForm.ts
@@ -235,11 +235,11 @@ export class NetworkForm extends BaseElement {
                 ></form-input>
 
                 <form-input
-                    required
-                    label="Synchronizer Id"
+                    label="Synchronizer Id (Optional)"
                     .value=${this.network.synchronizerId ?? ''}
                     @form-input-change=${(e: FormInputChangedEvent) => {
-                        this.network.synchronizerId = e.value
+                        this.network.synchronizerId =
+                            e.value === '' ? undefined : e.value
                     }}
                 ></form-input>
 

--- a/core/wallet-user-rpc-client/src/index.ts
+++ b/core/wallet-user-rpc-client/src/index.ts
@@ -67,7 +67,7 @@ export interface Network {
     id: NetworkId
     name: Name
     description: Description
-    synchronizerId: SynchronizerId
+    synchronizerId?: SynchronizerId
     identityProviderId: IdentityProviderId
     auth: Auth
     adminAuth?: Auth
@@ -99,7 +99,7 @@ export type Type = any
 export type ConfigUrl = string
 /**
  *
- * An identity provider for a network
+ * Structure representing the Identity Providers
  *
  */
 export interface Idp {

--- a/core/wallet-user-rpc-client/src/openrpc.json
+++ b/core/wallet-user-rpc-client/src/openrpc.json
@@ -538,7 +538,6 @@
                     "id",
                     "name",
                     "description",
-                    "synchronizerId",
                     "identityProviderId",
                     "auth",
                     "ledgerApi"
@@ -547,7 +546,7 @@
             },
             "Idp": {
                 "title": "Idp",
-                "description": "An identity provider for a network",
+                "description": "Structure representing the Identity Providers",
                 "type": "object",
                 "properties": {
                     "id": {

--- a/example/src/commands/createPingCommand.ts
+++ b/example/src/commands/createPingCommand.ts
@@ -2,17 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 // Corresponds to the built-in canton-builtin-admin-workflow-ping DAR every participant initializes with
 
-export const createPingCommand = (party: string) => ({
-    commands: [
-        {
-            CreateCommand: {
-                templateId: '#AdminWorkflows:Canton.Internal.Ping:Ping',
-                createArguments: {
-                    id: `my-test-${new Date().getTime()}`,
-                    initiator: party,
-                    responder: party,
+export const createPingCommand = (
+    ledgerApiVersion: string | undefined,
+    party: string
+) => {
+    const packageName = ledgerApiVersion?.startsWith('3.3.')
+        ? 'AdminWorkflows'
+        : 'canton-builtin-admin-workflow-ping'
+    return {
+        commands: [
+            {
+                CreateCommand: {
+                    templateId: `#${packageName}:Canton.Internal.Ping:Ping`,
+                    createArguments: {
+                        id: `my-test-${new Date().getTime()}`,
+                        initiator: party,
+                        responder: party,
+                    },
                 },
             },
-        },
-    ],
-})
+        ],
+    }
+}

--- a/wallet-gateway/remote/src/dapp-api/controller.ts
+++ b/wallet-gateway/remote/src/dapp-api/controller.ts
@@ -138,11 +138,15 @@ export const dappController = (
 
             notifier.emit('txChanged', { status: 'pending', commandId })
 
+            const synchronizerId =
+                network.synchronizerId ??
+                (await ledgerClient.getSynchronizerId())
+
             const { preparedTransactionHash, preparedTransaction = '' } =
                 await prepareSubmission(
                     context.userId,
                     wallet.partyId,
-                    network.synchronizerId,
+                    synchronizerId,
                     params.commands,
                     ledgerClient,
                     commandId

--- a/wallet-gateway/remote/src/ledger/party-allocation-service.test.ts
+++ b/wallet-gateway/remote/src/ledger/party-allocation-service.test.ts
@@ -47,7 +47,7 @@ jest.unstable_mockModule('@canton-network/core-ledger-client', () => ({
 }))
 
 describe('PartyAllocationService', () => {
-    const network: Network = {
+    const network: Network & { synchronizerId: string } = {
         name: 'test',
         id: 'network-id',
         synchronizerId: 'sync-id',
@@ -88,12 +88,12 @@ describe('PartyAllocationService', () => {
                 .mockResolvedValue('admin.jwt'),
         }
 
-        service = new pas.PartyAllocationService(
-            network.synchronizerId,
-            mockAccessTokenProvider,
-            network.ledgerApi.baseUrl,
-            mockLogger
-        )
+        service = new pas.PartyAllocationService({
+            synchronizerId: network.synchronizerId,
+            accessTokenProvider: mockAccessTokenProvider,
+            httpLedgerUrl: network.ledgerApi.baseUrl,
+            logger: mockLogger,
+        })
     })
 
     it('allocates an internal party', async () => {

--- a/wallet-gateway/remote/src/user-api/controller.ts
+++ b/wallet-gateway/remote/src/user-api/controller.ts
@@ -148,12 +148,12 @@ export const userController = (
                 network.adminAuth,
                 logger
             )
-            const partyAllocator = new PartyAllocationService(
-                network.synchronizerId,
-                tokenProvider,
-                network.ledgerApi.baseUrl,
-                logger
-            )
+            const partyAllocator = new PartyAllocationService({
+                synchronizerId: network.synchronizerId,
+                accessTokenProvider: tokenProvider,
+                httpLedgerUrl: network.ledgerApi.baseUrl,
+                logger,
+            })
             const driver =
                 drivers[signingProviderId as SigningProvider]?.controller(
                     userId
@@ -463,6 +463,9 @@ export const userController = (
 
             switch (wallet.signingProviderId) {
                 case SigningProvider.PARTICIPANT: {
+                    const synchronizerId =
+                        network.synchronizerId ??
+                        (await ledgerClient.getSynchronizerId())
                     // Participant signing provider specific logic can be added here
                     const request = {
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- because OpenRPC codegen type is incompatible with ledger codegen type
@@ -472,7 +475,7 @@ export const userController = (
                         actAs: [partyId],
                         readAs: [],
                         disclosedContracts: [],
-                        synchronizerId: network.synchronizerId,
+                        synchronizerId,
                         packageIdSelectionPreference: [],
                     }
                     try {

--- a/wallet-gateway/remote/src/user-api/rpc-gen/typings.ts
+++ b/wallet-gateway/remote/src/user-api/rpc-gen/typings.ts
@@ -67,7 +67,7 @@ export interface Network {
     id: NetworkId
     name: Name
     description: Description
-    synchronizerId: SynchronizerId
+    synchronizerId?: SynchronizerId
     identityProviderId: IdentityProviderId
     auth: Auth
     adminAuth?: Auth
@@ -99,7 +99,7 @@ export type Type = any
 export type ConfigUrl = string
 /**
  *
- * An identity provider for a network
+ * Structure representing the Identity Providers
  *
  */
 export interface Idp {

--- a/wallet-gateway/test/config.json
+++ b/wallet-gateway/test/config.json
@@ -125,6 +125,31 @@
                 "ledgerApi": {
                     "baseUrl": "https://lab-operator.utility.cnu.devnet.da-int.net/api/json-api"
                 }
+            },
+            {
+                "id": "canton:localnet",
+                "name": "localnet",
+                "description": "localnet configuration",
+                "identityProviderId": "idp-self-signed",
+                "auth": {
+                    "method": "self_signed",
+                    "issuer": "self-signed",
+                    "audience": "https://canton.network.global",
+                    "scope": "openid daml_ledger_api offline_access",
+                    "clientId": "ledger-api-user",
+                    "clientSecret": "unsafe"
+                },
+                "adminAuth": {
+                    "method": "self_signed",
+                    "issuer": "self-signed",
+                    "scope": "openid daml_ledger_api offline_access",
+                    "audience": "https://canton.network.global",
+                    "clientId": "ledger-api-user",
+                    "clientSecret": "unsafe"
+                },
+                "ledgerApi": {
+                    "baseUrl": "http://localhost:2975"
+                }
             }
         ]
     },


### PR DESCRIPTION
1.  Made `synchronizerId` optional in most places.  It is retrieved from the validator app if not specified.
2.  Added a `localnet` configuration.
3.  Changed the example dApp to retrieve the Ledger version, and toggle the ping contract based on that.