### PR TITLE
fix: playwright script sometimes fails on wk-page-popup

### DIFF
--- a/examples/ping/tests/example.spec.ts
+++ b/examples/ping/tests/example.spec.ts
@@ -101,8 +101,12 @@ test('dApp: execute externally signed tx', async ({ page: dappPage }) => {
                 .first()
         ).toBeVisible()
     } catch (e) {
-        await dappPage.screenshot({ path: 'error-dapp.png' })
-        await wkPage.screenshot({ path: 'error-wk.png' })
+        try {
+            await dappPage.screenshot({ path: 'error-dapp.png' })
+            await wkPage.screenshot({ path: 'error-wk.png' })
+        } catch {
+            // Ignore errors during screenshot capture
+        }
         throw e
     }
 })


### PR DESCRIPTION
this happens because we spawn the promise after pressing the button. if the UI is to quick to react then the popup event might happen before we set up the promise.

resolution is to set up the promise before clicking, but only awaiting it after clicking.