### PR TITLE
fix(wallet-gateway-remote): handle host for docker

### DIFF
--- a/wallet-gateway/remote/src/config/ConfigUtils.ts
+++ b/wallet-gateway/remote/src/config/ConfigUtils.ts
@@ -109,9 +109,12 @@ export const deriveKernelUrls = (
     serverConfig: ServerConfig
 ): { dappUrl: string; userUrl: string } => {
     const protocol = serverConfig.tls ? 'https' : 'http'
-    const dappUrl = `${protocol}://${serverConfig.host}:${serverConfig.port}${serverConfig.dappPath}`
+    // Convert 0.0.0.0 to localhost for URL generation since browsers can't use 0.0.0.0
+    const urlHost =
+        serverConfig.host === '0.0.0.0' ? 'localhost' : serverConfig.host
+    const dappUrl = `${protocol}://${urlHost}:${serverConfig.port}${serverConfig.dappPath}`
     // userUrl is the base URL for the web frontend (no path)
-    const userUrl = `${protocol}://${serverConfig.host}:${serverConfig.port}`
+    const userUrl = `${protocol}://${urlHost}:${serverConfig.port}`
 
     return { dappUrl, userUrl }
 }

--- a/wallet-gateway/remote/src/example-config.ts
+++ b/wallet-gateway/remote/src/example-config.ts
@@ -14,7 +14,7 @@ export default {
         tls: false,
         dappPath: '/api/v0/dapp',
         userPath: '/api/v0/user',
-        allowedOrigins: ['http://localhost:8080'],
+        allowedOrigins: '*',
     },
     signingStore: {
         connection: {

--- a/wallet-gateway/remote/src/init.ts
+++ b/wallet-gateway/remote/src/init.ts
@@ -142,11 +142,23 @@ export async function initialize(opts: CliOptions, logger: Logger) {
     const protocol = config.server.tls ? 'https' : 'http'
 
     const app = express()
-    const server = app.listen(port, host, () => {
-        logger.info(
-            `Remote Wallet Gateway starting on ${protocol}://${host}:${port}`
-        )
-    })
+
+    // Don't pass 'localhost' or '0.0.0.0' to listen() - let express default to 0.0.0.0
+    // This ensures Docker compatibility while keeping localhost as the default for URLs
+    const useDefaultListenHost = ['0.0.0.0', 'localhost', '127.0.0.1'].includes(
+        host
+    )
+    const server = useDefaultListenHost
+        ? app.listen(port, () => {
+              logger.info(
+                  `Remote Wallet Gateway starting on ${protocol}://${host}:${port} (bound to 0.0.0.0:${port})`
+              )
+          })
+        : app.listen(port, host, () => {
+              logger.info(
+                  `Remote Wallet Gateway starting on ${protocol}://${host}:${port}`
+              )
+          })
 
     app.use('/healthz', rpcRateLimit, (_req, res) => res.status(200).send('OK'))
     app.use('/readyz', rpcRateLimit, (_req, res) => {


### PR DESCRIPTION
fix for docker build not working due to host not being 0.0.00
before host was not passed to app.listen, so it defaulted to 0.0.0.0
I added conditional passing of host parameter - if host is local, don't pass parameter and listen on all addresses, otherwise pass 