### PR TITLE
fix(wallet-gateway-remote): display gateway version in startup logs + UI

### DIFF
--- a/wallet-gateway/remote/src/index.ts
+++ b/wallet-gateway/remote/src/index.ts
@@ -9,21 +9,15 @@ import { initialize } from './init.js'
 import { createCLI } from '@canton-network/core-wallet-store-sql'
 import { ConfigUtils } from './config/ConfigUtils.js'
 
-import { readFileSync } from 'fs'
-import { join, dirname } from 'path'
-import { fileURLToPath } from 'url'
 import pino from 'pino'
 import z from 'zod'
 import { configSchema } from './config/Config.js'
 import exampleConfig from './example-config.js'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'))
+import { GATEWAY_VERSION } from './version.js'
 
 const program = new Command()
     .name('wallet-gateway')
-    .version(pkg.version)
+    .version(GATEWAY_VERSION)
     .description('Run a remotely hosted Wallet Gateway')
     .option('-c, --config <path>', 'set config path', './config.json')
     .option('--config-schema', 'output the config schema and exit', false)

--- a/wallet-gateway/remote/src/init.ts
+++ b/wallet-gateway/remote/src/init.ts
@@ -33,6 +33,7 @@ import { Config } from './config/Config.js'
 import { deriveKernelUrls } from './config/ConfigUtils.js'
 import { existsSync, readFileSync } from 'fs'
 import path from 'path'
+import { GATEWAY_VERSION } from './version.js'
 
 let isReady = false
 
@@ -148,6 +149,7 @@ export async function initialize(opts: CliOptions, logger: Logger) {
     const useDefaultListenHost = ['0.0.0.0', 'localhost', '127.0.0.1'].includes(
         host
     )
+
     const server = useDefaultListenHost
         ? app.listen(port, () => {
               logger.info(
@@ -262,5 +264,7 @@ export async function initialize(opts: CliOptions, logger: Logger) {
     web(app, server, config.server.userPath)
     isReady = true
 
-    logger.info('Wallet Gateway initialization complete')
+    logger.info(
+        `Wallet Gateway (version: ${GATEWAY_VERSION}) initialization complete`
+    )
 }

--- a/wallet-gateway/remote/src/version.ts
+++ b/wallet-gateway/remote/src/version.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'))
+
+export const GATEWAY_VERSION = pkg.version

--- a/wallet-gateway/remote/src/web/frontend/settings/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/settings/index.ts
@@ -45,6 +45,7 @@ export class UserUiSettings extends LitElement {
     @state() accessor sessions: Session[] = []
     @state() accessor idps: Idp[] = []
     @state() accessor client: UserApiClient | null = null
+    @state() accessor gatewayVersion: string | undefined = undefined
 
     async connectedCallback(): Promise<void> {
         super.connectedCallback()
@@ -52,6 +53,12 @@ export class UserUiSettings extends LitElement {
         this.listNetworks()
         this.listSessions()
         this.listIdps()
+
+        const version = await fetch('/.well-known/wallet-gateway-version')
+            .then((res) => res.json())
+            .then((data) => data.version)
+
+        this.gatewayVersion = version ? `v${version}` : 'unknown_version'
     }
 
     private async listNetworks() {
@@ -178,6 +185,9 @@ export class UserUiSettings extends LitElement {
         const client = this.client
 
         return html`
+            <div>
+                <h1>Wallet Gateway (${this.gatewayVersion})</h1>
+            </div>
             <wg-sessions .sessions=${this.sessions}></wg-sessions>
 
             <wg-wallets-sync .client=${client}></wg-wallets-sync>

--- a/wallet-gateway/remote/src/web/server.ts
+++ b/wallet-gateway/remote/src/web/server.ts
@@ -6,6 +6,7 @@ import { Server } from 'http'
 import path, { dirname } from 'path'
 import { fileURLToPath } from 'url'
 import ViteExpress from 'vite-express'
+import { GATEWAY_VERSION } from '../version.js'
 
 export const web = (app: express.Express, server: Server, userPath: string) => {
     // Expose userPath via well-known configuration endpoint
@@ -26,6 +27,11 @@ export const web = (app: express.Express, server: Server, userPath: string) => {
             )
         )
     }
+
+    // Expose gateway version via well-known endpoint
+    app.get('/.well-known/wallet-gateway-version', (_req, res) => {
+        res.json({ version: GATEWAY_VERSION })
+    })
 
     // Middleware to ensure all paths end with a trailing slash
     // This is useful for static file serving and routing consistency


### PR DESCRIPTION
I figure this will start to become helpful as the number of clients (running varying versions of the gateway) grows and submits bug reports.. 

<img width="1170" height="348" alt="Screenshot 2025-12-04 at 2 03 25 PM" src="https://github.com/user-attachments/assets/2d074add-3778-435a-817d-db09dfab46d7" />

<img width="1170" height="301" alt="Screenshot 2025-12-04 at 2 04 32 PM" src="https://github.com/user-attachments/assets/578b843d-08a3-4a45-8b29-ad19bd1fdb45" />
