### PR TITLE
feat: implement signing api using blockdaemon

### DIFF
--- a/core/signing-blockdaemon/package.json
+++ b/core/signing-blockdaemon/package.json
@@ -1,0 +1,40 @@
+{
+    "name": "@canton-network/core-signing-blockdaemon",
+    "version": "0.14.2",
+    "type": "module",
+    "description": "Wallet Gateway signing driver for Blockdaemon",
+    "license": "Apache-2.0",
+    "packageManager": "yarn@4.9.4",
+    "main": "dist/index.cjs",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js",
+            "require": "./dist/index.cjs",
+            "default": "./dist/index.js"
+        }
+    },
+    "scripts": {
+        "build": "tsup && tsc -p tsconfig.types.json",
+        "clean": "rm -rf ./dist"
+    },
+    "dependencies": {
+        "@canton-network/core-signing-lib": "workspace:^",
+        "@canton-network/core-wallet-auth": "workspace:^"
+    },
+    "devDependencies": {
+        "@types/node": "^24.10.1",
+        "tsup": "^8.5.1",
+        "typescript": "^5.9.3"
+    },
+    "files": [
+        "dist/**"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "directory": "core/signing-blockdaemon"
+    }
+}

--- a/core/signing-blockdaemon/src/index.ts
+++ b/core/signing-blockdaemon/src/index.ts
@@ -1,0 +1,190 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    buildController,
+    type CreateKeyParams,
+    type CreateKeyResult,
+    type GetConfigurationResult,
+    type GetKeysResult,
+    type GetTransactionParams,
+    type GetTransactionResult,
+    type GetTransactionsParams,
+    type GetTransactionsResult,
+    PartyMode,
+    type SetConfigurationParams,
+    type SetConfigurationResult,
+    type SigningDriverInterface,
+    SigningProvider,
+    type SignTransactionParams,
+    type SignTransactionResult,
+    type SubscribeTransactionsParams,
+    type SubscribeTransactionsResult,
+} from '@canton-network/core-signing-lib'
+import { AuthContext } from '@canton-network/core-wallet-auth'
+import { SigningAPIClient } from './signing-api-sdk.js'
+
+export { SigningAPIClient } from './signing-api-sdk.js'
+
+export interface BlockdaemonConfig {
+    baseUrl: string
+    apiKey: string
+}
+
+export default class BlockdaemonSigningDriver implements SigningDriverInterface {
+    private client: SigningAPIClient
+
+    constructor(config: BlockdaemonConfig) {
+        this.client = new SigningAPIClient(config.baseUrl)
+        this.client.setConfiguration({ ApiKey: config.apiKey })
+    }
+
+    public partyMode = PartyMode.EXTERNAL
+    public signingProvider = SigningProvider.BLOCKDAEMON
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public controller = (_userId: AuthContext['userId'] | undefined) =>
+        buildController({
+            signTransaction: async (
+                params: SignTransactionParams
+            ): Promise<SignTransactionResult> => {
+                try {
+                    const tx = await this.client.signTransaction({
+                        tx: params.tx,
+                        txHash: params.txHash,
+                        publicKey: params.publicKey,
+                        internalTxId: params.internalTxId,
+                    })
+                    return {
+                        txId: tx.txId,
+                        status: tx.status,
+                        signature: tx.signature,
+                        publicKey: tx.publicKey,
+                    }
+                } catch (error) {
+                    return {
+                        error: 'signing_error',
+                        error_description: (error as Error).message,
+                    }
+                }
+            },
+
+            getTransaction: async (
+                params: GetTransactionParams
+            ): Promise<GetTransactionResult> => {
+                try {
+                    const tx = await this.client.getTransaction({
+                        txId: params.txId,
+                    })
+                    return {
+                        txId: tx.txId,
+                        status: tx.status,
+                        signature: tx.signature,
+                        publicKey: tx.publicKey,
+                    }
+                } catch (error) {
+                    return {
+                        error: 'transaction_not_found',
+                        error_description: (error as Error).message,
+                    }
+                }
+            },
+
+            getTransactions: async (
+                params: GetTransactionsParams
+            ): Promise<GetTransactionsResult> => {
+                if (params.publicKeys || params.txIds) {
+                    try {
+                        const transactions = await this.client.getTransactions({
+                            txIds: params.txIds,
+                            publicKeys: params.publicKeys,
+                        })
+                        return {
+                            transactions: transactions.map((tx) => ({
+                                txId: tx.txId,
+                                status: tx.status,
+                                signature: tx.signature,
+                                publicKey: tx.publicKey,
+                            })),
+                        }
+                    } catch (error) {
+                        return {
+                            error: 'fetch_error',
+                            error_description: (error as Error).message,
+                        }
+                    }
+                } else {
+                    return {
+                        error: 'bad_arguments',
+                        error_description:
+                            'either public key or txIds must be supplied',
+                    }
+                }
+            },
+
+            getKeys: async (): Promise<GetKeysResult> => {
+                try {
+                    const keys = await this.client.getKeys()
+                    return {
+                        keys: keys.map((k) => ({
+                            id: k.id,
+                            name: k.name,
+                            publicKey: k.publicKey,
+                        })),
+                    }
+                } catch (error) {
+                    return {
+                        error: 'fetch_error',
+                        error_description: (error as Error).message,
+                    }
+                }
+            },
+
+            createKey: async (
+                params: CreateKeyParams
+            ): Promise<CreateKeyResult> => {
+                try {
+                    const key = await this.client.createKey({
+                        name: params.name,
+                    })
+                    return {
+                        id: key.id,
+                        name: key.name,
+                        publicKey: key.publicKey,
+                    }
+                } catch (error) {
+                    return {
+                        error: 'create_key_error',
+                        error_description: (error as Error).message,
+                    }
+                }
+            },
+
+            getConfiguration: async (): Promise<GetConfigurationResult> => {
+                const config = this.client.getConfiguration()
+                return {
+                    ...config,
+                    ApiKey: config.ApiKey ? '***HIDDEN***' : undefined,
+                    MasterKey: config.MasterKey ? '***HIDDEN***' : undefined,
+                }
+            },
+
+            setConfiguration: async (
+                params: SetConfigurationParams
+            ): Promise<SetConfigurationResult> => {
+                this.client.setConfiguration({
+                    BaseURL: params['BaseURL'] as string | undefined,
+                    ApiKey: params['ApiKey'] as string | undefined,
+                    MasterKey: params['MasterKey'] as string | undefined,
+                    TestNetwork: params['TestNetwork'] as boolean | undefined,
+                })
+                return params
+            },
+
+            subscribeTransactions: async (
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                _params: SubscribeTransactionsParams
+            ): Promise<SubscribeTransactionsResult> =>
+                Promise.resolve({} as SubscribeTransactionsResult),
+        })
+}

--- a/core/signing-blockdaemon/src/signing-api-sdk.ts
+++ b/core/signing-blockdaemon/src/signing-api-sdk.ts
@@ -1,0 +1,170 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+    Key,
+    Transaction,
+    SignTransactionParams,
+    GetTransactionParams,
+    GetTransactionsParams,
+    CreateKeyParams,
+} from '@canton-network/core-signing-lib'
+
+/**
+ * A TypeScript SDK client for the Wallet Signing API.
+ */
+export class SigningAPIClient {
+    private baseUrl: string
+    private apiKey: string | undefined
+    private masterKey: string
+    private testNetwork: boolean
+
+    constructor(baseUrl: string) {
+        this.baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+        this.masterKey = 'Default'
+        this.testNetwork = true
+    }
+
+    private async post<I extends Record<string, unknown>, O>(
+        endpoint: string,
+        params: I
+    ): Promise<O> {
+        const url = `${this.baseUrl}${endpoint}`
+
+        // Merge context params (masterKey and testNetwork) into the request body
+        const bodyToSend = {
+            ...params,
+            masterKey: this.masterKey,
+            testNetwork: this.testNetwork,
+        }
+
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+        }
+
+        if (this.apiKey) {
+            headers['Authorization'] = `Bearer ${this.apiKey}`
+        }
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(bodyToSend),
+        })
+
+        if (!response.ok) {
+            const errorText = await response.text()
+            throw new Error(
+                `API call to ${endpoint} failed (${response.status}): ${errorText}`
+            )
+        }
+
+        // Handle 204 No Content for methods that return empty objects or null/void
+        if (
+            response.status === 204 ||
+            response.headers.get('content-length') === '0'
+        ) {
+            // SetConfiguration/GetConfiguration return map[string]any which might be empty
+            return {} as O
+        }
+
+        return response.json() as Promise<O>
+    }
+
+    /**
+     * Uses the Wallet Provider to sign a transaction.
+     * @param params - The transaction signing parameters.
+     */
+    public async signTransaction(
+        params: SignTransactionParams
+    ): Promise<Transaction> {
+        return this.post<SignTransactionParams, Transaction>(
+            '/signTransaction',
+            params
+        )
+    }
+
+    /**
+     * Get the status of a single transaction by its ID.
+     * @param params - The transaction ID parameters.
+     */
+    public async getTransaction(
+        params: GetTransactionParams
+    ): Promise<Transaction> {
+        return this.post<GetTransactionParams, Transaction>(
+            '/getTransaction',
+            params
+        )
+    }
+
+    /**
+     * Get the status of multiple transactions.
+     * @param params - Filters for transactions.
+     */
+    public async getTransactions(
+        params: GetTransactionsParams
+    ): Promise<Transaction[]> {
+        // Note: The Go handler returns []Transaction, the HTTP handler wraps it in JSON array.
+        return this.post<GetTransactionsParams, Transaction[]>(
+            '/getTransactions',
+            params
+        )
+    }
+
+    /**
+     * Get a list of public keys available for signing.
+     */
+    public async getKeys(): Promise<Key[]> {
+        // Go's addDummyArg is used for no-arg handlers, so we send an empty body.
+        return this.post<Record<string, never>, Key[]>('/getKeys', {})
+    }
+
+    /**
+     * Create a new key at the Wallet Provider.
+     * @param params - The key creation parameters.
+     */
+    public async createKey(params: CreateKeyParams): Promise<Key> {
+        return this.post<CreateKeyParams, Key>('/createKey', params)
+    }
+
+    /**
+     * Get configuration parameters (client-side only).
+     * Returns the current BaseURL, ApiKey, MasterKey, and TestNetwork settings.
+     */
+    public getConfiguration(): Record<string, unknown> {
+        return {
+            BaseURL: this.baseUrl,
+            ApiKey: this.apiKey,
+            MasterKey: this.masterKey,
+            TestNetwork: this.testNetwork,
+        }
+    }
+
+    /**
+     * Set configuration parameters (client-side only).
+     * Updates only the provided configuration fields.
+     * @param params - Configuration parameters to set. All fields are optional.
+     */
+    public setConfiguration(params: {
+        BaseURL?: string
+        ApiKey?: string
+        MasterKey?: string
+        TestNetwork?: boolean
+    }): Record<string, unknown> {
+        if (params.BaseURL !== undefined) {
+            this.baseUrl = params.BaseURL.endsWith('/')
+                ? params.BaseURL.slice(0, -1)
+                : params.BaseURL
+        }
+        if (params.ApiKey !== undefined) {
+            this.apiKey = params.ApiKey
+        }
+        if (params.MasterKey !== undefined) {
+            this.masterKey = params.MasterKey
+        }
+        if (params.TestNetwork !== undefined) {
+            this.testNetwork = params.TestNetwork
+        }
+        return this.getConfiguration()
+    }
+}

--- a/core/signing-blockdaemon/tsconfig.json
+++ b/core/signing-blockdaemon/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.node.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["**/*.test.*", "**/*.spec.*"]
+}

--- a/core/signing-blockdaemon/tsconfig.types.json
+++ b/core/signing-blockdaemon/tsconfig.types.json
@@ -1,0 +1,16 @@
+{
+    "extends": "../../tsconfig.web.json",
+    "compilerOptions": {
+        "emitDeclarationOnly": true,
+        "declaration": true,
+        "declarationMap": true,
+        "rootDir": "./src",
+        "outDir": "./dist",
+        "moduleResolution": "bundler",
+        "noEmit": false,
+        "composite": false,
+        "exactOptionalPropertyTypes": false
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["**/*.test.*", "**/*.spec.*"]
+}

--- a/core/signing-blockdaemon/tsup.config.ts
+++ b/core/signing-blockdaemon/tsup.config.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig } from 'tsup'
+import { base } from '../../tsup.base'
+
+export default defineConfig({
+    ...base,
+    entry: ['src/index.ts'],
+})

--- a/core/signing-lib/src/config/schema.ts
+++ b/core/signing-lib/src/config/schema.ts
@@ -7,6 +7,7 @@ export enum SigningProvider {
     WALLET_KERNEL = 'wallet-kernel',
     PARTICIPANT = 'participant',
     FIREBLOCKS = 'fireblocks',
+    BLOCKDAEMON = 'blockdaemon',
 }
 
 // Generic signing driver configuration schema

--- a/wallet-gateway/remote/package.json
+++ b/wallet-gateway/remote/package.json
@@ -34,6 +34,7 @@
     "dependencies": {
         "@canton-network/core-ledger-client": "workspace:^",
         "@canton-network/core-rpc-errors": "workspace:^",
+        "@canton-network/core-signing-blockdaemon": "workspace:^",
         "@canton-network/core-signing-fireblocks": "workspace:^",
         "@canton-network/core-signing-internal": "workspace:^",
         "@canton-network/core-signing-lib": "workspace:^",

--- a/wallet-gateway/remote/src/init.ts
+++ b/wallet-gateway/remote/src/init.ts
@@ -22,6 +22,7 @@ import { SigningProvider } from '@canton-network/core-signing-lib'
 import { ParticipantSigningDriver } from '@canton-network/core-signing-participant'
 import { InternalSigningDriver } from '@canton-network/core-signing-internal'
 import FireblocksSigningProvider from '@canton-network/core-signing-fireblocks'
+import BlockdaemonSigningProvider from '@canton-network/core-signing-blockdaemon'
 import { jwtAuthService } from './auth/jwt-auth-service.js'
 import express from 'express'
 import { CliOptions } from './index.js'
@@ -168,6 +169,11 @@ export async function initialize(opts: CliOptions, logger: Logger) {
     const keyInfo = { apiKey, apiSecret }
     const userApiKeys = new Map([['user', keyInfo]])
 
+    const blockdaemonApiUrl =
+        process.env.BLOCKDAEMON_API_URL ||
+        'http://localhost:5080/api/cwp/canton'
+    const blockdaemonApiKey = process.env.BLOCKDAEMON_API_KEY || ''
+
     const drivers = {
         [SigningProvider.PARTICIPANT]: new ParticipantSigningDriver(),
         [SigningProvider.WALLET_KERNEL]: new InternalSigningDriver(
@@ -176,6 +182,10 @@ export async function initialize(opts: CliOptions, logger: Logger) {
         [SigningProvider.FIREBLOCKS]: new FireblocksSigningProvider({
             defaultKeyInfo: keyInfo,
             userApiKeys,
+        }),
+        [SigningProvider.BLOCKDAEMON]: new BlockdaemonSigningProvider({
+            baseUrl: blockdaemonApiUrl,
+            apiKey: blockdaemonApiKey,
         }),
     }
 

--- a/wallet-gateway/remote/src/user-api/controller.ts
+++ b/wallet-gateway/remote/src/user-api/controller.ts
@@ -212,6 +212,106 @@ export const userController = (
                     publicKey = key.publicKey
                     break
                 }
+                case SigningProvider.BLOCKDAEMON: {
+                    if (signingProviderContext) {
+                        walletStatus = 'initialized'
+                        const { signature, status } =
+                            await driver.getTransaction({
+                                userId,
+                                txId: signingProviderContext.externalTxId,
+                            })
+
+                        if (!['pending', 'signed'].includes(status)) {
+                            await store.removeWallet(
+                                signingProviderContext.partyId
+                            )
+                        }
+
+                        if (signature) {
+                            await partyAllocator.allocatePartyWithExistingWallet(
+                                signingProviderContext.namespace,
+                                signingProviderContext.topologyTransactions.split(
+                                    ', '
+                                ),
+                                signature,
+                                userId
+                            )
+                            walletStatus = 'allocated'
+                        }
+                        party = {
+                            partyId: signingProviderContext.partyId,
+                            namespace: signingProviderContext.namespace,
+                            hint: partyHint,
+                        }
+                    } else {
+                        const key = await driver.createKey({
+                            name: partyHint,
+                        })
+                        if ('error' in key) {
+                            throw new Error(
+                                `Failed to create key: ${key.error_description}`
+                            )
+                        }
+
+                        const namespace =
+                            partyAllocator.createFingerprintFromKey(
+                                key.publicKey
+                            )
+
+                        const transactions =
+                            await partyAllocator.generateTopologyTransactions(
+                                partyHint,
+                                key.publicKey
+                            )
+                        topologyTransactions =
+                            transactions.topologyTransactions ?? []
+                        topologyTransactions.forEach((tx, idx) => {
+                            logger.info(
+                                `BLOCKDAEMON: topologyTransaction[${idx}] length=${tx.length} preview=${tx.substring(0, 100)}...`
+                            )
+                        })
+                        let partyId = ''
+
+                        const internalTxId = crypto
+                            .randomUUID()
+                            .replace(/-/g, '')
+                            .substring(0, 16)
+                        const txPayload = JSON.stringify(topologyTransactions)
+
+                        const { status, txId: id } =
+                            await driver.signTransaction({
+                                tx: Buffer.from(txPayload).toString('base64'),
+                                txHash: transactions.multiHash,
+                                publicKey: key.publicKey,
+                                internalTxId,
+                            })
+
+                        if (status === 'signed') {
+                            const { signature } = await driver.getTransaction({
+                                userId,
+                                txId: id,
+                            })
+                            partyId =
+                                await partyAllocator.allocatePartyWithExistingWallet(
+                                    namespace,
+                                    transactions.topologyTransactions ?? [],
+                                    signature,
+                                    userId
+                                )
+                        } else {
+                            txId = id
+                            walletStatus = 'initialized'
+                        }
+
+                        party = {
+                            partyId,
+                            namespace,
+                            hint: partyHint,
+                        }
+                        publicKey = key.publicKey
+                    }
+                    break
+                }
                 case SigningProvider.FIREBLOCKS: {
                     const keys = await driver.getKeys()
                     const key = keys?.keys?.find(
@@ -435,6 +535,60 @@ export const userController = (
                         partyId: wallet.partyId,
                     }
                 }
+                case SigningProvider.BLOCKDAEMON: {
+                    const internalTxId = crypto
+                        .randomUUID()
+                        .replace(/-/g, '')
+                        .substring(0, 16)
+                    let result = await driver.signTransaction({
+                        tx: preparedTransaction,
+                        txHash: preparedTransactionHash,
+                        publicKey: wallet.publicKey,
+                        internalTxId,
+                    })
+
+                    if (result.status === 'pending' && result.txId) {
+                        for (let i = 0; i < 60; i++) {
+                            await new Promise((r) => setTimeout(r, 1000))
+                            result = await driver.getTransaction({
+                                userId,
+                                txId: result.txId,
+                            })
+                            if (result.status === 'signed') break
+                        }
+                    }
+
+                    if (!result.signature) {
+                        throw new Error(
+                            'Signing timed out or failed: ' +
+                                JSON.stringify(result)
+                        )
+                    }
+
+                    const existingTx = await store.getTransaction(commandId)
+                    const now = new Date()
+
+                    const signedTx: Transaction = {
+                        commandId,
+                        status: 'signed',
+                        preparedTransaction,
+                        preparedTransactionHash,
+                        origin: existingTx?.origin ?? null,
+                        ...(existingTx?.createdAt && {
+                            createdAt: existingTx.createdAt,
+                        }),
+                        signedAt: now,
+                    }
+
+                    store.setTransaction(signedTx)
+                    notifier.emit('txChanged', signedTx)
+
+                    return {
+                        signature: result.signature,
+                        signedBy: wallet.namespace,
+                        partyId: wallet.partyId,
+                    }
+                }
                 default:
                     throw new Error(
                         `Unsupported signing provider: ${wallet.signingProviderId}`
@@ -521,7 +675,8 @@ export const userController = (
                         throw error
                     }
                 }
-                case SigningProvider.WALLET_KERNEL: {
+                case SigningProvider.WALLET_KERNEL:
+                case SigningProvider.BLOCKDAEMON: {
                     const result = await ledgerClient.postWithRetry(
                         '/v2/interactive-submission/execute',
                         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,6 +1577,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@canton-network/core-signing-blockdaemon@workspace:^, @canton-network/core-signing-blockdaemon@workspace:core/signing-blockdaemon":
+  version: 0.0.0-use.local
+  resolution: "@canton-network/core-signing-blockdaemon@workspace:core/signing-blockdaemon"
+  dependencies:
+    "@canton-network/core-signing-lib": "workspace:^"
+    "@canton-network/core-wallet-auth": "workspace:^"
+    "@types/node": "npm:^24.10.1"
+    tsup: "npm:^8.5.1"
+    typescript: "npm:^5.9.3"
+  languageName: unknown
+  linkType: soft
+
 "@canton-network/core-signing-fireblocks@workspace:^, @canton-network/core-signing-fireblocks@workspace:core/signing-fireblocks":
   version: 0.0.0-use.local
   resolution: "@canton-network/core-signing-fireblocks@workspace:core/signing-fireblocks"
@@ -2079,6 +2091,7 @@ __metadata:
   dependencies:
     "@canton-network/core-ledger-client": "workspace:^"
     "@canton-network/core-rpc-errors": "workspace:^"
+    "@canton-network/core-signing-blockdaemon": "workspace:^"
     "@canton-network/core-signing-fireblocks": "workspace:^"
     "@canton-network/core-signing-internal": "workspace:^"
     "@canton-network/core-signing-lib": "workspace:^"


### PR DESCRIPTION
Add Blockdaemon as a new signing provider for the Wallet Gateway, enabling transaction signing via Blockdaemon's API.
