### PR TITLE
feat: pass topology tx to signing driver

### DIFF
--- a/api-specs/openrpc-signing-api.json
+++ b/api-specs/openrpc-signing-api.json
@@ -15,10 +15,14 @@
                         "type": "object",
                         "title": "SignTransactionParams",
                         "properties": {
-                            "tx": {
-                                "title": "tx",
-                                "type": "string",
-                                "description": "Bytestring of the prepared transaction for verification purposes."
+                            "txs": {
+                                "title": "txs",
+                                "type": "array",
+                                "items": {
+                                    "title": "tx",
+                                    "type": "string"
+                                },
+                                "description": "Bytestring(s) of the prepared transaction(s) for verification purposes."
                             },
                             "txHash": {
                                 "title": "txHash",
@@ -36,7 +40,7 @@
                                 "description": "Internal txId used by the Wallet Gateway to store the transaction."
                             }
                         },
-                        "required": ["tx", "txHash", "publicKey"]
+                        "required": ["txs", "txHash", "publicKey"]
                     }
                 }
             ],

--- a/core/signing-lib/src/rpc-gen/typings.ts
+++ b/core/signing-lib/src/rpc-gen/typings.ts
@@ -3,12 +3,13 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+export type Tx = string
 /**
  *
- * Bytestring of the prepared transaction for verification purposes.
+ * Bytestring(s) of the prepared transaction(s) for verification purposes.
  *
  */
-export type Tx = string
+export type Txs = Tx[]
 /**
  *
  * Hash of the prepared transaction that will be signed.
@@ -125,7 +126,7 @@ export interface Key {
  */
 export type Keys = Key[]
 export interface SignTransactionParams {
-    tx: Tx
+    txs: Txs
     txHash: TxHash
     publicKey: PublicKey
     internalTxId?: InternalTxId

--- a/wallet-gateway/remote/src/ledger/party-allocation-service.ts
+++ b/wallet-gateway/remote/src/ledger/party-allocation-service.ts
@@ -15,7 +15,7 @@ export type AllocatedParty = {
     namespace: string
 }
 
-type SigningCbFn = (hash: string) => Promise<string>
+type SigningCbFn = (hash: string, tx?: string[]) => Promise<string>
 
 /**
  * This service provides an abstraction for Canton party allocation that seamlessly handles both internal and external parties.
@@ -249,7 +249,10 @@ export class PartyAllocationService {
             publicKey
         )
 
-        const signature = await signingCallback(transactions.multiHash)
+        const signature = await signingCallback(
+            transactions.multiHash,
+            transactions.topologyTransactions
+        )
 
         const res = await this.ledgerClient.allocateExternalParty(
             synchronizerId,

--- a/wallet-gateway/remote/src/user-api/controller.ts
+++ b/wallet-gateway/remote/src/user-api/controller.ts
@@ -199,9 +199,9 @@ export const userController = (
                         userId,
                         partyHint,
                         key.publicKey,
-                        async (hash) => {
+                        async (hash, txs) => {
                             const { signature } = await driver.signTransaction({
-                                tx: '',
+                                txs: txs || [],
                                 txHash: hash,
                                 publicKey: key.publicKey,
                             })
@@ -271,7 +271,7 @@ export const userController = (
 
                         const { status, txId: id } =
                             await driver.signTransaction({
-                                tx: '',
+                                txs: [],
                                 txHash: Buffer.from(
                                     transactions.multiHash,
                                     'base64'
@@ -398,7 +398,7 @@ export const userController = (
                 }
                 case SigningProvider.WALLET_KERNEL: {
                     const signature = await driver.signTransaction({
-                        tx: preparedTransaction,
+                        txs: [preparedTransaction],
                         txHash: preparedTransactionHash,
                         publicKey: wallet.publicKey,
                     })


### PR DESCRIPTION
Closes #1053

I suspect this is not necessary and we can work with a comma-separated list of strings.