### PR TITLE
chore(example-portfolio): cleanup imports

### DIFF
--- a/examples/portfolio/src/App.tsx
+++ b/examples/portfolio/src/App.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import RealDataApp from './RealDataApp.js'
+import RealDataApp from './RealDataApp'
 
 function App() {
     return (

--- a/examples/portfolio/src/RealDataApp.tsx
+++ b/examples/portfolio/src/RealDataApp.tsx
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import './App.css'
-import { RegistryServiceProvider } from './contexts/RegistriesServiceProvider.js'
-import { ConnectionProvider } from './contexts/ConnectionProvider.js'
-import { PortfolioProvider } from './contexts/PortfolioProvider.js'
-import { HoldingsTab } from './oldcomponents/HoldingsTab.js'
-import { RegistriesTab } from './oldcomponents/RegistriesTab.js'
-import { PendingTransfersTab } from './oldcomponents/PendingTransfersTab.js'
-import { TwoStepTransferTab } from './oldcomponents/TwoStepTransferTab.js'
-import { TransactionHistoryTab } from './oldcomponents/TransactionHistoryTab.js'
-import { ConnectionCard } from './oldcomponents/ConnectionCard.js'
-import { AllocationsTab } from './oldcomponents/AllocationsTab.js'
-import { Tabs } from './oldcomponents/Tabs.js'
+import { RegistryServiceProvider } from './contexts/RegistriesServiceProvider'
+import { ConnectionProvider } from './contexts/ConnectionProvider'
+import { PortfolioProvider } from './contexts/PortfolioProvider'
+import { HoldingsTab } from './oldcomponents/HoldingsTab'
+import { RegistriesTab } from './oldcomponents/RegistriesTab'
+import { PendingTransfersTab } from './oldcomponents/PendingTransfersTab'
+import { TwoStepTransferTab } from './oldcomponents/TwoStepTransferTab'
+import { TransactionHistoryTab } from './oldcomponents/TransactionHistoryTab'
+import { ConnectionCard } from './oldcomponents/ConnectionCard'
+import { AllocationsTab } from './oldcomponents/AllocationsTab'
+import { Tabs } from './oldcomponents/Tabs'
 
 const RealDataApp: React.FC = () => (
     <RegistryServiceProvider>

--- a/examples/portfolio/src/contexts/ConnectionProvider.tsx
+++ b/examples/portfolio/src/contexts/ConnectionProvider.tsx
@@ -3,10 +3,7 @@
 
 import { useEffect, useState } from 'react'
 import * as sdk from '@canton-network/dapp-sdk'
-import {
-    type ConnectionStatus,
-    ConnectionContext,
-} from './ConnectionContext.js'
+import { type ConnectionStatus, ConnectionContext } from './ConnectionContext'
 
 export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
     children,

--- a/examples/portfolio/src/contexts/PortfolioProvider.tsx
+++ b/examples/portfolio/src/contexts/PortfolioProvider.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import * as portfolioServiceImplementation from '../services/portfolio-service-implementation.js'
-import { PortfolioContext } from './PortfolioContext.js'
+import * as portfolioServiceImplementation from '../services/portfolio-service-implementation'
+import { PortfolioContext } from './PortfolioContext'
 
 export const PortfolioProvider: React.FC<{ children: React.ReactNode }> = ({
     children,

--- a/examples/portfolio/src/contexts/RegistriesServiceProvider.tsx
+++ b/examples/portfolio/src/contexts/RegistriesServiceProvider.tsx
@@ -5,8 +5,8 @@ import { pino } from 'pino'
 import {
     type RegistryUrls,
     RegistryServiceImplementation,
-} from '../services/registry-service.js'
-import { RegistryServiceContext } from './RegistryServiceContext.js'
+} from '../services/registry-service'
+import { RegistryServiceContext } from './RegistryServiceContext'
 
 const loadRegistryUrls = (): RegistryUrls => {
     const value = window.localStorage.getItem('registries')

--- a/examples/portfolio/src/oldcomponents/AllocationRequestCard.tsx
+++ b/examples/portfolio/src/oldcomponents/AllocationRequestCard.tsx
@@ -3,9 +3,9 @@
 
 import type { PartyId } from '@canton-network/core-types'
 import { type AllocationRequestView } from '@canton-network/core-token-standard'
-import { useRegistryUrls } from '../contexts/RegistryServiceContext.js'
-import { usePortfolio } from '../contexts/PortfolioContext.js'
-import { AssetCard } from './AssetCard.js'
+import { useRegistryUrls } from '../contexts/RegistryServiceContext'
+import { usePortfolio } from '../contexts/PortfolioContext'
+import { AssetCard } from './AssetCard'
 
 export type AllocationRequestCardProps = {
     party: PartyId

--- a/examples/portfolio/src/oldcomponents/AllocationsTab.tsx
+++ b/examples/portfolio/src/oldcomponents/AllocationsTab.tsx
@@ -4,15 +4,15 @@
 import { useState, useEffect } from 'react'
 import { type AllocationRequestView } from '@canton-network/core-token-standard'
 import { type PrettyContract } from '@canton-network/core-ledger-client'
-import { useConnection } from '../contexts/ConnectionContext.js'
-import { usePortfolio } from '../contexts/PortfolioContext.js'
-import { useRegistryUrls } from '../contexts/RegistryServiceContext.js'
+import { useConnection } from '../contexts/ConnectionContext'
+import { usePortfolio } from '../contexts/PortfolioContext'
+import { useRegistryUrls } from '../contexts/RegistryServiceContext'
 import {
     type TransferLegInputFields,
     TransferLegInput,
-} from './TransferLegInput.js'
-import { DateTimePicker } from './DateTimePicker.js'
-import { AllocationRequestCard } from './AllocationRequestCard.js'
+} from './TransferLegInput'
+import { DateTimePicker } from './DateTimePicker'
+import { AllocationRequestCard } from './AllocationRequestCard'
 
 export const AllocationsTab: React.FC = () => {
     const registryUrls = useRegistryUrls()

--- a/examples/portfolio/src/oldcomponents/HoldingsTab.tsx
+++ b/examples/portfolio/src/oldcomponents/HoldingsTab.tsx
@@ -6,11 +6,11 @@ import {
     TokenStandardService,
     type Holding,
 } from '@canton-network/core-ledger-client'
-import { useConnection } from '../contexts/ConnectionContext.js'
-import { usePortfolio } from '../contexts/PortfolioContext.js'
-import { useRegistryUrls } from '../contexts/RegistryServiceContext.js'
-import { AssetCard } from './AssetCard.js'
-import { SelectInstrument } from './SelectInstrument.js'
+import { useConnection } from '../contexts/ConnectionContext'
+import { usePortfolio } from '../contexts/PortfolioContext'
+import { useRegistryUrls } from '../contexts/RegistryServiceContext'
+import { AssetCard } from './AssetCard'
+import { SelectInstrument } from './SelectInstrument'
 
 export const HoldingsTab: React.FC = () => {
     const {

--- a/examples/portfolio/src/oldcomponents/PendingTransfersTab.tsx
+++ b/examples/portfolio/src/oldcomponents/PendingTransfersTab.tsx
@@ -6,9 +6,9 @@ import type {
     PrettyContract,
     TransferInstructionView,
 } from '@canton-network/core-ledger-client'
-import { useConnection } from '../contexts/ConnectionContext.js'
-import { usePortfolio } from '../contexts/PortfolioContext.js'
-import { TransferCard } from './TransferCard.js'
+import { useConnection } from '../contexts/ConnectionContext'
+import { usePortfolio } from '../contexts/PortfolioContext'
+import { TransferCard } from './TransferCard'
 
 export const PendingTransfersTab: React.FC = () => {
     const {

--- a/examples/portfolio/src/oldcomponents/TransactionHistoryTab.tsx
+++ b/examples/portfolio/src/oldcomponents/TransactionHistoryTab.tsx
@@ -3,9 +3,9 @@
 
 import { useState, useEffect } from 'react'
 import { type Transaction } from '@canton-network/core-ledger-client'
-import { useConnection } from '../contexts/ConnectionContext.js'
-import { usePortfolio } from '../contexts/PortfolioContext.js'
-import { TransferCard } from './TransferCard.js'
+import { useConnection } from '../contexts/ConnectionContext'
+import { usePortfolio } from '../contexts/PortfolioContext'
+import { TransferCard } from './TransferCard'
 
 export const TransactionHistoryTab: React.FC = () => {
     const {

--- a/examples/portfolio/src/oldcomponents/TransferCard.tsx
+++ b/examples/portfolio/src/oldcomponents/TransferCard.tsx
@@ -6,9 +6,9 @@ import {
     type TransferInstructionView,
     TokenStandardService,
 } from '@canton-network/core-ledger-client'
-import { useRegistryUrls } from '../contexts/RegistryServiceContext.js'
-import { usePortfolio } from '../contexts/PortfolioContext.js'
-import { AssetCard } from './AssetCard.js'
+import { useRegistryUrls } from '../contexts/RegistryServiceContext'
+import { usePortfolio } from '../contexts/PortfolioContext'
+import { AssetCard } from './AssetCard'
 
 export type TransferCardProps = {
     party: PartyId

--- a/examples/portfolio/src/oldcomponents/TransferLegInput.tsx
+++ b/examples/portfolio/src/oldcomponents/TransferLegInput.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { SelectInstrument } from './SelectInstrument.js'
+import { SelectInstrument } from './SelectInstrument'
 
 export type TransferLegInputFields = {
     transferLegId: string

--- a/examples/portfolio/src/oldcomponents/TwoStepTransferTab.tsx
+++ b/examples/portfolio/src/oldcomponents/TwoStepTransferTab.tsx
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState } from 'react'
-import { useRegistryUrls } from '../contexts/RegistryServiceContext.js'
-import { useConnection } from '../contexts/ConnectionContext.js'
-import { usePortfolio } from '../contexts/PortfolioContext.js'
-import { SelectInstrument } from './SelectInstrument.js'
+import { useRegistryUrls } from '../contexts/RegistryServiceContext'
+import { useConnection } from '../contexts/ConnectionContext'
+import { usePortfolio } from '../contexts/PortfolioContext'
+import { SelectInstrument } from './SelectInstrument'
 
 export const TwoStepTransferTab: React.FC = () => {
     const {

--- a/examples/portfolio/src/services/portfolio-service-implementation.ts
+++ b/examples/portfolio/src/services/portfolio-service-implementation.ts
@@ -24,7 +24,7 @@ import {
     resolveTokenStandardService,
     resolveTransactionHistoryService,
     resolveAmuletService,
-} from './resolve.js'
+} from './resolve'
 
 // PortfolioService is a fat interface that tries to capture everything our
 // portflio can do.  Separating the interface from the implementation will

--- a/examples/portfolio/src/services/resolve.ts
+++ b/examples/portfolio/src/services/resolve.ts
@@ -10,7 +10,7 @@ import {
 import * as sdk from '@canton-network/dapp-sdk'
 import { TokenStandardClient } from '@canton-network/core-token-standard'
 import { ScanProxyClient } from '@canton-network/core-splice-client'
-import { TransactionHistoryService } from './transaction-history-service.js'
+import { TransactionHistoryService } from './transaction-history-service'
 
 // This module allows us to resolve (i.e. get an instance of) the different
 // dependency services used throughout the project.


### PR DESCRIPTION

file extensions are not necessary. In bundler mode, vite will resolve the imports automatically.