### PR TITLE
fix(dapp-sdk): more reliable verified gateways

### DIFF
--- a/core/wallet-ui-components/src/windows/discovery.ts
+++ b/core/wallet-ui-components/src/windows/discovery.ts
@@ -24,16 +24,14 @@ export class WindowState {
 }
 
 export async function discover(
-    config: GatewaysConfig[]
+    verifiedGateways: GatewaysConfig[]
 ): Promise<DiscoverResult> {
-    const win = await popup(Discovery)
+    const win = await popup(Discovery, { title: 'Connect to a Wallet Gateway' })
 
-    win.onload = () => {
-        win.postMessage(
-            { type: 'SPLICE_WALLET_CONFIG_LOAD', payload: config },
-            '*'
-        )
-    }
+    localStorage.setItem(
+        'splice_wallet_verified_gateways',
+        JSON.stringify(verifiedGateways)
+    )
 
     return new Promise((resolve, reject) => {
         let response: DiscoverResult | undefined = undefined

--- a/sdk/dapp-sdk/src/gateways.json
+++ b/sdk/dapp-sdk/src/gateways.json
@@ -1,10 +1,6 @@
 [
     {
-        "name": "Canton Wallet Gateway (Local)",
-        "rpcUrl": "http://localhost:3030/api/v0/dapp"
-    },
-    {
-        "name": "Example2",
+        "name": "Wallet Gateway (localhost, dev)",
         "rpcUrl": "http://localhost:3030/api/v0/dapp"
     }
 ]

--- a/sdk/dapp-sdk/src/provider/request.ts
+++ b/sdk/dapp-sdk/src/provider/request.ts
@@ -10,9 +10,23 @@ import { GatewaysConfig } from '@canton-network/core-types'
 import gateways from '../gateways.json'
 import { clearAllLocalState } from '../util'
 
-export async function connect(): Promise<dappAPI.StatusEvent> {
-    const config: GatewaysConfig[] = gateways
-    return discover(config)
+interface ConnectOptions {
+    defaultGateways?: GatewaysConfig[]
+    additionalGateways?: GatewaysConfig[]
+}
+
+export async function connect(
+    options?: ConnectOptions
+): Promise<dappAPI.StatusEvent> {
+    const { defaultGateways = gateways, additionalGateways = [] } =
+        options || {}
+
+    const verifiedGateways: GatewaysConfig[] = [
+        ...defaultGateways,
+        ...additionalGateways,
+    ]
+
+    return discover(verifiedGateways)
         .then(async (result) => {
             // Store discovery result and remove previous session
             clearAllLocalState()


### PR DESCRIPTION
The verified kernels in discovery popup are now populated via Localstorage, instead of `postMessage` (the latter is brittle, as it depends on the popup's `onload` event firing, which may no longer be the case depending on if there is an existing WindowProxy reference in memory)

Also adds the ability for the dapp to override the default gateways, or provide additional ones. 