### PR TITLE
feat(example-portfolio): add network banner

### DIFF
--- a/examples/portfolio/src/components/network-banner.tsx
+++ b/examples/portfolio/src/components/network-banner.tsx
@@ -1,0 +1,27 @@
+import { Box, Typography } from '@mui/material'
+import { useConnection } from '../contexts/ConnectionContext'
+
+export const NetworkBanner = () => {
+    const { status } = useConnection()
+    const networkId = status?.network?.networkId
+
+    return (
+        <Box
+            sx={{
+                position: 'sticky',
+                top: 0,
+                width: '100%',
+                backgroundColor: 'grey.900',
+                py: 0.5,
+                textAlign: 'center',
+                zIndex: (theme) => theme.zIndex.appBar + 1,
+            }}
+        >
+            <Typography variant="caption" sx={{ color: 'grey.400' }}>
+                {networkId
+                    ? `Network: ${networkId}`
+                    : 'Not Connected to a Network'}
+            </Typography>
+        </Box>
+    )
+}

--- a/examples/portfolio/src/routes/__root.tsx
+++ b/examples/portfolio/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import { TanStackDevtools } from '@tanstack/react-devtools'
 import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
 import { ReactQueryDevtoolsPanel } from '@tanstack/react-query-devtools'
 import { Header } from '../components/header'
+import { NetworkBanner } from '../components/network-banner'
 import { Container } from '@mui/material'
 import type { QueryClient } from '@tanstack/react-query'
 
@@ -17,6 +18,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 function RootComponent() {
     return (
         <>
+            <NetworkBanner />
             <Container maxWidth="lg">
                 <Header />
                 <Outlet />


### PR DESCRIPTION
Small pr to show  a network banner at all times in the portfolio. You currently have to open the wallet gateway for this which has becoming annoying.

<img width="1239" height="549" alt="Screenshot 2026-01-23 at 14 17 06" src="https://github.com/user-attachments/assets/7ed5ab20-bda2-42b0-9adc-9f407dfa7e94" />
<img width="1241" height="310" alt="Screenshot 2026-01-23 at 14 17 35" src="https://github.com/user-attachments/assets/ae506179-e3c6-4d56-abb4-2303544d3db5" />
