### PR TITLE
chore: include examples workspace directory for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,4 +41,4 @@ jobs:
             - name: Publish
               run: |
                   yarn config set npmAuthToken ${{ secrets.NPM_TOKEN_DA }}
-                  yarn workspaces foreach --no-private -t -A --include 'core/*' --include 'sdk/*' --include 'wallet-gateway/*' npm publish --tolerate-republish
+                  yarn workspaces foreach --no-private -t -A --include 'core/*' --include 'sdk/*' --include 'wallet-gateway/*' --include 'examples/*' npm publish --tolerate-republish


### PR DESCRIPTION
the portfolio did not publish because it was excluded in the CI job