### PR TITLE
chore: full release script

### DIFF
--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -2,24 +2,15 @@
 
 This repository is a monorepo of independently versioned Javascript packages. We use Conventional Commits to track changes to individual packages over time. When it comes time to publish updates to NPM, a maintainer runs through the following process from the repo root:
 
-1. Checkout `main` and `git pull` to be up-to-date
-2. Run `git fetch --tags --force` to fetch the latest tags locally
-3. Create a new branch to hold the version bump commit: `git checkout -b release/$(date +%s)`
-4. Push the branch to the remote: `git push --set-upstream origin <branch from prior step>`
-5. Ensure you have the `gh` CLI tool installed and authenticated: `gh auth status`
-    - if unauthenticated, `gh auth login`
-6. Run `yarn script:release` to sanity check the new update versions via a dry-run
-7. Run `yarn script:release --no-dry-run` if all looks good. This will
-    - create and push new git tags for each package
-    - create new GH releases with changelogs
-    - create a commit containing the version bumps in all affected package.json's
-8. Merge the version bump PR into `main`
-    - if you squash and merge, the release commit will change when merged in main, leaving the tags pointing to orphaned hashes
-    - to fix this manually, then run `yarn script:retag <oldHash> <newHash>` using the new commit hash found on `main` corresponding to the release
-        - pro-tip: if you use SSH, run `ssh-add` before calling the retag script. This will remember your SSH credentials for the session, so you do not retype your password for every tag being updated.
-9. Open a PR from `main` to `latest`
-10. Ensure you change "Squash and merge" to "Create a merge commit", and then merge the PR
-11. Wait for the `publish.yml` workflow to complete on `latest`. Afterwards, any updated packages should be pushed to NPM
+1. Run `yarn script:release` to sanity check the new update versions via a dry-run
+2. Run `yarn script:release --no-dry-run` if all looks good. This will
+    - create and push new git tags for each package.
+    - create new GH releases with changelogs.
+    - create a commit containing the version bumps in all affected package.
+    - waits for the pr to be merged (keep the terminal open).
+    - retags the GH releases created earlier to the merge to main (since the PR squashes).
+    - once it is merged creates a new pr from `main` to `latest`.
+3. Wait for the `publish.yml` workflow to complete on `latest`. Afterwards, any updated packages should be pushed to NPM
     - Check the page here to confirm: https://www.npmjs.com/org/canton-network
 
 ## Backporting

--- a/scripts/src/release.ts
+++ b/scripts/src/release.ts
@@ -25,6 +25,64 @@ async function cmd(command: string): Promise<void> {
     })
 }
 
+async function cmdCapture(command: string): Promise<string> {
+    const [bin, ...args] = command.split(' ')
+    const child = spawn(bin, args, { shell: true })
+
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout?.on('data', (data) => {
+        stdout += data.toString()
+    })
+
+    child.stderr?.on('data', (data) => {
+        stderr += data.toString()
+    })
+
+    return new Promise<string>((resolve, reject) => {
+        child.on('close', (code) => {
+            if (code !== 0) {
+                reject(new Error(`Command failed: ${command}\n${stderr}`))
+            } else {
+                resolve(stdout + stderr)
+            }
+        })
+    })
+}
+
+async function checkGhAuth(): Promise<void> {
+    try {
+        await cmdCapture('gh --version')
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (error) {
+        console.error('Error: gh CLI is not installed.')
+        console.error(
+            'Please install gh CLI: https://cli.github.com/manual/installation'
+        )
+        process.exit(1)
+    }
+
+    let authOutput: string
+    try {
+        authOutput = await cmdCapture('gh auth status')
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (error) {
+        console.error('Error: gh CLI is not authenticated.')
+        console.error('Please run: gh auth login')
+        process.exit(1)
+    }
+
+    if (!authOutput.includes('write:packages')) {
+        console.error('Error: gh CLI token does not have write:packages scope.')
+        console.error('Please run:')
+        console.error('gh auth refresh -h github.com -s repo,write:packages')
+        process.exit(1)
+    }
+
+    console.log('gh CLI is authenticated with required scopes')
+}
+
 const options = [
     'wallet-sdk',
     'dapp-sdk',
@@ -36,6 +94,24 @@ program
     .option('--dry-run', 'Perform a dry run (default: true)')
     .option('--no-dry-run', 'Perform a real release')
     .action(async ({ dryRun = true }) => {
+        console.log('Checking gh CLI authentication...')
+        await checkGhAuth()
+
+        console.log('Checking out main branch and pulling latest changes...')
+        await cmd('git checkout main')
+        await cmd('git pull')
+
+        console.log('Fetching latest tags...')
+        await cmd('git fetch --tags --force')
+
+        const timestamp = Math.floor(Date.now() / 1000)
+        const branchName = `release/${timestamp}`
+        console.log(`Creating release branch: ${branchName}`)
+        await cmd(`git checkout -b ${branchName}`)
+
+        console.log('Pushing branch to remote...')
+        await cmd(`git push --set-upstream origin ${branchName}`)
+
         const groups = await select({
             canToggleAll: true,
             message: 'Select groups to release',
@@ -48,6 +124,65 @@ program
         }
 
         await runRelease(dryRun, groups)
+
+        if (!dryRun) {
+            console.log('Getting current commit hash...')
+            const oldHash = (await cmdCapture('git rev-parse HEAD')).trim()
+            console.log(`Old hash: ${oldHash}`)
+
+            console.log('Creating PR and enabling auto-merge...')
+            await cmd(
+                `gh pr create --base main --head ${branchName} --title "chore(release): ${groups.join(', ')}" --body "Automated release PR for ${groups.join(', ')}"`
+            )
+            await cmd(`gh pr merge ${branchName} --auto --squash`)
+            console.log('PR created with auto-merge enabled')
+
+            console.log('Waiting for PR to be merged...')
+            let merged = false
+            while (!merged) {
+                await new Promise((resolve) => setTimeout(resolve, 5000)) // Wait 5 seconds
+                try {
+                    const prStatus = await cmdCapture(
+                        `gh pr view ${branchName} --json state,mergeCommit`
+                    )
+                    const status = JSON.parse(prStatus)
+                    if (status.state === 'MERGED') {
+                        merged = true
+                        console.log('PR has been merged!')
+                    } else {
+                        console.log(`PR status: ${status.state}, waiting...`)
+                    }
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                } catch (error) {
+                    console.log('Checking PR status...')
+                }
+            }
+
+            console.log('Checking out main and pulling latest changes...')
+            await cmd('git checkout main')
+            await cmd('git pull')
+
+            const newHash = (await cmdCapture('git rev-parse HEAD')).trim()
+            console.log(`New hash: ${newHash}`)
+
+            if (oldHash !== newHash) {
+                console.log('Running retag to update tag references...')
+                await cmd(`yarn script:retag ${oldHash} ${newHash}`)
+                console.log('Tags updated successfully')
+            } else {
+                console.log('Hashes are identical, no retagging needed')
+            }
+
+            console.log('Creating PR from main to latest...')
+            await cmd(
+                `gh pr create --base latest --head main --title "chore(release): Merge main to latest" --body "Automated PR to merge main into latest for publishing"`
+            )
+            await cmd(`gh pr merge main --auto --merge`)
+            console.log(
+                'PR from main to latest created with auto-merge (merge commit) enabled'
+            )
+        }
+
         process.exit(0)
     })
     .parseAsync(process.argv)
@@ -83,6 +218,9 @@ async function runRelease(dryRun: boolean, groups: string[]): Promise<void> {
             process.exit(0)
         }
     }
+
+    const ghToken = (await cmdCapture('gh auth token')).trim()
+    await cmd(`GITHUB_TOKEN=${ghToken} ${releaseCmd}`)
 
     await cmd(releaseCmd)
 }


### PR DESCRIPTION
full release script that handles the entire process and pr creation. 

used to create this release: https://github.com/hyperledger-labs/splice-wallet-kernel/pull/1248
from start to finish.

Fixes #961 

change list:
- checks and runs `gh` for status
- go to main and pull latest
- creates release branch
- give `gh auth token` to nx so it can perform the releases
- create PR merge to main
- run the script:retag from old commit to new commit
- creates PR from main to latest

now a full release can be done with `yarn script:release --no-dry-run` and waiting