### PR TITLE
fix: explicitly set additionalProperties in signing RPC schemas

### DIFF
--- a/api-specs/openrpc-signing-api.json
+++ b/api-specs/openrpc-signing-api.json
@@ -14,6 +14,7 @@
                     "schema": {
                         "type": "object",
                         "title": "SignTransactionParams",
+                        "additionalProperties": true,
                         "properties": {
                             "tx": {
                                 "title": "tx",
@@ -65,6 +66,7 @@
                     "schema": {
                         "title": "getTransactionParams",
                         "type": "object",
+                        "additionalProperties": true,
                         "properties": {
                             "txId": {
                                 "title": "txId",
@@ -100,6 +102,7 @@
                     "schema": {
                         "title": "GetTransactionsParams",
                         "type": "object",
+                        "additionalProperties": true,
                         "properties": {
                             "txIds": {
                                 "title": "txIds",
@@ -135,6 +138,7 @@
                         {
                             "type": "object",
                             "title": "TransactionsResult",
+                            "additionalProperties": false,
                             "properties": {
                                 "transactions": {
                                     "title": "transactions",
@@ -158,17 +162,14 @@
                 "name": "result",
                 "schema": {
                     "title": "getKeysResult",
-                    "type": "object",
-                    "properties": {
-                        "keys": {
-                            "title": "keys",
-                            "type": "array",
-                            "description": "List of keys availabile at the Wallet Provider",
-                            "items": {
-                                "$ref": "#/components/schemas/Key"
-                            }
+                    "oneOf": [
+                        {
+                            "$ref": "#/components/schemas/Error"
+                        },
+                        {
+                            "$ref": "#/components/schemas/Keys"
                         }
-                    }
+                    ]
                 }
             }
         },
@@ -181,6 +182,7 @@
                     "schema": {
                         "title": "createKeyParams",
                         "type": "object",
+                        "additionalProperties": true,
                         "properties": {
                             "name": {
                                 "title": "name",
@@ -214,7 +216,8 @@
                 "name": "result",
                 "schema": {
                     "title": "getConfigurationResult",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": true
                 }
             }
         },
@@ -227,6 +230,7 @@
                     "schema": {
                         "title": "setConfigurationParams",
                         "type": "object",
+                        "additionalProperties": true,
                         "description": "Configuration parameters to set"
                     }
                 }
@@ -235,6 +239,7 @@
                 "name": "result",
                 "schema": {
                     "title": "SetConfigurationResult",
+                    "additionalProperties": true,
                     "type": "object"
                 }
             }
@@ -248,6 +253,7 @@
                     "schema": {
                         "title": "subscribeTransactionsParams",
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "txIds": {
                                 "title": "txIds",
@@ -282,6 +288,7 @@
             "KeyIdentifierWithPublicKey": {
                 "title": "KeyIdentifierWithPublicKey",
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "publicKey": {
                         "title": "publicKey",
@@ -300,6 +307,7 @@
             "KeyIdentifierWithId": {
                 "title": "KeyIdentifierWithId",
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "publicKey": {
                         "title": "publicKey",
@@ -330,6 +338,7 @@
             "Key": {
                 "title": "Key",
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "id": {
                         "title": "id",
@@ -349,9 +358,26 @@
                 },
                 "required": ["id", "name", "publicKey"]
             },
-            "Error": {
+            "Keys": {
+                "title": "Keys",
                 "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "keys": {
+                        "title": "keysList",
+                        "type": "array",
+                        "description": "List of keys availabile at the Wallet Provider",
+                        "items": {
+                            "$ref": "#/components/schemas/Key"
+                        }
+                    }
+                },
+                "required": ["keys"]
+            },
+            "Error": {
                 "title": "Error",
+                "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "error": {
                         "title": "errorCode",
@@ -375,6 +401,7 @@
             "Transaction": {
                 "type": "object",
                 "title": "Transaction",
+                "additionalProperties": false,
                 "properties": {
                     "txId": {
                         "title": "txId",
@@ -398,6 +425,7 @@
                     "metadata": {
                         "title": "metadata",
                         "type": "object",
+                        "additionalProperties": true,
                         "description": "Additional metadata about the transaction."
                     }
                 },

--- a/core/signing-lib/src/rpc-gen/typings.ts
+++ b/core/signing-lib/src/rpc-gen/typings.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
  *
@@ -35,7 +36,6 @@ export type Id = string
 export interface KeyIdentifierWithPublicKey {
     publicKey: PublicKey
     id?: Id
-    [k: string]: any
 }
 /**
  *
@@ -45,7 +45,6 @@ export interface KeyIdentifierWithPublicKey {
 export interface KeyIdentifierWithId {
     publicKey?: PublicKey
     id: Id
-    [k: string]: any
 }
 /**
  *
@@ -59,6 +58,7 @@ export type KeyIdentifier = KeyIdentifierWithPublicKey | KeyIdentifierWithId
  *
  */
 export type InternalTxId = string
+type AlwaysTrue = any
 /**
  *
  * Unique identifier of the signed transaction given by the Signing Provider. This may not be the same as the internal txId given by the Wallet Gateway.
@@ -98,7 +98,6 @@ export type ErrorDescription = string
 export interface Error {
     error: ErrorCode
     error_description: ErrorDescription
-    [k: string]: any
 }
 /**
  *
@@ -126,7 +125,6 @@ export interface Transaction {
     signature?: Signature
     publicKey?: PublicKey
     metadata?: Metadata
-    [k: string]: any
 }
 /**
  *
@@ -136,20 +134,21 @@ export interface Transaction {
 export type Transactions = Transaction[]
 export interface TransactionsResult {
     transactions?: Transactions
-    [k: string]: any
 }
 export interface Key {
     id: Id
     name: Name
     publicKey: PublicKey
-    [k: string]: any
 }
 /**
  *
  * List of keys availabile at the Wallet Provider
  *
  */
-export type Keys = Key[]
+export type KeysList = Key[]
+export interface Keys {
+    keys: KeysList
+}
 export interface SignTransactionParams {
     tx: Tx
     txHash: TxHash
@@ -180,15 +179,11 @@ export interface SetConfigurationParams {
 }
 export interface SubscribeTransactionsParams {
     txIds: TxIds
-    [k: string]: any
 }
 export type SignTransactionResult = Error | Transaction
 export type GetTransactionResult = Error | Transaction
 export type GetTransactionsResult = Error | TransactionsResult
-export interface GetKeysResult {
-    keys?: Keys
-    [k: string]: any
-}
+export type GetKeysResult = Error | Keys
 export type CreateKeyResult = Error | Key
 export interface GetConfigurationResult {
     [key: string]: any
@@ -202,7 +197,6 @@ export interface SubscribeTransactionsResult {
     signature?: Signature
     publicKey?: PublicKey
     metadata?: Metadata
-    [k: string]: any
 }
 /**
  *

--- a/wallet-gateway/remote/src/ledger/wallet-sync-service.test.ts
+++ b/wallet-gateway/remote/src/ledger/wallet-sync-service.test.ts
@@ -154,6 +154,12 @@ describe('WalletSyncService - resolveSigningProvider', () => {
         const controller = internalDriver.controller(authContext.userId)
         const key = await controller.createKey({ name: 'test-key' })
 
+        if ('error' in key) {
+            throw new Error(
+                `Failed to create key in test: ${key.error_description}`
+            )
+        }
+
         const namespace = partyAllocator.createFingerprintFromKey(key.publicKey)
 
         mockLedgerGet.mockResolvedValueOnce({

--- a/wallet-gateway/remote/src/user-api/controller.ts
+++ b/wallet-gateway/remote/src/user-api/controller.ts
@@ -55,8 +55,8 @@ import {
     type PrepareParams,
     ledgerPrepareParams,
 } from '../utils.js'
-import { StatusEvent } from '../dapp-api/rpc-gen/typings.js'
 import { v4 } from 'uuid'
+import { Error } from '@canton-network/core-signing-lib'
 
 type AvailableSigningDrivers = Partial<
     Record<SigningProvider, SigningDriverInterface>
@@ -77,6 +77,15 @@ export const userController = (
         version: 'TODO',
         providerType: kernelInfo.clientType,
         userUrl: `${userUrl}/login/`,
+    }
+
+    function handleSigningError<T extends object>(result: Error | T): T {
+        if ('error' in result) {
+            throw new Error(
+                `Error from signing driver: ${result.error_description}`
+            )
+        }
+        return result
     }
 
     return buildController({
@@ -197,22 +206,32 @@ export const userController = (
                     break
                 }
                 case SigningProvider.WALLET_KERNEL: {
-                    const key = await driver.createKey({
-                        name: partyHint,
-                    })
+                    const key = await driver
+                        .createKey({
+                            name: partyHint,
+                        })
+                        .then(handleSigningError)
 
                     party = await partyAllocator.allocateParty(
                         userId,
                         partyHint,
                         key.publicKey,
                         async (hash) => {
-                            const { signature } = await driver.signTransaction({
-                                tx: '',
-                                txHash: hash,
-                                keyIdentifier: {
-                                    publicKey: key.publicKey,
-                                },
-                            })
+                            const { signature } = await driver
+                                .signTransaction({
+                                    tx: '',
+                                    txHash: hash,
+                                    keyIdentifier: {
+                                        publicKey: key.publicKey,
+                                    },
+                                })
+                                .then(handleSigningError)
+
+                            if (!signature) {
+                                throw new Error(
+                                    'No signature returned from signing driver'
+                                )
+                            }
 
                             return signature
                         }
@@ -223,11 +242,12 @@ export const userController = (
                 case SigningProvider.BLOCKDAEMON: {
                     if (signingProviderContext?.externalTxId) {
                         walletStatus = 'initialized'
-                        const { signature, status } =
-                            await driver.getTransaction({
+                        const { signature } = await driver
+                            .getTransaction({
                                 userId,
                                 txId: signingProviderContext.externalTxId,
                             })
+                            .then(handleSigningError)
 
                         if (!['pending', 'signed'].includes(status)) {
                             await store.removeWallet(
@@ -286,8 +306,8 @@ export const userController = (
                             .substring(0, 16)
                         const txPayload = JSON.stringify(topologyTransactions)
 
-                        const { status, txId: id } =
-                            await driver.signTransaction({
+                        const { status, txId: id } = await driver
+                            .signTransaction({
                                 tx: Buffer.from(txPayload).toString('base64'),
                                 txHash: transactions.multiHash,
                                 keyIdentifier: {
@@ -295,12 +315,22 @@ export const userController = (
                                 },
                                 internalTxId,
                             })
+                            .then(handleSigningError)
 
                         if (status === 'signed') {
-                            const { signature } = await driver.getTransaction({
-                                userId,
-                                txId: id,
-                            })
+                            const { signature } = await driver
+                                .getTransaction({
+                                    userId,
+                                    txId: id,
+                                })
+                                .then(handleSigningError)
+
+                            if (!signature) {
+                                throw new Error(
+                                    'Transaction signed but no signature found in result'
+                                )
+                            }
+
                             partyId =
                                 await partyAllocator.allocatePartyWithExistingWallet(
                                     namespace,
@@ -323,7 +353,8 @@ export const userController = (
                     break
                 }
                 case SigningProvider.FIREBLOCKS: {
-                    const keys = await driver.getKeys()
+                    const keys = await driver.getKeys().then(handleSigningError)
+
                     const key = keys?.keys?.find(
                         (k) => k.name === 'Canton Party'
                     )
@@ -331,11 +362,12 @@ export const userController = (
 
                     if (signingProviderContext) {
                         walletStatus = 'initialized'
-                        const { signature, status } =
-                            await driver.getTransaction({
+                        const { signature, status } = await driver
+                            .getTransaction({
                                 userId,
                                 txId: signingProviderContext.externalTxId,
                             })
+                            .then(handleSigningError)
 
                         if (!['pending', 'signed'].includes(status)) {
                             await store.removeWallet(
@@ -379,8 +411,8 @@ export const userController = (
                             transactions.topologyTransactions!
                         let partyId = ''
 
-                        const { status, txId: id } =
-                            await driver.signTransaction({
+                        const { status, txId: id } = await driver
+                            .signTransaction({
                                 tx: '',
                                 txHash: Buffer.from(
                                     transactions.multiHash,
@@ -390,11 +422,21 @@ export const userController = (
                                     publicKey: key.publicKey,
                                 },
                             })
+                            .then(handleSigningError)
                         if (status === 'signed') {
-                            const { signature } = await driver.getTransaction({
-                                userId,
-                                txId: id,
-                            })
+                            const { signature } = await driver
+                                .getTransaction({
+                                    userId,
+                                    txId: id,
+                                })
+                                .then(handleSigningError)
+
+                            if (!signature) {
+                                throw new Error(
+                                    'Transaction signed but no signature found in result'
+                                )
+                            }
+
                             partyId =
                                 await partyAllocator.allocatePartyWithExistingWallet(
                                     namespace,
@@ -514,15 +556,17 @@ export const userController = (
                     }
                 }
                 case SigningProvider.WALLET_KERNEL: {
-                    const signature = await driver.signTransaction({
-                        tx: preparedTransaction,
-                        txHash: preparedTransactionHash,
-                        keyIdentifier: {
-                            publicKey: wallet.publicKey,
-                        },
-                    })
+                    const { signature } = await driver
+                        .signTransaction({
+                            tx: preparedTransaction,
+                            txHash: preparedTransactionHash,
+                            keyIdentifier: {
+                                publicKey: wallet.publicKey,
+                            },
+                        })
+                        .then(handleSigningError)
 
-                    if (!signature.signature) {
+                    if (!signature) {
                         throw new Error(
                             'Failed to sign transaction: ' +
                                 JSON.stringify(signature)
@@ -549,7 +593,7 @@ export const userController = (
                     notifier.emit('txChanged', signedTx)
 
                     return {
-                        signature: signature.signature,
+                        signature,
                         signedBy: wallet.namespace,
                         partyId: wallet.partyId,
                     }
@@ -559,22 +603,26 @@ export const userController = (
                         .randomUUID()
                         .replace(/-/g, '')
                         .substring(0, 16)
-                    let result = await driver.signTransaction({
-                        tx: preparedTransaction,
-                        txHash: preparedTransactionHash,
-                        keyIdentifier: {
-                            publicKey: wallet.publicKey,
-                        },
-                        internalTxId,
-                    })
+                    let result = await driver
+                        .signTransaction({
+                            tx: preparedTransaction,
+                            txHash: preparedTransactionHash,
+                            keyIdentifier: {
+                                publicKey: wallet.publicKey,
+                            },
+                            internalTxId,
+                        })
+                        .then(handleSigningError)
 
                     if (result.status === 'pending' && result.txId) {
                         for (let i = 0; i < 60; i++) {
                             await new Promise((r) => setTimeout(r, 1000))
-                            result = await driver.getTransaction({
-                                userId,
-                                txId: result.txId,
-                            })
+                            result = await driver
+                                .getTransaction({
+                                    userId,
+                                    txId: result.txId,
+                                })
+                                .then(handleSigningError)
                             if (result.status === 'signed') break
                         }
                     }


### PR DESCRIPTION
Same as #1259 , but specifically for the signing RPC. Made a separate PR b/c these changes required more implementation changes, so should have a more focused review. 