### PR TITLE
refactor(wallet-gateway-remote): migrate frontend styles from custom css to bootstrap

### DIFF
--- a/core/wallet-ui-components/src/index.ts
+++ b/core/wallet-ui-components/src/index.ts
@@ -20,3 +20,5 @@ export * from './windows/discovery.js'
 export * from './windows/popup.js'
 
 export * from './handle-errors.js'
+
+export { BaseElement } from './internal/base-element.js'

--- a/wallet-gateway/remote/src/web/frontend/404/index.html
+++ b/wallet-gateway/remote/src/web/frontend/404/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Wallet Kernel - Not found</title>
         <script type="module" src="/index.ts"></script>
         <script type="module" src="/404/index.ts"></script>

--- a/wallet-gateway/remote/src/web/frontend/404/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/404/index.ts
@@ -2,35 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@canton-network/core-wallet-ui-components'
-import { html, css, LitElement } from 'lit'
+import { BaseElement } from '@canton-network/core-wallet-ui-components'
+import { html, css } from 'lit'
 import { customElement } from 'lit/decorators.js'
-import '/index.css'
 import '../index'
 
 @customElement('user-ui-404')
-export class ApproveUi extends LitElement {
-    static styles = css`
-        :host {
-            display: block;
-            box-sizing: border-box;
-            padding: 0rem;
-            max-width: 900px;
-            margin: 20% auto;
-            font-family: var(--swk-font, Arial, sans-serif);
-            color: var(--text-color, #222);
-            padding: 20px;
-        }
-    `
-
-    connectedCallback(): void {
-        super.connectedCallback()
-    }
+export class NotFoundUi extends BaseElement {
+    static styles = [
+        BaseElement.styles,
+        css`
+            :host {
+                display: block;
+                max-width: 900px;
+                margin: 20% auto;
+                padding: 20px;
+            }
+        `,
+    ]
 
     protected render() {
-        return html`
-            <div class="wrapper">
-                <not-found href="/"></not-found>
-            </div>
-        `
+        return html`<not-found href="/"></not-found>`
     }
 }

--- a/wallet-gateway/remote/src/web/frontend/approve/index.html
+++ b/wallet-gateway/remote/src/web/frontend/approve/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Wallet Kernel - Approve Write Request</title>
         <script type="module" src="/index.ts"></script>
         <script type="module" src="/approve/index.ts"></script>

--- a/wallet-gateway/remote/src/web/frontend/approve/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/approve/index.ts
@@ -1,10 +1,12 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { html, css, LitElement, nothing } from 'lit'
+import { html, css, nothing } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
-import '@canton-network/core-wallet-ui-components'
-import { handleErrorToast } from '@canton-network/core-wallet-ui-components'
+import {
+    BaseElement,
+    handleErrorToast,
+} from '@canton-network/core-wallet-ui-components'
 import { createUserClient } from '../rpc-client'
 import { stateManager } from '../state-manager'
 import '../index'
@@ -14,7 +16,7 @@ import {
 } from '../transactions/decode'
 
 @customElement('user-ui-approve')
-export class ApproveUi extends LitElement {
+export class ApproveUi extends BaseElement {
     @state() accessor loading = false
     @state() accessor commandId = ''
     @state() accessor partyId = ''
@@ -28,160 +30,26 @@ export class ApproveUi extends LitElement {
     @state() accessor signedAt: string | null = null
     @state() accessor origin: string | null = null
 
-    static styles = css`
-        :host {
-            display: block;
-            box-sizing: border-box;
-            padding: 0rem;
-            max-width: 900px;
-            margin: 0 auto;
-            font-family: var(--swk-font, Arial, sans-serif);
-            color: var(--text-color, #222);
-        }
-
-        :host([theme='dark']) {
-            --card-bg: #1e1e1e;
-            --border-color: #333;
-            --text-color: #fff;
-            --button-bg: #4caf50;
-            --button-hover: #66bb6a;
-            --message-info: #81c784;
-            --message-error: #ff6b6b;
-        }
-
-        :host(:not([theme='dark'])) {
-            --card-bg: #fff;
-            --border-color: #ddd;
-            --text-color: #222;
-            --button-bg: #4caf50;
-            --button-hover: #43a047;
-            --message-info: #388e3c;
-            --message-error: #d32f2f;
-        }
-
-        .card {
-            background: var(--card-bg);
-            border: 1px solid var(--border-color);
-            border-radius: 16px;
-            padding: 1.5rem;
-            width: 100%;
-            box-sizing: border-box;
-            display: flex;
-            flex-direction: column;
-            gap: 1rem;
-            overflow-x: hidden;
-            word-break: break-word;
-            margin-top: 2rem;
-        }
-
-        h1 {
-            font-size: 1.25rem;
-            margin: 0;
-        }
-
-        h2 {
-            font-size: 1rem;
-            margin: 0.5rem 0 0.25rem 0;
-        }
-
-        h3 {
-            font-size: 0.875rem;
-            margin: 0.25rem 0;
-        }
-
-        p {
-            font-size: 0.85rem;
-            margin: 0.25rem 0;
-            word-break: break-word;
-        }
-
-        .tx-box {
-            background: rgba(0, 0, 0, 0.05);
-            border-radius: 8px;
-            padding: 0.5rem;
-            max-height: 150px;
-            overflow-y: auto;
-            overflow-x: auto;
-            font-family: monospace;
-            color: var(--text-color);
-            word-break: break-word;
-        }
-
-        .section-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            gap: 0.5rem;
-        }
-
-        .copy-btn {
-            background: transparent;
-            border: 1px solid var(--border-color);
-            padding: 0.25rem 0.5rem;
-            font-size: 0.75rem;
-            color: var(--text-color);
-            cursor: pointer;
-            border-radius: 4px;
-            transition: all 0.2s ease;
-        }
-
-        .copy-btn:hover {
-            background: var(--button-bg);
-            border-color: var(--button-bg);
-            color: white;
-        }
-
-        button {
-            padding: 0.75rem;
-            border-radius: 8px;
-            border: none;
-            cursor: pointer;
-            background: var(--button-bg);
-            color: white;
-            font-weight: 600;
-            font-size: 1rem;
-            transition: background 0.2s ease;
-        }
-
-        button:hover {
-            background: var(--button-hover);
-        }
-
-        button[disabled] {
-            opacity: 0.6;
-            cursor: not-allowed;
-        }
-
-        .message {
-            padding: 0.5rem;
-            border-radius: 6px;
-            font-size: 0.875rem;
-        }
-
-        .message.info {
-            background-color: var(--message-info);
-            color: white;
-        }
-
-        .message.error {
-            background-color: var(--message-error);
-            color: white;
-        }
-
-        @media (max-width: 480px) {
-            .card {
-                padding: 1rem;
+    static styles = [
+        BaseElement.styles,
+        css`
+            :host {
+                display: block;
+                max-width: 900px;
+                margin: 0 auto;
             }
-
-            h1 {
-                font-size: 1.1rem;
+            .tx-box {
+                background: var(--bs-tertiary-bg, rgba(0, 0, 0, 0.05));
+                border-radius: var(--bs-border-radius);
+                padding: 0.5rem;
+                max-height: 150px;
+                overflow-y: auto;
+                overflow-x: auto;
+                font-family: var(--bs-font-monospace);
+                word-break: break-word;
             }
-
-            button {
-                font-size: 0.95rem;
-            }
-        }
-    `
+        `,
+    ]
 
     connectedCallback(): void {
         super.connectedCallback()
@@ -271,96 +139,109 @@ export class ApproveUi extends LitElement {
 
     protected render() {
         return html`
-            <div class="card">
-                <h1>Pending Transaction Request</h1>
+            <div class="card mt-4 overflow-hidden">
+                <div class="card-body text-break">
+                    <h1 class="card-title h5">Pending Transaction Request</h1>
 
-                <h2>Transaction Details</h2>
+                    <h2 class="h6 mt-3">Transaction Details</h2>
 
-                <h3>Command Id</h3>
-                <p>${this.commandId}</p>
+                    <h3 class="h6 mt-3">Command Id</h3>
+                    <p>${this.commandId}</p>
 
-                <h3>Status</h3>
-                <p>${this.status}</p>
+                    <h3 class="h6 mt-3">Status</h3>
+                    <p>${this.status}</p>
 
-                ${this.createdAt
-                    ? html`<h3>Created At</h3>
-                          <p>${this.createdAt}</p>`
-                    : nothing}
-                ${this.signedAt
-                    ? html`<h3>Signed At</h3>
-                          <p>${this.signedAt}</p>`
-                    : nothing}
-                ${this.origin
-                    ? html`<h3>Origin</h3>
-                          <p>${this.origin}</p>`
-                    : nothing}
+                    ${this.createdAt
+                        ? html`<h3 class="h6 mt-3">Created At</h3>
+                              <p>${this.createdAt}</p>`
+                        : nothing}
+                    ${this.signedAt
+                        ? html`<h3 class="h6 mt-3">Signed At</h3>
+                              <p>${this.signedAt}</p>`
+                        : nothing}
+                    ${this.origin
+                        ? html`<h3 class="h6 mt-3">Origin</h3>
+                              <p>${this.origin}</p>`
+                        : nothing}
 
-                <h3>Template</h3>
-                <p>
-                    ${this.txParsed?.packageName || 'N/A'}:${this.txParsed
-                        ?.moduleName || 'N/A'}:${this.txParsed?.entityName ||
-                    'N/A'}
-                </p>
+                    <h3 class="h6 mt-3">Template</h3>
+                    <p>
+                        ${this.txParsed?.packageName || 'N/A'}:${this.txParsed
+                            ?.moduleName || 'N/A'}:${this.txParsed
+                            ?.entityName || 'N/A'}
+                    </p>
 
-                <h3>Signatories</h3>
-                <ul>
-                    ${this.txParsed?.signatories?.map(
-                        (signatory) => html`<li>${signatory}</li>`
-                    ) || html`<li>N/A</li>`}
-                </ul>
+                    <h3 class="h6 mt-3">Signatories</h3>
+                    <ul>
+                        ${this.txParsed?.signatories?.map(
+                            (signatory) => html`<li>${signatory}</li>`
+                        ) || html`<li>N/A</li>`}
+                    </ul>
 
-                <h3>Stakeholders</h3>
-                <ul>
-                    ${this.txParsed?.stakeholders?.map(
-                        (stakeholder) => html`<li>${stakeholder}</li>`
-                    ) || html`<li>N/A</li>`}
-                </ul>
+                    <h3 class="h6 mt-3">Stakeholders</h3>
+                    <ul>
+                        ${this.txParsed?.stakeholders?.map(
+                            (stakeholder) => html`<li>${stakeholder}</li>`
+                        ) || html`<li>N/A</li>`}
+                    </ul>
 
-                <h3>Transaction Hash</h3>
-                <p>${this.txHash}</p>
+                    <h3 class="h6 mt-3">Transaction Hash</h3>
+                    <p>${this.txHash}</p>
 
-                <div class="section-header">
-                    <h3>Base64 Transaction</h3>
-                    <button
-                        class="copy-btn"
-                        @click=${() => this._copyToClipboard(this.tx)}
-                        title="Copy to clipboard"
+                    <div
+                        class="d-flex justify-content-between align-items-center gap-2 mt-3"
                     >
-                        📋 Copy
-                    </button>
-                </div>
-                <div class="tx-box">${this.tx}</div>
+                        <h3 class="h6 mb-0">Base64 Transaction</h3>
+                        <button
+                            class="btn btn-sm btn-outline-secondary"
+                            @click=${() => this._copyToClipboard(this.tx)}
+                            title="Copy to clipboard"
+                        >
+                            Copy
+                        </button>
+                    </div>
+                    <div class="tx-box">${this.tx}</div>
 
-                <div class="section-header">
-                    <h3>Decoded Transaction</h3>
-                    <button
-                        class="copy-btn"
-                        @click=${() =>
-                            this._copyToClipboard(
-                                this.txParsed?.jsonString || ''
-                            )}
-                        title="Copy to clipboard"
+                    <div
+                        class="d-flex justify-content-between align-items-center gap-2 mt-3"
                     >
-                        📋 Copy
-                    </button>
-                </div>
-                <div class="tx-box">${this.txParsed?.jsonString || 'N/A'}</div>
+                        <h3 class="h6 mb-0">Decoded Transaction</h3>
+                        <button
+                            class="btn btn-sm btn-outline-secondary"
+                            @click=${() =>
+                                this._copyToClipboard(
+                                    this.txParsed?.jsonString || ''
+                                )}
+                            title="Copy to clipboard"
+                        >
+                            Copy
+                        </button>
+                    </div>
+                    <div class="tx-box">
+                        ${this.txParsed?.jsonString || 'N/A'}
+                    </div>
 
-                ${this.status === 'executed'
-                    ? nothing
-                    : html`
-                          <button
-                              ?disabled=${this.loading}
-                              @click=${this.handleExecute}
+                    ${this.status === 'executed'
+                        ? nothing
+                        : html`
+                              <button
+                                  class="btn btn-primary w-100 mt-3"
+                                  ?disabled=${this.loading}
+                                  @click=${this.handleExecute}
+                              >
+                                  ${this.loading ? 'Processing...' : 'Approve'}
+                              </button>
+                          `}
+                    ${this.message
+                        ? html`<div
+                              class="alert ${this.messageType === 'error'
+                                  ? 'alert-danger'
+                                  : 'alert-success'} mt-3"
                           >
-                              ${this.loading ? 'Processing...' : 'Approve'}
-                          </button>
-                      `}
-                ${this.message
-                    ? html`<div class="message ${this.messageType}">
-                          ${this.message}
-                      </div>`
-                    : null}
+                              ${this.message}
+                          </div>`
+                        : null}
+                </div>
             </div>
         `
     }

--- a/wallet-gateway/remote/src/web/frontend/callback/index.html
+++ b/wallet-gateway/remote/src/web/frontend/callback/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Wallet Kernel Remote Callback</title>
     </head>
     <body>

--- a/wallet-gateway/remote/src/web/frontend/index.css
+++ b/wallet-gateway/remote/src/web/frontend/index.css
@@ -1,3 +1,0 @@
-body {
-    margin: 0;
-}

--- a/wallet-gateway/remote/src/web/frontend/index.html
+++ b/wallet-gateway/remote/src/web/frontend/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Wallet Kernel Remote</title>
         <script type="module" src="/index.ts"></script>
         <base href="/" />

--- a/wallet-gateway/remote/src/web/frontend/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/index.ts
@@ -6,8 +6,6 @@ import { customElement } from 'lit/decorators.js'
 import { createUserClient, attemptRemoveSession } from './rpc-client'
 
 import '@canton-network/core-wallet-ui-components'
-import '@canton-network/core-wallet-ui-components/dist/index.css'
-import '/index.css'
 import { stateManager } from './state-manager'
 import { WalletEvent } from '@canton-network/core-types'
 import {

--- a/wallet-gateway/remote/src/web/frontend/login/index.html
+++ b/wallet-gateway/remote/src/web/frontend/login/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Wallet Kernel Login</title>
         <script type="module" src="/index.ts"></script>
         <script type="module" src="/login/login.ts"></script>

--- a/wallet-gateway/remote/src/web/frontend/login/login.ts
+++ b/wallet-gateway/remote/src/web/frontend/login/login.ts
@@ -1,10 +1,14 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { html, css, LitElement } from 'lit'
+import { html, css } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
 
 import '@canton-network/core-wallet-ui-components'
+import {
+    BaseElement,
+    handleErrorToast,
+} from '@canton-network/core-wallet-ui-components'
 import { createUserClient } from '../rpc-client'
 import { Idp, Network } from '@canton-network/core-wallet-user-rpc-client'
 import { stateManager } from '../state-manager'
@@ -14,10 +18,9 @@ import {
     ClientCredentials,
 } from '@canton-network/core-wallet-auth'
 import { redirectToIntendedOrDefault, addUserSession } from '../index'
-import { handleErrorToast } from '@canton-network/core-wallet-ui-components'
 
 @customElement('user-ui-login')
-export class LoginUI extends LitElement {
+export class LoginUI extends BaseElement {
     @state()
     accessor networks: Network[] = []
 
@@ -36,162 +39,20 @@ export class LoginUI extends LitElement {
     @state()
     accessor messageType: 'error' | 'info' | null = null
 
-    static styles = css`
-        :host {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            width: 100%;
-            padding: 1.5rem;
-            box-sizing: border-box;
-            color: var(--text-color, #222);
-            background: transparent;
-        }
-
-        :host([theme='dark']) {
-            --card-bg: #1e1e1e;
-            --text-color: #fff;
-            --border-color: #333;
-            --button-bg: #4caf50;
-            --button-hover: #66bb6a;
-            --error-color: #ff6b6b;
-            --info-color: #81c784;
-        }
-
-        :host(:not([theme='dark'])) {
-            --card-bg: #fff;
-            --border-color: #ddd;
-            --button-bg: #4caf50;
-            --button-hover: #43a047;
-            --error-color: #d32f2f;
-            --info-color: #388e3c;
-        }
-
-        .card {
-            background: var(--card-bg);
-            border: 1px solid var(--border-color);
-            border-radius: 16px;
-            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-            padding: 1.5rem;
-            width: 100%;
-            max-width: 360px;
-            display: flex;
-            flex-direction: column;
-            gap: 1rem;
-            text-align: center;
-            box-sizing: border-box;
-        }
-
-        h1 {
-            font-size: 1.25rem;
-            margin: 0.25rem 0 0.5rem 0;
-        }
-
-        select {
-            appearance: none;
-            padding: 0.6rem 0.75rem;
-            border-radius: 8px;
-            border: 1px solid var(--border-color);
-            background: var(--card-bg);
-            color: var(--text-color);
-            font-size: 1rem;
-            cursor: pointer;
-            outline: none;
-            transition: border 0.2s ease;
-            width: 100%;
-            box-sizing: border-box;
-        }
-
-        select:focus {
-            border-color: #4caf50;
-        }
-
-        input[type='text'] {
-            appearance: none;
-            padding: 0.6rem 0.75rem;
-            border-radius: 8px;
-            border: 1px solid var(--border-color);
-            background: var(--card-bg);
-            color: var(--text-color);
-            font-size: 1rem;
-            cursor: pointer;
-            outline: none;
-            transition: border 0.2s ease;
-            width: 100%;
-            box-sizing: border-box;
-        }
-
-        input[type='text']:focus {
-            border-color: #4caf50;
-        }
-
-        button {
-            padding: 0.7rem;
-            border-radius: 8px;
-            border: none;
-            cursor: pointer;
-            background: var(--button-bg);
-            color: white;
-            font-weight: 600;
-            font-size: 1rem;
-            transition: background 0.2s ease;
-            width: 100%;
-        }
-
-        button:hover {
-            background: var(--button-hover);
-        }
-
-        .message {
-            font-size: 0.85rem;
-            border-radius: 6px;
-            padding: 0.5rem;
-            text-align: center;
-            transition: opacity 0.2s ease;
-        }
-
-        .message.error {
-            color: var(--error-color);
-            background-color: color-mix(
-                in srgb,
-                var(--error-color) 10%,
-                transparent
-            );
-        }
-
-        .message.info {
-            color: var(--info-color);
-            background-color: color-mix(
-                in srgb,
-                var(--info-color) 10%,
-                transparent
-            );
-        }
-
-        p {
-            font-size: 0.85rem;
-            color: var(--text-color);
-            opacity: 0.8;
-            margin-top: 0.25rem;
-        }
-
-        @media (max-width: 480px) {
-            .card {
-                border-radius: 12px;
-                padding: 1.25rem;
-                gap: 0.75rem;
+    static styles = [
+        BaseElement.styles,
+        css`
+            :host {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: 100%;
+                padding: 1.5rem;
+                box-sizing: border-box;
+                background: transparent;
             }
-
-            h1 {
-                font-size: 1.1rem;
-            }
-
-            button,
-            select {
-                font-size: 0.95rem;
-            }
-        }
-    `
+        `,
+    ]
 
     private handleChange(e: Event) {
         const index = parseInt((e.target as HTMLSelectElement).value)
@@ -323,45 +184,61 @@ export class LoginUI extends LitElement {
 
     protected render() {
         return html`
-            <div class="card">
-                <h1>Sign in to Canton Network</h1>
+            <div class="card shadow" style="max-width: 360px;">
+                <div class="card-body d-flex flex-column gap-3 text-center">
+                    <h1 class="card-title h5">Sign in to Canton Network</h1>
 
-                <select id="network" @change=${this.handleChange}>
-                    <option value="">Select Network</option>
-                    ${this.networks.map(
-                        (net, index) =>
-                            html`<option
-                                value=${index}
-                                ?disabled=${net.auth.method ==
-                                'client_credentials'}
-                            >
-                                ${net.name}
-                            </option>`
-                    )}
-                </select>
+                    <select
+                        id="network"
+                        class="form-select"
+                        @change=${this.handleChange}
+                    >
+                        <option value="">Select Network</option>
+                        ${this.networks.map(
+                            (net, index) =>
+                                html`<option
+                                    value=${index}
+                                    ?disabled=${net.auth.method ==
+                                    'client_credentials'}
+                                >
+                                    ${net.name}
+                                </option>`
+                        )}
+                    </select>
 
-                ${this.selectedIdp?.type === 'self_signed'
-                    ? html`
-                          <input
-                              type="text"
-                              title="client id"
-                              id="client-id"
-                              .value=${this.selectedNetwork?.auth.clientId ||
-                              ''}
-                          />
-                      `
-                    : null}
-                <button @click=${this.handleConnectToIDP}>Connect</button>
+                    ${this.selectedIdp?.type === 'self_signed'
+                        ? html`
+                              <input
+                                  type="text"
+                                  class="form-control"
+                                  title="client id"
+                                  id="client-id"
+                                  .value=${this.selectedNetwork?.auth
+                                      .clientId || ''}
+                              />
+                          `
+                        : null}
+                    <button
+                        class="btn btn-primary w-100"
+                        @click=${this.handleConnectToIDP}
+                    >
+                        Connect
+                    </button>
 
-                ${this.message
-                    ? html`<div class="message ${this.messageType}">
-                          ${this.message}
-                      </div>`
-                    : html`<p>
-                          ${this.selectedNetwork
-                              ? `Selected: ${this.selectedNetwork.name}`
-                              : `Please choose a network`}
-                      </p>`}
+                    ${this.message
+                        ? html`<div
+                              class="alert ${this.messageType === 'error'
+                                  ? 'alert-danger'
+                                  : 'alert-success'} py-2"
+                          >
+                              ${this.message}
+                          </div>`
+                        : html`<p class="text-body-secondary small mb-0">
+                              ${this.selectedNetwork
+                                  ? `Selected: ${this.selectedNetwork.name}`
+                                  : `Please choose a network`}
+                          </p>`}
+                </div>
             </div>
         `
     }

--- a/wallet-gateway/remote/src/web/frontend/settings/index.html
+++ b/wallet-gateway/remote/src/web/frontend/settings/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Wallet Kernel - Settings</title>
         <script type="module" src="/settings/index.ts"></script>
     </head>

--- a/wallet-gateway/remote/src/web/frontend/settings/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/settings/index.ts
@@ -3,6 +3,7 @@
 
 import '@canton-network/core-wallet-ui-components'
 import {
+    BaseElement,
     handleErrorToast,
     IdpAddEvent,
     IdpCardDeleteEvent,
@@ -10,7 +11,7 @@ import {
     NetworkEditSaveEvent,
 } from '@canton-network/core-wallet-ui-components'
 
-import { LitElement, html, css } from 'lit'
+import { html, css } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
 import {
     Network,
@@ -21,24 +22,23 @@ import {
 import UserApiClient from '@canton-network/core-wallet-user-rpc-client'
 
 import '../index'
-import '/index.css'
 import { stateManager } from '../state-manager'
 import { createUserClient } from '../rpc-client'
 
 import { Auth } from '@canton-network/core-wallet-auth'
 
 @customElement('user-ui-settings')
-export class UserUiSettings extends LitElement {
-    static styles = css`
-        :host {
-            display: block;
-            box-sizing: border-box;
-            padding: 0rem;
-            max-width: 900px;
-            margin: 0 auto;
-            font-family: var(--wg-theme-font-family, Arial, sans-serif);
-        }
-    `
+export class UserUiSettings extends BaseElement {
+    static styles = [
+        BaseElement.styles,
+        css`
+            :host {
+                display: block;
+                max-width: 900px;
+                margin: 0 auto;
+            }
+        `,
+    ]
 
     @state() accessor networks: Network[] = []
     @state() accessor sessions: Session[] = []

--- a/wallet-gateway/remote/src/web/frontend/transactions/index.html
+++ b/wallet-gateway/remote/src/web/frontend/transactions/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Wallet Kernel – Transactions</title>
         <script type="module" src="/transactions/index.ts"></script>
     </head>

--- a/wallet-gateway/remote/src/web/frontend/transactions/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/transactions/index.ts
@@ -1,10 +1,10 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { css, html, LitElement, nothing } from 'lit'
+import { css, html, nothing } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
 
-import '@canton-network/core-wallet-ui-components'
+import { BaseElement } from '@canton-network/core-wallet-ui-components'
 
 import { createUserClient } from '../rpc-client'
 
@@ -17,7 +17,7 @@ import {
 import { parsePreparedTransaction, PreparedTransactionParsed } from './decode'
 
 @customElement('user-ui-transactions')
-export class UserUiTransactions extends LitElement {
+export class UserUiTransactions extends BaseElement {
     @state()
     accessor transactions: Transaction[] = []
 
@@ -28,164 +28,83 @@ export class UserUiTransactions extends LitElement {
     @state()
     accessor loading = false
 
-    static styles = css`
-        :host {
-            display: block;
-            box-sizing: border-box;
-            max-width: 900px;
-            margin: 0 auto;
-            font-family: var(--wg-theme-font-family, Arial, sans-serif);
-        }
-        .header {
-            margin-bottom: 1rem;
-        }
-        .card-list {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-            gap: 1rem;
-            margin: 1rem 0;
-        }
-        .form-card,
-        .wallet-card {
-            background: #fff;
-            border-radius: 8px;
-            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-            padding: 1rem;
-            display: flex;
-            flex-direction: column;
-            gap: 0.5rem;
-            min-width: 0;
-        }
-        form {
-            display: flex;
-            flex-direction: column;
-            gap: 1rem;
-        }
-        label {
-            font-weight: 500;
-            margin-bottom: 0.2rem;
-        }
-        .form-control {
-            padding: 0.5rem;
-            border: 1px solid var(--splice-wk-border-color, #ccc);
-            border-radius: 4px;
-            font-size: 1rem;
-        }
-        .inline {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-        .buttons {
-            padding: 0.4rem 0.8rem;
-            font-size: 1rem;
-            border-radius: 4px;
-            border: 1px solid #ccc;
-            background: #f5f5f5;
-            cursor: pointer;
-            transition: background 0.2s;
-        }
-        .buttons:hover {
-            background: #e2e6ea;
-        }
-        .wallet-title {
-            font-size: 1.1rem;
-            font-weight: 600;
-            margin-bottom: 0.25rem;
-            color: #0052cc;
-            word-break: break-all;
-        }
-        .wallet-meta {
-            font-size: 0.95rem;
-            color: #555;
-            margin-bottom: 0.5rem;
-            word-break: break-all;
-        }
-        .wallet-actions {
-            display: flex;
-            gap: 0.5rem;
-            margin-top: 0.5rem;
-        }
-        .status {
-            font-size: 0.95rem;
-            color: #009900;
-        }
-        @media (max-width: 600px) {
-            .header h1 {
-                font-size: 1.2rem;
+    static styles = [
+        BaseElement.styles,
+        css`
+            :host {
+                display: block;
+                max-width: 900px;
+                margin: 0 auto;
             }
-            .card-list {
-                grid-template-columns: 1fr;
-            }
-            .wallet-card,
-            .form-card {
-                padding: 0.7rem;
-            }
-            .buttons {
-                font-size: 0.9rem;
-                padding: 0.3rem 0.6rem;
-            }
-        }
-    `
+        `,
+    ]
 
     protected render() {
         return html`
-            <div class="header">
-                <h1>Transactions</h1>
-            </div>
+            <h1 class="mb-3">Transactions</h1>
 
-            <div class="card-list">
+            <div class="row g-3">
                 ${this.transactions.map(
                     (tx) => html`
-                        <div class="wallet-card">
-                            <div class="wallet-title">${tx.commandId}</div>
-                            <div class="wallet-meta">
-                                <strong>Status:</strong>
-                                <span class="status"> ${tx.status} </span>
-                                <br />
-                                <strong>Template:</strong>
-                                ${this.parsedTransactions.get(tx.commandId)
-                                    ?.packageName ||
-                                'N/A'}:${this.parsedTransactions.get(
-                                    tx.commandId
-                                )?.moduleName ||
-                                'N/A'}:${this.parsedTransactions.get(
-                                    tx.commandId
-                                )?.entityName || 'N/A'}
-                                <br />
-                                <strong>Signatories:</strong>
-                                <ul>
-                                    ${this.parsedTransactions
-                                        .get(tx.commandId)
-                                        ?.signatories?.map(
-                                            (signatory) =>
-                                                html`<li>${signatory}</li>`
-                                        ) || html`<li>N/A</li>`}
-                                </ul>
-                                ${tx.createdAt
-                                    ? html`<br />
-                                          <strong>Created At:</strong>
-                                          ${tx.createdAt}`
-                                    : nothing}
-                                ${tx.signedAt
-                                    ? html`<br />
-                                          <strong>Signed At:</strong>
-                                          ${tx.signedAt}`
-                                    : nothing}
-                                ${tx.origin
-                                    ? html`<br />
-                                          <strong>Origin:</strong>
-                                          ${tx.origin}`
-                                    : nothing}
-                            </div>
-                            <div class="wallet-actions">
-                                <button
-                                    class="buttons"
-                                    @click=${() =>
-                                        (window.location.href = `/approve/index.html?commandId=${tx.commandId}`)}
-                                >
-                                    Review
-                                </button>
+                        <div class="col-md-6 col-lg-4">
+                            <div class="card shadow-sm">
+                                <div class="card-body">
+                                    <h5
+                                        class="card-title text-primary fw-semibold text-break"
+                                    >
+                                        ${tx.commandId}
+                                    </h5>
+                                    <p class="card-text text-muted text-break">
+                                        <strong>Status:</strong>
+                                        <span class="text-success">
+                                            ${tx.status}
+                                        </span>
+                                        <br />
+                                        <strong>Template:</strong>
+                                        ${this.parsedTransactions.get(
+                                            tx.commandId
+                                        )?.packageName ||
+                                        'N/A'}:${this.parsedTransactions.get(
+                                            tx.commandId
+                                        )?.moduleName ||
+                                        'N/A'}:${this.parsedTransactions.get(
+                                            tx.commandId
+                                        )?.entityName || 'N/A'}
+                                        <br />
+                                        <strong>Signatories:</strong>
+                                    </p>
+                                    <ul>
+                                        ${this.parsedTransactions
+                                            .get(tx.commandId)
+                                            ?.signatories?.map(
+                                                (signatory) =>
+                                                    html`<li>${signatory}</li>`
+                                            ) || html`<li>N/A</li>`}
+                                    </ul>
+                                    <p class="card-text text-muted text-break">
+                                        ${tx.createdAt
+                                            ? html`<strong>Created At:</strong>
+                                                  ${tx.createdAt}<br />`
+                                            : nothing}
+                                        ${tx.signedAt
+                                            ? html`<strong>Signed At:</strong>
+                                                  ${tx.signedAt}<br />`
+                                            : nothing}
+                                        ${tx.origin
+                                            ? html`<strong>Origin:</strong>
+                                                  ${tx.origin}`
+                                            : nothing}
+                                    </p>
+                                    <div class="d-flex gap-2 mt-2">
+                                        <button
+                                            class="btn btn-sm btn-outline-secondary"
+                                            @click=${() =>
+                                                (window.location.href = `/approve/index.html?commandId=${tx.commandId}`)}
+                                        >
+                                            Review
+                                        </button>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     `

--- a/wallet-gateway/remote/src/web/frontend/wallets/index.html
+++ b/wallet-gateway/remote/src/web/frontend/wallets/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Wallet Kernel – Wallets</title>
         <script type="module" src="/wallets/index.ts"></script>
     </head>


### PR DESCRIPTION
Main things I did are:
- Export BaseElement from core-wallet-ui-components
- Migrate wallets/*.ts extending LitElement to extending BaseElement
- Replace all custom CSS classes with Bootstrap equivalents
- Delete unused/stale/duplicate CSS imports
- Rename misleading ApproveUi in 404/index.ts to NotFoundUi

It's not a direct translation at the moment (see screenshots below) and I didn't want to put it more effect to replicate exactly what we had before because we are about to redesign it all.

<img width="1033" height="945" alt="screenshot-2026-02-09_17-10-57" src="https://github.com/user-attachments/assets/0566618a-70d4-4ab8-a76e-f94656d1838c" />
<img width="1091" height="1125" alt="screenshot-2026-02-09_17-10-18" src="https://github.com/user-attachments/assets/40739353-bd77-4cc7-82af-d7e0a4ed06a2" />
<img width="1091" height="1125" alt="screenshot-2026-02-09_17-10-10" src="https://github.com/user-attachments/assets/e0d80576-0635-4893-accc-814e618c4cec" />
<img width="1091" height="1125" alt="screenshot-2026-02-09_17-09-58" src="https://github.com/user-attachments/assets/20e8b100-dab0-4aae-8234-4831f0d899e7" />
<img width="1911" height="1050" alt="screenshot-2026-02-09_17-09-40" src="https://github.com/user-attachments/assets/0a6c0dd5-c484-4c74-bcaa-7f5caee532b8" />
<img width="1911" height="1050" alt="screenshot-2026-02-09_17-09-33" src="https://github.com/user-attachments/assets/5d09da1b-85ac-42c0-9ee5-f251ba0b8b52" />
<img width="1911" height="1050" alt="screenshot-2026-02-09_17-09-24" src="https://github.com/user-attachments/assets/73e04ba3-af17-44bb-ba95-46b3aca7ba8b" />
<img width="1911" height="1050" alt="screenshot-2026-02-09_17-09-14" src="https://github.com/user-attachments/assets/bcbdbfd7-1b20-4e7a-a778-4c9543ce4793" />
