### PR TITLE
fix: fetch localnet script type declaration

### DIFF
--- a/scripts/src/fetch-localnet.ts
+++ b/scripts/src/fetch-localnet.ts
@@ -5,7 +5,7 @@ import {
     error,
     ensureDir,
     downloadAndUnpackTarball,
-    Network,
+    type Network,
     SUPPORTED_VERSIONS,
     getNetworkArg,
     hasFlag,


### PR DESCRIPTION
Correct the type declaration for the `Network` import in the fetch localnet script. This seems to fix the `script:fetch:localnet` command which currently complains about the Network import