### PR TITLE
fix(wallet-gateway-remote): build relative paths for vite assets

### DIFF
--- a/wallet-gateway/remote/vite.config.ts
+++ b/wallet-gateway/remote/vite.config.ts
@@ -9,6 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
     root: 'src/web/frontend',
+    base: './',
     build: {
         outDir: resolve(__dirname, './dist/web/frontend'),
         emptyOutDir: true,


### PR DESCRIPTION
changes the build output in `dist/` to relative asset pathing. for example:

`index.html` goes from 

```html
      <script type="module" crossorigin src="/assets/index-CQrtnMOY.js"></script>
```

to

```html
      <script type="module" crossorigin src="./assets/index-CQrtnMOY.js"></script>
```

And child pages (like `404/index.html`) also path correctly:

```html
      <script type="module" crossorigin src="../assets/404-D_79zQBx.js"></script>
      <link rel="modulepreload" crossorigin href="../assets/index-CQrtnMOY.js">

```