### PR TITLE
feat: add docs snippet sync pipeline and new documentation snippets

### DIFF
--- a/.github/workflows/update-docs-snippets.yml
+++ b/.github/workflows/update-docs-snippets.yml
@@ -1,0 +1,49 @@
+name: Update Docs Snippets
+
+on:
+    workflow_dispatch:
+
+    push:
+        branches:
+            - main
+        paths:
+            - docs/wallet-integration-guide/examples/snippets/**
+            - docs/wallet-integration-guide/examples/scripts/**
+
+jobs:
+    update-snippets:
+        if: vars.ENABLE_SYNC_PROCESS == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v5
+
+            - name: Extract Snippet data
+              run: node docs/scripts/generateOutputDocs.js
+
+            - name: Store Artifact output
+              id: store-artifact
+              uses: actions/upload-artifact@v7
+              with:
+                  name: splice-wallet-kernel-snippets
+                  path: docs-output/
+              env:
+                  main_repo_token: ${{ secrets.SOURCE_REPO_TOKEN }}
+
+            - name: Prepare additional params
+              id: additional-params
+              run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+            - name: Update Main Docs Repo
+              uses: passeidireto/trigger-external-workflow-action@main
+              env:
+                  PAYLOAD_run-id: ${{ github.run_id }}
+                  PAYLOAD_artifact-id: ${{ steps.store-artifact.outputs.artifact-id }}
+                  PAYLOAD_repo-name: ${{ vars.SOURCE_REPO_NAME }}
+                  PAYLOAD_repo-org: ${{ vars.SOURCE_REPO_ORG }}
+                  PAYLOAD_repo-version: ${{ vars.SOURCE_REPO_VERSION }}
+                  PAYLOAD_trigger_sha_short: ${{ steps.additional-params.outputs.short_sha }}
+              with:
+                  repository: ${{ vars.MAIN_REPO_ORG }}/${{ vars.MAIN_REPO_NAME }}
+                  event: update_snippets
+                  github_pat: ${{ secrets.MAIN_DOCS_REPO_TOKEN }}

--- a/docs/config/exportConfig.json
+++ b/docs/config/exportConfig.json
@@ -1,0 +1,904 @@
+{
+    "snippets": [
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/01-auth",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/01-auth.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "SDK auth, connect to ledger/admin/topology, generate external party, submit ping command.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/02-auth-localnet",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/02-auth-localnet.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Auth on localnet: allocate external party with signAndAllocateExternalParty.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/03-ping-localnet",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/03-ping-localnet.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Create and submit ping command.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/04-token-standard-localnet.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Token standard on localnet: two parties, list holdings, transfer.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/05-token-standard-transfer-autoaccept.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Token standard transfer with auto-accept between sender and receiver.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/06-multi-hosted-party.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Multi-hosted party setup with multiple key pairs and observer participant.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/07-token-standard-reject-expire-withdraw-localnet",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/07-token-standard-reject-expire-withdraw-localnet.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Token standard: reject, expire, and withdraw transfer instructions; list locked/unlocked holdings.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/08-offline-signing-localnet",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/08-offline-signing-localnet.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Offline signing: online SDK prepares, offline signs, online executes.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/09-token-standard-allocation-localnet",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/09-token-standard-allocation-localnet.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Token standard: allocation, upload DAR, tap coins, list holdings.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/10-idempotent-and-error-localnet",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/10-idempotent-and-error-localnet.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Idempotency and error handling for submissions.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/11-multi-user-setup",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/11-multi-user-setup.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Multi-user setup.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/12-integration-extensions",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/12-integration-extensions.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Integration extensions.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/13-auth-tls",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/13-auth-tls.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Auth and connectivity with TLS.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/14-token-standard-preapproval-renew-cancel-localnet",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/14-token-standard-preapproval-renew-cancel-localnet.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Token standard: preapproval create, renew, cancel.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/15-rewards-for-deposits",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/15-rewards-for-deposits.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Rewards for deposits.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/16-buy-traffic",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/16-buy-traffic.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Buy traffic.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/17-input-cid-filtering",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/17-input-cid-filtering.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Input CID filtering.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/18-merge-delegation-proposal",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/18-merge-delegation-proposal.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Merge delegation proposal.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/19-create-party-with-preapproval",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/19-create-party-with-preapproval.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Create or manage transfer preapproval.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/20-active-contracts-loop",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/20-active-contracts-loop.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Loop over active contracts.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/exchange-integration/01-one-step-deposit",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/exchange-integration/01-one-step-deposit.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Exchange: one-step deposit from customer to treasury.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/exchange-integration/02-one-step-withdrawal",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/exchange-integration/02-one-step-withdrawal.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Exchange: one-step withdrawal from treasury to customer.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/exchange-integration/03-multi-step-deposit",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/exchange-integration/03-multi-step-deposit.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Exchange: multi-step deposit flow.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/exchange-integration/04-multi-step-withdrawal",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/exchange-integration/04-multi-step-withdrawal.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Exchange: multi-step withdrawal flow.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/exchange-integration/setup-demo-customer",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/exchange-integration/setup-demo-customer.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Setup demo customer for exchange flows.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/exchange-integration/setup-exchange",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/exchange-integration/setup-exchange.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Setup exchange (treasury party and SDK).",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/exchange-integration/tap-devnet-faucet",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/exchange-integration/tap-devnet-faucet.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Tap DevNet faucet for coins.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/exchange-integration/validate-transfers",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/exchange-integration/validate-transfers.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Validate transfer inputs/outputs.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/stress/01-active-contracts-stress-test",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/stress/01-active-contracts-stress-test.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Stress test: active contracts.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/stress/02-merge-utxos-stress-test",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/stress/02-merge-utxos-stress-test.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Stress test: merge UTXOs.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/stress/background-stress-load",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/stress/background-stress-load.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Background stress load runner.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/scripts/stress/utils",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/scripts/stress/utils.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Stress test utilities.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/accept-or-reject-transfer",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/accept-or-reject-transfer.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Accept or reject a transfer instruction.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/allocate-party-without-rights",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/allocate-party-without-rights.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Allocate external party without rights.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/allocate-party",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/allocate-party.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Sign and allocate external party on localnet.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/await-completion-and-fetch",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/await-completion-and-fetch.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Await command completion and fetch result.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/can-execute-as-any-party",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/can-execute-as-any-party.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Check can execute as any party.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/can-read-as-any-party",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/can-read-as-any-party.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Check can read as any party.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/cancel-preapproval",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/cancel-preapproval.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Cancel a transfer preapproval.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/change-party-and-synchronizer",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/change-party-and-synchronizer.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Change party and synchronizer.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/compute-transaction-hash",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/compute-transaction-hash.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Compute transaction hash.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/config-template",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/config-template.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "SDK config template.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/convert-transaction-to-json",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/convert-transaction-to-json.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Convert transaction to JSON.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/create-key-from-mnenomic-phrase",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/create-key-from-mnenomic-phrase.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Create key from mnemonic phrase.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/create-key-pair",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/create-key-pair.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Create key pair.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/create-new-user",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/create-new-user.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Create new user.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/create-topology-transactions",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/create-topology-transactions.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Create topology transactions.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/create-transfer-command-full",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/create-transfer-command-full.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Create transfer command (full).",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/create-transfer-command",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/create-transfer-command.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Create token transfer between two parties.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/create-transfer-preapproval",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/create-transfer-preapproval.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Create transfer preapproval.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/create-transfer",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/create-transfer.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Create token transfer.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/decode-topology-tx",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/decode-topology-tx.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Decode topology transaction.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/default-config",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/default-config.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Default SDK configuration for localnet.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/execute-transaction",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/execute-transaction.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Execute a prepared transaction.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/generate-fingerprint",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/generate-fingerprint.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Generate fingerprint.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/list-holdings",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/list-holdings.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "List token holdings/UTXOs.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/list-wallets",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/list-wallets.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "List wallets via user ledger.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/monitor-transaction-holdings",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/monitor-transaction-holdings.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Monitor transaction holdings.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/oauth-controller",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/oauth-controller.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "OAuth controller example.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/prepare-incoming-command",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/prepare-incoming-command.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Prepare incoming command.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/prepare-transfer-transaction",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/prepare-transfer-transaction.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Prepare transfer transaction.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/read-active-contracts",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/read-active-contracts.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Read active contracts.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/read-ledger-end",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/read-ledger-end.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Read ledger end.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/read-pending-transfer-instructions",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/read-pending-transfer-instructions.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Read pending transfer instructions.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/renew-preapproval",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/renew-preapproval.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Renew transfer preapproval.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/setupTests",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/setupTests.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Test setup (Jest/global fixtures).",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/sign-party-transaction-hash",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/sign-party-transaction-hash.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Sign party transaction hash.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/sign-transaction-hash",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/sign-transaction-hash.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Sign transaction hash.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/submit-signed-topology-transaction",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/submit-signed-topology-transaction.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Submit signed topology transaction.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/tap-coins",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/tap-coins.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Tap coins for a party.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/snippets/withdraw-transfer-instruction",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/snippets/withdraw-transfer-instruction.ts",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Withdraw transfer instruction.",
+            "options": {
+                "language": "typescript"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/bash/create-command",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/bash/create-command.sh",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Bash: get ledger end and build transfer context (create command).",
+            "options": {
+                "language": "bash"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/bash/execute-transaction",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/bash/execute-transaction.sh",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Bash: prepare then submit transaction.",
+            "options": {
+                "language": "bash"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/bash/prepare-transaction",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/bash/prepare-transaction.sh",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Bash: prepare transaction.",
+            "options": {
+                "language": "bash"
+            }
+        },
+        {
+            "snippetName": "docs/wallet-integration-guide/examples/bash/sign-transaction-hash",
+            "sourceRepo": "splice-wallet-kernel",
+            "sourceFilepath": "docs/wallet-integration-guide/examples/bash/sign-transaction-hash.sh",
+            "location": {
+                "type": "fullFile"
+            },
+            "description": "Bash: sign transaction hash.",
+            "options": {
+                "language": "bash"
+            }
+        }
+    ]
+}

--- a/docs/scripts/generateOutputDocs.js
+++ b/docs/scripts/generateOutputDocs.js
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+// generateOutputDocs.js
+//
+// - Reads a single export config: docs/config/exportConfig.json
+// - Writes extracted snippets into: docs-output/<snippetName>.mdx
+// - Resolves source files relative to the repo root
+
+const fs = require('fs')
+const path = require('path')
+
+const REPO_ROOT = path.join(__dirname, '..', '..')
+const EXPORT_CONFIG_PATH = path.join(REPO_ROOT, 'docs/config/exportConfig.json')
+const OUTPUT_FOLDER_PATH = path.join(REPO_ROOT, 'docs-output')
+
+function readFileContent(filePath) {
+    try {
+        return fs.readFileSync(filePath, 'utf8')
+    } catch (error) {
+        throw new Error(`Failed to read file ${filePath}: ${error.message}`)
+    }
+}
+
+function extractByLines(fileContent, start, end) {
+    const lines = fileContent.split(/\r?\n/)
+    const startLine = Number(start)
+    const endLine = Number(end)
+
+    if (
+        startLine < 1 ||
+        endLine < 1 ||
+        startLine > lines.length ||
+        endLine > lines.length
+    ) {
+        throw new Error(
+            `Line numbers out of range: start=${startLine}, end=${endLine}, file has ${lines.length} lines`
+        )
+    }
+
+    if (startLine > endLine) {
+        throw new Error(
+            `Invalid line range: start (${startLine}) must be <= end (${endLine})`
+        )
+    }
+
+    return lines.slice(startLine - 1, endLine).join('\n')
+}
+
+function extractByStringMarker(fileContent, startMarker, endMarker) {
+    const startIndex = fileContent.indexOf(startMarker)
+    if (startIndex === -1) {
+        throw new Error(`Start marker not found: "${startMarker}"`)
+    }
+
+    const contentStart = startIndex + startMarker.length
+    const endIndex = fileContent.indexOf(endMarker, contentStart)
+    if (endIndex === -1) {
+        throw new Error(`End marker not found: "${endMarker}"`)
+    }
+
+    return fileContent.substring(contentStart, endIndex).trim()
+}
+
+function extractByRegexWrap(fileContent, startRegex, endRegex) {
+    const startPattern = new RegExp(startRegex)
+    const endPattern = new RegExp(endRegex)
+
+    const startMatch = fileContent.match(startPattern)
+    if (!startMatch) {
+        throw new Error(`Start regex pattern not found: "${startRegex}"`)
+    }
+
+    const contentStart = startMatch.index + startMatch[0].length
+    const remainingContent = fileContent.substring(contentStart)
+    const endMatch = remainingContent.match(endPattern)
+
+    if (!endMatch) {
+        throw new Error(`End regex pattern not found: "${endRegex}"`)
+    }
+
+    return remainingContent.substring(0, endMatch.index).trim()
+}
+
+function extractByJsonIndex(fileContent, start, end) {
+    let arr
+    try {
+        arr = JSON.parse(fileContent)
+    } catch (e) {
+        throw new Error(`File is not valid JSON: ${e.message}`)
+    }
+    if (!Array.isArray(arr)) {
+        throw new Error(
+            'JSON root must be an array for location type jsonIndex'
+        )
+    }
+    const startIdx = Number(start)
+    const endIdx = Number(end)
+    if (
+        startIdx < 0 ||
+        endIdx < 0 ||
+        startIdx >= arr.length ||
+        endIdx >= arr.length
+    ) {
+        throw new Error(
+            `Array index out of range: start=${startIdx}, end=${endIdx}, array length=${arr.length}`
+        )
+    }
+    if (startIdx > endIdx) {
+        throw new Error(
+            `Invalid index range: start (${startIdx}) must be <= end (${endIdx})`
+        )
+    }
+    if (startIdx === endIdx) {
+        const item = arr[startIdx]
+        return typeof item === 'string' ? item : String(item)
+    }
+    return arr
+        .slice(startIdx, endIdx + 1)
+        .map((item) => (typeof item === 'string' ? item : String(item)))
+        .join('\n')
+}
+
+function extractSnippetContent(fileContent, location) {
+    switch (location.type) {
+        case 'fullFile':
+            return fileContent
+
+        case 'lines':
+            return extractByLines(fileContent, location.start, location.end)
+
+        case 'jsonIndex':
+            return extractByJsonIndex(fileContent, location.start, location.end)
+
+        case 'stringMarker':
+            return extractByStringMarker(
+                fileContent,
+                location.start,
+                location.end
+            )
+
+        case 'regexWrap':
+            return extractByRegexWrap(fileContent, location.start, location.end)
+
+        default:
+            throw new Error(`Unknown location type: ${location.type}`)
+    }
+}
+
+function normalizeIndent(content) {
+    const lines = content.split('\n')
+
+    let minIndent = null
+    for (const line of lines) {
+        if (line.trim() === '') continue
+        const match = line.match(/^(\s*)/)
+        const indent = match ? match[1].length : 0
+        if (minIndent === null || indent < minIndent) {
+            minIndent = indent
+        }
+    }
+
+    if (minIndent === null || minIndent === 0) {
+        return lines
+            .map((line) =>
+                line.trim() === '' ? '' : `  ${line.replace(/^\s*/, '')}`
+            )
+            .join('\n')
+    }
+
+    return lines
+        .map((line) => {
+            if (line.trim() === '') return ''
+            return `  ${line.slice(minIndent)}`
+        })
+        .join('\n')
+}
+
+function formatSnippetContent(content, options) {
+    if (options && options.transform === 'rstjson') {
+        return content
+    }
+    const displayStyle = (options && options.displayStyle) || 'wrapCode'
+    const rawLanguage = options && options.language ? options.language : ''
+    const language =
+        rawLanguage && rawLanguage.toLowerCase() === 'none' ? '' : rawLanguage
+
+    switch (displayStyle) {
+        case 'wrapCode':
+            if (language) {
+                return `\`\`\`${language}\n${content}\n\`\`\``
+            } else {
+                return `\`\`\`\n${content}\n\`\`\``
+            }
+
+        default:
+            return content
+    }
+}
+
+function getSourceFilePath(snippet) {
+    if (snippet.sourceFilepath) {
+        return path.join(REPO_ROOT, snippet.sourceFilepath)
+    } else {
+        throw new Error(
+            `Snippet "${snippet.snippetName}" has no source file path specified`
+        )
+    }
+}
+
+function processSnippet(snippet) {
+    try {
+        console.log(`Processing snippet: ${snippet.snippetName}`)
+
+        if (!snippet.snippetName) {
+            throw new Error('Snippet missing required field: snippetName')
+        }
+
+        if (!snippet.location) {
+            throw new Error(
+                `Snippet "${snippet.snippetName}" missing required field: location`
+            )
+        }
+
+        const sourceFilePath = getSourceFilePath(snippet)
+
+        const fileContent = readFileContent(sourceFilePath)
+
+        const extractedContent = extractSnippetContent(
+            fileContent,
+            snippet.location
+        )
+        const normalizedContent =
+            snippet.options && snippet.options.transform === 'rstjson'
+                ? extractedContent
+                : normalizeIndent(extractedContent)
+
+        const formattedContent = formatSnippetContent(
+            normalizedContent,
+            snippet.options || {}
+        )
+
+        const outputFileName = `${snippet.snippetName}.mdx`
+        const outputPath = path.join(OUTPUT_FOLDER_PATH, outputFileName)
+        const outputPathDir = path.dirname(outputPath)
+
+        fs.mkdirSync(outputPathDir, { recursive: true })
+
+        fs.writeFileSync(outputPath, formattedContent, 'utf8')
+
+        console.log(`✓ Successfully extracted snippet to: ${outputPath}`)
+    } catch (error) {
+        console.error(
+            `✗ Error processing snippet "${snippet.snippetName}": ${error.message}`
+        )
+        throw error
+    }
+}
+
+/**
+ * Main function
+ * Reads docs/config/exportConfig.json and processes each snippet.
+ */
+function main() {
+    try {
+        const configContent = readFileContent(EXPORT_CONFIG_PATH)
+        const config = JSON.parse(configContent)
+
+        if (!config.snippets || !Array.isArray(config.snippets)) {
+            throw new Error(
+                'exportConfig.json must have a top-level "snippets" array'
+            )
+        }
+
+        let successCount = 0
+        let errorCount = 0
+
+        for (const snippet of config.snippets) {
+            try {
+                processSnippet(snippet)
+                successCount++
+            } catch (error) {
+                errorCount++
+            }
+        }
+
+        console.log(
+            `\nProcessing complete: ${successCount} succeeded, ${errorCount} failed`
+        )
+
+        if (errorCount > 0) {
+            process.exit(1)
+        }
+    } catch (error) {
+        console.error(`Fatal error: ${error.message}`)
+        process.exit(1)
+    }
+}
+
+main()


### PR DESCRIPTION
Adds a GitHub Actions workflow, extraction script, and export config to automatically sync code snippets from this repo to the canton.network docs repo.

1. `.github/workflows/update-docs-snippets.yml` — triggers on pushes to `main` that touch `snippets/` or `scripts/`, runs extraction, uploads artifacts, and triggers an update workflow in the docs repo
2. `docs/scripts/generateOutputDocs.js` — reads `docs/config/exportConfig.json` and extracts 78 snippets from source files into `docs-output/*.mdx`, supporting full-file, line-range, string-marker, regex-wrap, and JSON-index extraction modes
3. `docs/config/exportConfig.json` — maps 78 snippet names to source file locations across `snippets/`, `scripts/`, and `bash/` examples
4. Three new tested snippets in `docs/wallet-integration-guide/examples/snippets/`:
   - `submit-with-retry.ts` — retry pattern with exponential backoff for ledger contention
   - `query-active-contracts-by-party.ts` — querying active contracts scoped to a party via the SDK
   - `fetch-pending-transfer-instructions.ts` — fetching pending transfer instructions using `fetchPendingTransferInstructionView()`

The new snippets follow the existing `snippets.test.ts` auto-discovery pattern.

Signed-off-by: Ibo Sy <ibo@b9lab.com>