### PR TITLE
fix(core-wallet-ui-components): fix exposed path regex

### DIFF
--- a/core/wallet-ui-components/src/routing.ts
+++ b/core/wallet-ui-components/src/routing.ts
@@ -26,6 +26,9 @@ function normalizePathname(pathname: string): string {
     if (!pathname || pathname === '/') {
         return '/'
     }
+    if (pathname.length > 1000) {
+        throw new Error('Path is too long')
+    }
 
     const trimmedPathname = pathname.replace(/\/+$/, '') || '/'
 


### PR DESCRIPTION
the path trimming regex is exposed directly against an user input, this can be considered a possible attack vector so we limit the input to 1000 characters (this is excluding query parameters) to avoid potential ddos attacks.

while ddos would normally be the responsibility of a reverse proxy, this case is usually overlooked and directly relates to internal coding.