### PR TITLE
feat: expose connected provider

### DIFF
--- a/sdk/dapp-sdk/src/adapter/remote-adapter.ts
+++ b/sdk/dapp-sdk/src/adapter/remote-adapter.ts
@@ -180,6 +180,10 @@ class RemoteMappedProvider implements Provider<DappRpcTypes> {
                 return controller.getPrimaryAccount() as Promise<
                     DappRpcTypes[M]['result']
                 >
+            case 'getActiveNetwork':
+                return controller.getActiveNetwork() as Promise<
+                    DappRpcTypes[M]['result']
+                >
             default:
                 throw new Error('Unsupported method')
         }

--- a/sdk/dapp-sdk/src/index.ts
+++ b/sdk/dapp-sdk/src/index.ts
@@ -56,6 +56,7 @@ export {
     prepareExecuteAndWait,
     ledgerApi,
     open,
+    getConnectedProvider,
     onStatusChanged,
     onAccountsChanged,
     onTxChanged,

--- a/sdk/dapp-sdk/src/sdk.ts
+++ b/sdk/dapp-sdk/src/sdk.ts
@@ -17,7 +17,10 @@ import {
     type WalletPickerFn,
 } from '@canton-network/core-wallet-discovery'
 import { pickWallet } from '@canton-network/core-wallet-ui-components'
-import type { EventListener } from '@canton-network/core-splice-provider'
+import type {
+    EventListener,
+    Provider,
+} from '@canton-network/core-splice-provider'
 import type {
     StatusEvent,
     ConnectResult,
@@ -28,6 +31,7 @@ import type {
     ListAccountsResult,
     AccountsChangedEvent,
     TxChangedEvent,
+    RpcTypes as DappRpcTypes,
 } from '@canton-network/core-wallet-dapp-rpc-client'
 import { DappClient } from './client'
 import { ExtensionAdapter } from './adapter/extension-adapter'
@@ -240,6 +244,18 @@ export class DappSDK {
         return this.client
     }
 
+    /**
+     * Returns the raw connected provider instance (if any).
+     *
+     * This is useful for advanced integrations that need to call methods that
+     * are not wrapped by the higher-level SDK helpers.
+     */
+    getConnectedProvider(): Provider<DappRpcTypes> | null {
+        const session = this.discovery?.getActiveSession()
+        if (!session) return null
+        return session.provider
+    }
+
     async connect(options?: DappSDKConnectOptions): Promise<ConnectResult> {
         await this.ensureInit(options)
         const discovery = this.discovery!
@@ -425,6 +441,10 @@ export const ledgerApi = (params: LedgerApiParams): Promise<LedgerApiResult> =>
     sdk.ledgerApi(params)
 
 export const open = (): Promise<void> => sdk.open()
+
+export const getConnectedProvider = (): ReturnType<
+    DappSDK['getConnectedProvider']
+> => sdk.getConnectedProvider()
 
 export const onStatusChanged = (
     listener: EventListener<StatusEvent>


### PR DESCRIPTION
This exposes the provider connected, so that it can be used in conjunction with the wallet sdk. 
Likewise, we will need the provider object to run other services within dapps that are build using the provider architecture. 