### PR TITLE
feat: configurable log level

### DIFF
--- a/docs/dapp-building/wallet-gateway/configuration/schema.md
+++ b/docs/dapp-building/wallet-gateway/configuration/schema.md
@@ -114,6 +114,23 @@ npx @canton-network/wallet-gateway-remote@latest --config-schema
             ],
             "additionalProperties": false
         },
+        "logging": {
+            "type": "object",
+            "properties": {
+                "level": {
+                    "description": "The log level for the gateway. If omitted, defaults to info.",
+                    "type": "string",
+                    "enum": ["trace", "debug", "info", "warn", "error", "fatal"]
+                },
+                "format": {
+                    "description": "The log format for the gateway. If omitted, defaults to pretty.",
+                    "type": "string",
+                    "enum": ["json", "pretty"]
+                }
+            },
+            "additionalProperties": false,
+            "description": "Optional logging configuration. If omitted, defaults will be used."
+        },
         "store": {
             "type": "object",
             "properties": {

--- a/wallet-gateway/remote/package.json
+++ b/wallet-gateway/remote/package.json
@@ -11,7 +11,7 @@
     "scripts": {
         "build": "vite build && tsc -b && tsc -b tsconfig.frontend.json",
         "clean": "tsc -b --clean && rm -rf ./dist && rm ./*.sqlite || true",
-        "dev": "NODE_ENV=development tsx watch src/index.ts -f pretty -l debug -c ../test/config.json",
+        "dev": "NODE_ENV=development tsx watch src/index.ts -c ../test/config.json",
         "test": "yarn node --trace-warnings --experimental-vm-modules $(yarn bin jest)",
         "start": "yarn node dist/index.js -c ../test/config.json",
         "debug": "yarn node --inspect-brk dist/index.js -c ../test/config.json",

--- a/wallet-gateway/remote/src/config/Config.ts
+++ b/wallet-gateway/remote/src/config/Config.ts
@@ -68,6 +68,25 @@ export const serverConfigSchema = z.object({
     }),
 })
 
+const loggingConfigSchema = z
+    .object({
+        level: z
+            .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
+            .optional()
+            .meta({
+                description:
+                    'The log level for the gateway. If omitted, defaults to info.',
+            }),
+        format: z.enum(['json', 'pretty']).optional().meta({
+            description:
+                'The log format for the gateway. If omitted, defaults to pretty.',
+        }),
+    })
+    .meta({
+        description:
+            'Optional logging configuration. If omitted, defaults will be used.',
+    })
+
 const authFromEnvOrConfig = z.union([authSchema, authFromEnvSchema])
 
 const bootstrapFromEnv = bootstrapConfigSchema.extend({
@@ -83,6 +102,7 @@ const bootstrapFromEnv = bootstrapConfigSchema.extend({
 export const rawConfigSchema = z.object({
     kernel: kernelInfoSchema,
     server: z.preprocess((val) => val ?? {}, serverConfigSchema),
+    logging: z.preprocess((val) => val ?? {}, loggingConfigSchema).optional(),
     store: storeConfigSchema,
     signingStore: signingStoreConfigSchema,
     bootstrap: bootstrapFromEnv,
@@ -91,6 +111,7 @@ export const rawConfigSchema = z.object({
 export const configSchema = z.object({
     kernel: kernelInfoSchema,
     server: z.preprocess((val) => val ?? {}, serverConfigSchema),
+    logging: z.preprocess((val) => val ?? {}, loggingConfigSchema).optional(),
     store: storeConfigSchema,
     signingStore: signingStoreConfigSchema,
     bootstrap: bootstrapConfigSchema,

--- a/wallet-gateway/remote/src/example-config.ts
+++ b/wallet-gateway/remote/src/example-config.ts
@@ -8,6 +8,10 @@ export default {
         id: 'remote-da',
         clientType: 'remote',
     },
+    logging: {
+        level: 'info',
+        format: 'pretty',
+    },
     server: {
         port: 3030,
         dappPath: '/api/v0/dapp',

--- a/wallet-gateway/remote/src/index.ts
+++ b/wallet-gateway/remote/src/index.ts
@@ -28,14 +28,20 @@ const program = new Command()
     .option('--config-example', 'output an example config and exit', false)
     .option('-p, --port [port]', 'set port (overrides config)')
     .addOption(
-        new Option('-f, --log-format <format>', 'set log format')
-            .choices(['json', 'pretty'])
-            .default('pretty')
+        new Option('-f, --log-format <format>', 'set log format').choices([
+            'json',
+            'pretty',
+        ])
     )
     .addOption(
-        new Option('-l, --log-level <level>', 'set log level')
-            .choices(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
-            .default('info')
+        new Option('-l, --log-level <level>', 'set log level').choices([
+            'trace',
+            'debug',
+            'info',
+            'warn',
+            'error',
+            'fatal',
+        ])
     )
     .action((opts) => {
         if (opts.configSchema) {
@@ -50,11 +56,17 @@ const program = new Command()
             process.exit(0)
         }
 
+        const config = ConfigUtils.loadConfigFile(opts.config)
+        const configLogging = config.logging ?? {}
+
+        const logFormat = opts.logFormat ?? configLogging.format ?? 'pretty'
+        const logLevel = opts.logLevel ?? configLogging.level ?? 'info'
+
         // Define project-global logger
         const logger = pino({
             name: 'main',
-            level: opts.logLevel,
-            ...(opts.logFormat === 'pretty'
+            level: logLevel,
+            ...(logFormat === 'pretty'
                 ? {
                       transport: {
                           target: 'pino-pretty',

--- a/wallet-gateway/test/config.json
+++ b/wallet-gateway/test/config.json
@@ -3,6 +3,10 @@
         "id": "remote-da",
         "clientType": "remote"
     },
+    "logging": {
+        "level": "debug",
+        "format": "pretty"
+    },
     "server": {
         "host": "localhost",
         "port": 3030,


### PR DESCRIPTION
- The dev script now passes `-l debug`, so `yarn workspace @canton-network/wallet-gateway-remote dev` and the PM2 remote app both run with debug logs.
- Otherwise unchanged, e.g. default to `info`