### PR TITLE
feat: global popup

### DIFF
--- a/core/types/src/index.ts
+++ b/core/types/src/index.ts
@@ -171,6 +171,8 @@ export interface WalletPickerEntry {
     description?: string | undefined
     icon?: string | undefined
     url?: string | undefined
+    /** Keep the global wallet popup open after pick for async HTTP-gateway navigation. */
+    reuseGlobalWalletPopup?: boolean | undefined
 }
 
 export interface WalletPickerResult {
@@ -178,6 +180,7 @@ export interface WalletPickerResult {
     name: string
     type: string
     url?: string | undefined
+    reuseGlobalWalletPopup?: boolean | undefined
 }
 
 // RPC related types

--- a/core/wallet-discovery/src/client.ts
+++ b/core/wallet-discovery/src/client.ts
@@ -162,6 +162,7 @@ export class DiscoveryClient {
                     description: info.description,
                     icon: info.icon,
                     url: info.url,
+                    reuseGlobalWalletPopup: info.reuseGlobalWalletPopup,
                 }
             })
 

--- a/core/wallet-discovery/src/types.ts
+++ b/core/wallet-discovery/src/types.ts
@@ -23,6 +23,12 @@ export interface WalletInfo {
     description?: string | undefined
     icon?: string | undefined
     url?: string | undefined
+    /**
+     * If set, wallet picker keeps the global popup open after pick for reuse
+     * by async navigations (e.g. HTTP wallet gateway). Not used for sync DApp API
+     * wallets (browser extension, Loop) even when `type` is `remote`.
+     */
+    reuseGlobalWalletPopup?: boolean | undefined
 }
 
 /**

--- a/core/wallet-ui-components/src/components/wallet-picker.ts
+++ b/core/wallet-ui-components/src/components/wallet-picker.ts
@@ -341,14 +341,7 @@ export class WalletPicker extends HTMLElement {
     private readonly RECENT_KEY = 'splice_wallet_picker_recent'
 
     private root: HTMLElement
-    private entries: {
-        providerId: string
-        name: string
-        type: string
-        description?: string
-        icon?: string
-        url?: string
-    }[] = []
+    private entries: WalletPickerEntry[] = []
     private recentGateways: { name: string; rpcUrl: string }[] = []
     private state: 'list' | 'connecting' | 'connected' | 'error' = 'list'
     private selectedEntry: WalletPickerEntry | null = null
@@ -407,14 +400,7 @@ export class WalletPicker extends HTMLElement {
         }
     }
 
-    private getAllEntries(): {
-        providerId: string
-        name: string
-        type: string
-        description?: string
-        icon?: string
-        url?: string
-    }[] {
+    private getAllEntries(): WalletPickerEntry[] {
         // Merge all entries into a single flat list:
         // 1. Registered entries (extensions + gateways from discovery)
         // 2. Recent gateways not already in the registered list
@@ -424,13 +410,14 @@ export class WalletPicker extends HTMLElement {
                 .map((e) => e.url)
         )
 
-        const recentEntries = this.recentGateways
+        const recentEntries: WalletPickerEntry[] = this.recentGateways
             .filter((r) => !knownUrls.has(r.rpcUrl))
             .map((r) => ({
                 providerId: 'remote:' + r.rpcUrl,
                 name: r.name,
                 type: 'remote' as const,
                 url: r.rpcUrl,
+                reuseGlobalWalletPopup: true,
             }))
 
         return [...this.entries, ...recentEntries]
@@ -438,12 +425,7 @@ export class WalletPicker extends HTMLElement {
 
     // ── Actions ─────────────────────────────────────────────
 
-    private selectWallet(entry: {
-        providerId: string
-        name: string
-        type: string
-        url?: string
-    }): void {
+    private selectWallet(entry: WalletPickerEntry): void {
         this.selectedEntry = entry
         this.state = 'connecting'
         this.render()
@@ -456,6 +438,7 @@ export class WalletPicker extends HTMLElement {
                     name: entry.name,
                     walletType: entry.type,
                     url: entry.url,
+                    reuseGlobalWalletPopup: entry.reuseGlobalWalletPopup,
                 },
                 '*'
             )
@@ -473,6 +456,7 @@ export class WalletPicker extends HTMLElement {
             name: trimmed,
             type: 'remote',
             url: trimmed,
+            reuseGlobalWalletPopup: true,
         })
     }
 
@@ -507,14 +491,7 @@ export class WalletPicker extends HTMLElement {
         return header
     }
 
-    private renderWalletCard(entry: {
-        providerId: string
-        name: string
-        type: string
-        description?: string
-        icon?: string
-        url?: string
-    }): HTMLElement {
+    private renderWalletCard(entry: WalletPickerEntry): HTMLElement {
         const card = this.el('button', '', { class: 'wallet-card' })
 
         const icon = this.el('div', '', { class: 'wallet-icon' })

--- a/core/wallet-ui-components/src/windows/wallet-picker.ts
+++ b/core/wallet-ui-components/src/windows/wallet-picker.ts
@@ -45,20 +45,25 @@ export async function pickWallet(
                     name: event.data.name,
                     type: event.data.walletType,
                     url: event.data.url,
+                    reuseGlobalWalletPopup: event.data.reuseGlobalWalletPopup,
                 }
                 window.removeEventListener('message', handler)
                 resolve(result)
-                // Popup already switched to “Connecting…”; close it now that the opener
-                // has the selection and will run discovery.connect in the main window.
-                queueMicrotask(() => {
-                    if (!win.closed) {
-                        try {
-                            win.close()
-                        } catch {
-                            // ignore
+                // HTTP wallet gateway reuses this named popup after async connect
+                // (see RemoteAdapter.reuseGlobalWalletPopup). Closing would force a
+                // second window.open without user activation. Other wallets must close
+                // or the picker UI would stay visible (e.g. Loop, browser extension).
+                if (!result.reuseGlobalWalletPopup) {
+                    queueMicrotask(() => {
+                        if (!win.closed) {
+                            try {
+                                win.close()
+                            } catch {
+                                // ignore
+                            }
                         }
-                    }
-                })
+                    })
+                }
             }
         }
 

--- a/sdk/dapp-sdk/src/adapter/remote-adapter.ts
+++ b/sdk/dapp-sdk/src/adapter/remote-adapter.ts
@@ -65,6 +65,7 @@ export class RemoteAdapter implements ProviderAdapter {
             description: this.description,
             icon: this.icon,
             url: this.rpcUrl,
+            reuseGlobalWalletPopup: true,
         }
     }
 

--- a/sdk/dapp-sdk/src/sdk.ts
+++ b/sdk/dapp-sdk/src/sdk.ts
@@ -279,6 +279,7 @@ export class DappSDK {
                     description: info.description,
                     icon: info.icon,
                     url: info.url,
+                    reuseGlobalWalletPopup: info.reuseGlobalWalletPopup,
                 }
             })
 


### PR DESCRIPTION
We give the wallet picker the option to keep a global popup open after the user picks an adapter. This is relevant for async dApp API Wallets. Otherwise, a new popup will be opened (given the userUrl), that is blocked initally by the browser and needs an additional user consent.

An alternative to #1560