### PR TITLE
docs: add offline signing script

### DIFF
--- a/docs/wallet-integration-guide/examples/package.json
+++ b/docs/wallet-integration-guide/examples/package.json
@@ -24,7 +24,8 @@
         "run-10": "tsx ./scripts/10-init-with-ledger-provider.ts | pino-pretty",
         "run-11": "tsx ./scripts/11-hashing.ts | pino-pretty",
         "run-12": "tsx ./scripts/12-subscribe-to-events.ts | pino-pretty",
-        "run-13": "tsx ./scripts/13-rewards-for-deposits/index.ts | pino-pretty"
+        "run-13": "tsx ./scripts/13-rewards-for-deposits/index.ts | pino-pretty",
+        "run-14": "tsx ./scripts/14-offline-signing.ts | pino-pretty"
     },
     "devDependencies": {
         "@canton-network/core-signing-lib": "workspace:^",

--- a/docs/wallet-integration-guide/examples/scripts/14-offline-signing.ts
+++ b/docs/wallet-integration-guide/examples/scripts/14-offline-signing.ts
@@ -1,0 +1,279 @@
+import {
+    localNetStaticConfig,
+    SDK,
+    signTransactionHash,
+} from '@canton-network/wallet-sdk'
+import { pino } from 'pino'
+import { v4 } from 'uuid'
+import {
+    TOKEN_NAMESPACE_CONFIG,
+    TOKEN_PROVIDER_CONFIG_DEFAULT,
+    AMULET_NAMESPACE_CONFIG,
+} from './utils/index.js'
+
+const onlineLogger = pino({ name: '14-online-localnet', level: 'info' })
+const offlineLogger = pino({ name: '14-oggline-localnet', level: 'info' })
+
+const onlineSDK = await SDK.create({
+    auth: TOKEN_PROVIDER_CONFIG_DEFAULT,
+    ledgerClientUrl: localNetStaticConfig.LOCALNET_APP_USER_LEDGER_URL,
+})
+
+onlineLogger.info(`Online sdk initialized.`)
+
+const offlineSdk = await SDK.create({
+    auth: TOKEN_PROVIDER_CONFIG_DEFAULT,
+    ledgerClientUrl: localNetStaticConfig.LOCALNET_APP_USER_LEDGER_URL,
+})
+
+offlineLogger.info(`Offline sdk initialized.`)
+
+const keyPairSender = offlineSdk.keys.generate()
+
+offlineLogger.info('Created sender keyPair')
+
+const senderPartyPrepared = onlineSDK.party.external.create(
+    keyPairSender.publicKey,
+    {
+        partyHint: 'v1-14-alice',
+    }
+)
+
+const senderPartyTopology = await senderPartyPrepared.topology()
+
+onlineLogger.info(
+    `Prepared sender onboarding with multi hash: ${senderPartyTopology.multiHash}`
+)
+
+const senderSignedTopologyTx = signTransactionHash(
+    senderPartyTopology.multiHash,
+    keyPairSender.privateKey
+)
+
+offlineLogger.info(`Sender signed onboarding hash`)
+
+const senderParty = await senderPartyPrepared.execute(senderSignedTopologyTx)
+
+onlineLogger.info(`Created sender party: ${senderParty}`)
+
+const keyPairReceiver = offlineSdk.keys.generate()
+
+offlineLogger.info('Created sender keyPair')
+
+const receiverPartyPrepared = onlineSDK.party.external.create(
+    keyPairReceiver.publicKey,
+    {
+        partyHint: 'v1-14-bob',
+    }
+)
+
+const receiverPartyTopology = await receiverPartyPrepared.topology()
+
+onlineLogger.info(
+    `Prepared sender onboarding with multi hash: ${receiverPartyTopology.multiHash}`
+)
+
+const receiverSignedTopologyTx = signTransactionHash(
+    receiverPartyTopology.multiHash,
+    keyPairReceiver.privateKey
+)
+
+offlineLogger.info(`Receiver signed onboarding hash`)
+
+const receiverParty = await receiverPartyPrepared.execute(
+    receiverSignedTopologyTx
+)
+
+onlineLogger.info(`Created receiver party: ${receiverParty}`)
+
+// Configure amulet namespace for online sdk
+
+const amulet = await onlineSDK.amulet(AMULET_NAMESPACE_CONFIG)
+
+onlineLogger.info(
+    '===================== SENDER TAP (PREPARE) ====================='
+)
+
+const [amuletTapCommand, amuletTapDisclosedContracts] = await amulet.tap(
+    senderParty.partyId,
+    '10000'
+)
+
+const preparedTapCommand = onlineSDK.ledger.prepare({
+    partyId: senderParty.partyId,
+    commands: amuletTapCommand,
+    disclosedContracts: amuletTapDisclosedContracts,
+})
+
+const { response: preparedTapCommandResponse } =
+    await preparedTapCommand.toJSON()
+
+onlineLogger.info(
+    `Prepared tap with hash: ${preparedTapCommandResponse.preparedTransactionHash}`
+)
+
+offlineLogger.info(
+    '===================== OFFLINE TAP SIGNING ====================='
+)
+const calculatedTxHash = await offlineSdk.ledger.preparedTransaction.hash(
+    preparedTapCommandResponse.preparedTransaction
+)
+
+if (
+    calculatedTxHash.toBase64() !==
+    preparedTapCommandResponse.preparedTransactionHash
+)
+    throw Error('Recomputed tap hash does not match prepared tap hash')
+
+const signatureTapCommand = signTransactionHash(
+    preparedTapCommandResponse.preparedTransactionHash,
+    keyPairSender.privateKey
+)
+offlineLogger.info('Signed tap transaction hash')
+
+const signed = onlineSDK.ledger.fromSignature(
+    preparedTapCommandResponse,
+    signatureTapCommand
+)
+
+await onlineSDK.ledger.execute(signed, { partyId: senderParty.partyId })
+
+onlineLogger.info('Tap completed')
+
+//creating a transfer
+onlineLogger.info(
+    '===================== SENDER TRANSFER (PREPARE) ====================='
+)
+
+const token = await onlineSDK.token(TOKEN_NAMESPACE_CONFIG)
+
+const [transferCommand, transferDisclosedContracts] =
+    await token.transfer.create({
+        sender: senderParty.partyId,
+        recipient: receiverParty.partyId,
+        instrumentId: 'Amulet',
+        registryUrl: localNetStaticConfig.LOCALNET_REGISTRY_API_URL,
+        amount: '100',
+    })
+
+const preparedTransferCommand = onlineSDK.ledger.prepare({
+    partyId: senderParty.partyId,
+    commands: transferCommand,
+    disclosedContracts: transferDisclosedContracts,
+})
+
+offlineLogger.info(
+    '===================== OFFLINE TRANSFER SIGNING ====================='
+)
+
+const { response: preparedTransferResponse } =
+    await preparedTransferCommand.toJSON()
+
+onlineLogger.info(
+    `Prepared create transfer with hash: ${preparedTransferResponse.preparedTransactionHash}`
+)
+
+const calculatedCreateTransferHash =
+    await offlineSdk.ledger.preparedTransaction.hash(
+        preparedTransferResponse.preparedTransaction
+    )
+
+if (
+    calculatedCreateTransferHash.toBase64() !==
+    preparedTransferResponse.preparedTransactionHash
+)
+    throw Error(
+        'Recomputed create transfer hash does not match prepared create transfer hash'
+    )
+
+const signatureTransferCommand = signTransactionHash(
+    preparedTransferResponse.preparedTransactionHash,
+    keyPairSender.privateKey
+)
+offlineLogger.info('Signed create transfer transaction hash')
+
+const signedTransferHash = onlineSDK.ledger.fromSignature(
+    preparedTransferResponse,
+    signatureTransferCommand
+)
+
+onlineLogger.info(
+    '====================== SUBMITTING TRANSFER ====================='
+)
+
+await onlineSDK.ledger.execute(signedTransferHash, {
+    partyId: senderParty.partyId,
+})
+
+onlineLogger.info(
+    `Created a transfer from ${senderParty.partyId} to ${receiverParty.partyId}`
+)
+
+onlineLogger.info(
+    '===================== ACCEPT TRANSFER (PREPARE) ====================='
+)
+
+const pendingOffers = await token.transfer.pending(receiverParty.partyId)
+
+if (pendingOffers?.length !== 1) {
+    throw new Error(
+        `Expected exactly one pending transfer instruction, but found ${pendingOffers?.length}`
+    )
+}
+
+onlineLogger.info(`Found pending offer: ${pendingOffers[0].contractId}`)
+
+const pendingOffer = pendingOffers[0]
+
+const [acceptTransferCommand, transferDisclosedContractsAccept] =
+    await token.transfer.accept({
+        transferInstructionCid: pendingOffer.contractId,
+        registryUrl: localNetStaticConfig.LOCALNET_REGISTRY_API_URL,
+    })
+
+const preparedTransferAcceptCommand = onlineSDK.ledger.prepare({
+    partyId: receiverParty.partyId,
+    commands: acceptTransferCommand,
+    disclosedContracts: transferDisclosedContractsAccept,
+})
+
+const { response: preparedTransferAcceptResponse } =
+    await preparedTransferAcceptCommand.toJSON()
+
+onlineLogger.info(
+    `Prepared create transfer with hash: ${preparedTransferAcceptResponse.preparedTransactionHash}`
+)
+
+const calculatedAcceptTransferHash =
+    await offlineSdk.ledger.preparedTransaction.hash(
+        preparedTransferAcceptResponse.preparedTransaction
+    )
+
+if (
+    calculatedAcceptTransferHash.toBase64() !==
+    preparedTransferAcceptResponse.preparedTransactionHash
+)
+    throw Error(
+        'Recomputed accept transfer hash does not match prepared accept transfer hash'
+    )
+
+const signatureAcceptTransfer = signTransactionHash(
+    preparedTransferAcceptResponse.preparedTransactionHash,
+    keyPairReceiver.privateKey
+)
+offlineLogger.info('Signed accept transfer transaction hash')
+
+const signedAcceptTransferHash = onlineSDK.ledger.fromSignature(
+    preparedTransferAcceptResponse,
+    signatureAcceptTransfer
+)
+
+onlineLogger.info(
+    '===================== SUBMITTING ACCEPT ====================='
+)
+
+await onlineSDK.ledger.execute(signedAcceptTransferHash, {
+    partyId: receiverParty.partyId,
+})
+
+onlineLogger.info('Accepted transfer instruction')

--- a/docs/wallet-integration-guide/examples/scripts/14-offline-signing.ts
+++ b/docs/wallet-integration-guide/examples/scripts/14-offline-signing.ts
@@ -4,7 +4,6 @@ import {
     signTransactionHash,
 } from '@canton-network/wallet-sdk'
 import { pino } from 'pino'
-import { v4 } from 'uuid'
 import {
     TOKEN_NAMESPACE_CONFIG,
     TOKEN_PROVIDER_CONFIG_DEFAULT,

--- a/docs/wallet-integration-guide/examples/scripts/14-offline-signing.ts
+++ b/docs/wallet-integration-guide/examples/scripts/14-offline-signing.ts
@@ -44,6 +44,18 @@ onlineLogger.info(
     `Prepared sender onboarding with multi hash: ${senderPartyTopology.multiHash}`
 )
 
+offlineLogger.info(
+    `Recomputing sender multihash from prepared topology transactions`
+)
+const senderTopologyTxCalculated = await offlineSdk.party.hashTopologyTx(
+    senderPartyTopology.topologyTransactions
+)
+
+if (senderTopologyTxCalculated !== senderPartyTopology.multiHash)
+    throw Error(
+        'Recomputed sender topology hash does not match received sender multihash'
+    )
+
 const senderSignedTopologyTx = signTransactionHash(
     senderPartyTopology.multiHash,
     keyPairSender.privateKey
@@ -71,6 +83,19 @@ const receiverPartyTopology = await receiverPartyPrepared.topology()
 onlineLogger.info(
     `Prepared sender onboarding with multi hash: ${receiverPartyTopology.multiHash}`
 )
+
+offlineLogger.info(
+    `Recomputing receiver multihash from prepared topology transactions`
+)
+
+const receiverTopologyHashCalculated = await offlineSdk.party.hashTopologyTx(
+    receiverPartyTopology.topologyTransactions
+)
+
+if (receiverTopologyHashCalculated !== receiverPartyTopology.multiHash)
+    throw Error(
+        'Recomputed receiver topology hash does not match received multihash'
+    )
 
 const receiverSignedTopologyTx = signTransactionHash(
     receiverPartyTopology.multiHash,

--- a/docs/wallet-integration-guide/examples/scripts/14-offline-signing.ts
+++ b/docs/wallet-integration-guide/examples/scripts/14-offline-signing.ts
@@ -31,6 +31,10 @@ const keyPairSender = offlineSdk.keys.generate()
 
 offlineLogger.info('Created sender keyPair')
 
+onlineLogger.info(
+    '===================== ONLINE CREATED TOPOLOGY TRANSACTIONS ALICE ====================='
+)
+
 const senderPartyPrepared = onlineSDK.party.external.create(
     keyPairSender.publicKey,
     {
@@ -45,8 +49,9 @@ onlineLogger.info(
 )
 
 offlineLogger.info(
-    `Recomputing sender multihash from prepared topology transactions`
+    '===================== OFFLINE TOPOLOGY TX HASHING ALICE ====================='
 )
+
 const senderTopologyTxCalculated = await offlineSdk.party.hashTopologyTx(
     senderPartyTopology.topologyTransactions
 )
@@ -67,9 +72,17 @@ const senderParty = await senderPartyPrepared.execute(senderSignedTopologyTx)
 
 onlineLogger.info(`Created sender party: ${senderParty}`)
 
+offlineLogger.info(
+    '===================== OFFLINE GENERATE KEYS BOB ====================='
+)
+
 const keyPairReceiver = offlineSdk.keys.generate()
 
 offlineLogger.info('Created sender keyPair')
+
+onlineLogger.info(
+    '===================== ONLINE CREATED TOPOLOGY TRANSACTIONS BOB ====================='
+)
 
 const receiverPartyPrepared = onlineSDK.party.external.create(
     keyPairReceiver.publicKey,
@@ -85,7 +98,7 @@ onlineLogger.info(
 )
 
 offlineLogger.info(
-    `Recomputing receiver multihash from prepared topology transactions`
+    '===================== OFFLINE COMPUTE MULTIHASH FROM TOPOLOGY TX BOB ====================='
 )
 
 const receiverTopologyHashCalculated = await offlineSdk.party.hashTopologyTx(
@@ -104,6 +117,10 @@ const receiverSignedTopologyTx = signTransactionHash(
 
 offlineLogger.info(`Receiver signed onboarding hash`)
 
+onlineLogger.info(
+    '===================== EXECUTE TOPOLOGY TX FOR BOB ====================='
+)
+
 const receiverParty = await receiverPartyPrepared.execute(
     receiverSignedTopologyTx
 )
@@ -115,7 +132,7 @@ onlineLogger.info(`Created receiver party: ${receiverParty}`)
 const amulet = await onlineSDK.amulet(AMULET_NAMESPACE_CONFIG)
 
 onlineLogger.info(
-    '===================== SENDER TAP (PREPARE) ====================='
+    '===================== ONLINE SENDER TAP (PREPARE) ====================='
 )
 
 const [amuletTapCommand, amuletTapDisclosedContracts] = await amulet.tap(
@@ -137,7 +154,7 @@ onlineLogger.info(
 )
 
 offlineLogger.info(
-    '===================== OFFLINE TAP SIGNING ====================='
+    '===================== OFFLINE TAP SIGNING AND HASH RECOMPUTATION ====================='
 )
 const calculatedTxHash = await offlineSdk.ledger.preparedTransaction.hash(
     preparedTapCommandResponse.preparedTransaction
@@ -187,7 +204,7 @@ const preparedTransferCommand = onlineSDK.ledger.prepare({
 })
 
 offlineLogger.info(
-    '===================== OFFLINE TRANSFER SIGNING ====================='
+    '===================== OFFLINE TRANSFER SIGNING AND HASH RECOMPUTATION ====================='
 )
 
 const { response: preparedTransferResponse } =
@@ -266,6 +283,10 @@ const { response: preparedTransferAcceptResponse } =
 
 onlineLogger.info(
     `Prepared create transfer with hash: ${preparedTransferAcceptResponse.preparedTransactionHash}`
+)
+
+offlineLogger.info(
+    '===================== OFFLINE CALCULATE TX HASH AND SIGNING FOR ACCEPT TRANSFER ====================='
 )
 
 const calculatedAcceptTransferHash =

--- a/docs/wallet-integration-guide/examples/scripts/14-offline-signing.ts
+++ b/docs/wallet-integration-guide/examples/scripts/14-offline-signing.ts
@@ -27,12 +27,14 @@ const offlineSdk = await SDK.create({
 
 offlineLogger.info(`Offline sdk initialized.`)
 
+offlineLogger.info(
+    '===================== OFFLINE CREATED KEYS SENDER ====================='
+)
+
 const keyPairSender = offlineSdk.keys.generate()
 
-offlineLogger.info('Created sender keyPair')
-
 onlineLogger.info(
-    '===================== ONLINE CREATED TOPOLOGY TRANSACTIONS ALICE ====================='
+    '===================== ONLINE CREATED TOPOLOGY TRANSACTIONS SENDER ====================='
 )
 
 const senderPartyPrepared = onlineSDK.party.external.create(
@@ -49,7 +51,7 @@ onlineLogger.info(
 )
 
 offlineLogger.info(
-    '===================== OFFLINE TOPOLOGY TX HASHING ALICE ====================='
+    '===================== OFFLINE TOPOLOGY TX HASHING SENDER ====================='
 )
 
 const senderTopologyTxCalculated = await offlineSdk.party.hashTopologyTx(
@@ -68,12 +70,16 @@ const senderSignedTopologyTx = signTransactionHash(
 
 offlineLogger.info(`Sender signed onboarding hash`)
 
+onlineLogger.info(
+    '===================== ONLINE EXECUTE TOPOLOGY TX SENDER ====================='
+)
+
 const senderParty = await senderPartyPrepared.execute(senderSignedTopologyTx)
 
 onlineLogger.info(`Created sender party: ${senderParty}`)
 
 offlineLogger.info(
-    '===================== OFFLINE GENERATE KEYS BOB ====================='
+    '===================== OFFLINE GENERATE KEYS RECEIVER ====================='
 )
 
 const keyPairReceiver = offlineSdk.keys.generate()
@@ -81,7 +87,7 @@ const keyPairReceiver = offlineSdk.keys.generate()
 offlineLogger.info('Created sender keyPair')
 
 onlineLogger.info(
-    '===================== ONLINE CREATED TOPOLOGY TRANSACTIONS BOB ====================='
+    '===================== ONLINE CREATED TOPOLOGY TRANSACTIONS RECEIVER ====================='
 )
 
 const receiverPartyPrepared = onlineSDK.party.external.create(
@@ -98,7 +104,7 @@ onlineLogger.info(
 )
 
 offlineLogger.info(
-    '===================== OFFLINE COMPUTE MULTIHASH FROM TOPOLOGY TX BOB ====================='
+    '===================== OFFLINE COMPUTE MULTIHASH FROM TOPOLOGY TX RECEIVER ====================='
 )
 
 const receiverTopologyHashCalculated = await offlineSdk.party.hashTopologyTx(
@@ -118,7 +124,7 @@ const receiverSignedTopologyTx = signTransactionHash(
 offlineLogger.info(`Receiver signed onboarding hash`)
 
 onlineLogger.info(
-    '===================== EXECUTE TOPOLOGY TX FOR BOB ====================='
+    '===================== ONLINE EXECUTE TOPOLOGY TX FOR RECEIVER ====================='
 )
 
 const receiverParty = await receiverPartyPrepared.execute(
@@ -140,14 +146,13 @@ const [amuletTapCommand, amuletTapDisclosedContracts] = await amulet.tap(
     '10000'
 )
 
-const preparedTapCommand = onlineSDK.ledger.prepare({
-    partyId: senderParty.partyId,
-    commands: amuletTapCommand,
-    disclosedContracts: amuletTapDisclosedContracts,
-})
-
-const { response: preparedTapCommandResponse } =
-    await preparedTapCommand.toJSON()
+const { response: preparedTapCommandResponse } = await onlineSDK.ledger
+    .prepare({
+        partyId: senderParty.partyId,
+        commands: amuletTapCommand,
+        disclosedContracts: amuletTapDisclosedContracts,
+    })
+    .toJSON()
 
 onlineLogger.info(
     `Prepared tap with hash: ${preparedTapCommandResponse.preparedTransactionHash}`
@@ -177,13 +182,17 @@ const signed = onlineSDK.ledger.fromSignature(
     signatureTapCommand
 )
 
+onlineLogger.info(
+    '===================== ONLINE EXECUTE TAP COMMAND SENDER ====================='
+)
+
 await onlineSDK.ledger.execute(signed, { partyId: senderParty.partyId })
 
 onlineLogger.info('Tap completed')
 
 //creating a transfer
 onlineLogger.info(
-    '===================== SENDER TRANSFER (PREPARE) ====================='
+    '===================== ONLINE SENDER TRANSFER (PREPARE) ====================='
 )
 
 const token = await onlineSDK.token(TOKEN_NAMESPACE_CONFIG)
@@ -197,18 +206,17 @@ const [transferCommand, transferDisclosedContracts] =
         amount: '100',
     })
 
-const preparedTransferCommand = onlineSDK.ledger.prepare({
-    partyId: senderParty.partyId,
-    commands: transferCommand,
-    disclosedContracts: transferDisclosedContracts,
-})
+const { response: preparedTransferResponse } = await onlineSDK.ledger
+    .prepare({
+        partyId: senderParty.partyId,
+        commands: transferCommand,
+        disclosedContracts: transferDisclosedContracts,
+    })
+    .toJSON()
 
 offlineLogger.info(
     '===================== OFFLINE TRANSFER SIGNING AND HASH RECOMPUTATION ====================='
 )
-
-const { response: preparedTransferResponse } =
-    await preparedTransferCommand.toJSON()
 
 onlineLogger.info(
     `Prepared create transfer with hash: ${preparedTransferResponse.preparedTransactionHash}`
@@ -251,7 +259,7 @@ onlineLogger.info(
 )
 
 onlineLogger.info(
-    '===================== ACCEPT TRANSFER (PREPARE) ====================='
+    '===================== ONLINE ACCEPT TRANSFER (PREPARE) ====================='
 )
 
 const pendingOffers = await token.transfer.pending(receiverParty.partyId)
@@ -272,14 +280,13 @@ const [acceptTransferCommand, transferDisclosedContractsAccept] =
         registryUrl: localNetStaticConfig.LOCALNET_REGISTRY_API_URL,
     })
 
-const preparedTransferAcceptCommand = onlineSDK.ledger.prepare({
-    partyId: receiverParty.partyId,
-    commands: acceptTransferCommand,
-    disclosedContracts: transferDisclosedContractsAccept,
-})
-
-const { response: preparedTransferAcceptResponse } =
-    await preparedTransferAcceptCommand.toJSON()
+const { response: preparedTransferAcceptResponse } = await onlineSDK.ledger
+    .prepare({
+        partyId: receiverParty.partyId,
+        commands: acceptTransferCommand,
+        disclosedContracts: transferDisclosedContractsAccept,
+    })
+    .toJSON()
 
 onlineLogger.info(
     `Prepared create transfer with hash: ${preparedTransferAcceptResponse.preparedTransactionHash}`
@@ -314,7 +321,7 @@ const signedAcceptTransferHash = onlineSDK.ledger.fromSignature(
 )
 
 onlineLogger.info(
-    '===================== SUBMITTING ACCEPT ====================='
+    '===================== ONLINE SUBMITTING ACCEPT ====================='
 )
 
 await onlineSDK.ledger.execute(signedAcceptTransferHash, {

--- a/docs/wallet-integration-guide/src/preparing-and-signing-transactions/index.rst
+++ b/docs/wallet-integration-guide/src/preparing-and-signing-transactions/index.rst
@@ -190,7 +190,7 @@ interaction between `Alice` and `Bob` with signing happening in an offline envir
 submit.
 
 
-.. literalinclude:: ../../examples/scripts/03-parties.ts
+.. literalinclude:: ../../examples/scripts/14-offline-signing.ts
     :language: typescript
     :dedent:
 

--- a/sdk/wallet-sdk/src/wallet/namespace/party/client.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/party/client.ts
@@ -6,6 +6,10 @@ import { CommonCtx } from '../../sdk.js'
 import { ExternalPartyNamespace } from './external/index.js'
 import { InternalPartyNamespace } from './internal.js'
 import { Ops } from '@canton-network/core-provider-ledger'
+import {
+    computeMultiHashForTopology,
+    computeSha256CantonHash,
+} from '@canton-network/core-tx-visualizer'
 
 export default class PartyNamespace {
     public readonly internal: InternalPartyNamespace
@@ -62,5 +66,32 @@ export default class PartyNamespace {
             }) ?? []
 
         return Array.from(new Set(parties))
+    }
+
+    /**
+     *
+     * @param preparedTransactions list of prepared topology transactions
+     * @returns a multihash combining all of the topology txs
+     */
+    public async hashTopologyTx(
+        preparedTransactions: Uint8Array<ArrayBufferLike>[] | string[]
+    ) {
+        let normalized: Uint8Array<ArrayBufferLike>[]
+        if (typeof preparedTransactions[0] === 'string') {
+            normalized = (preparedTransactions as string[]).map((tx) =>
+                Buffer.from(tx, 'base64')
+            )
+        } else {
+            normalized = preparedTransactions as Uint8Array<ArrayBufferLike>[]
+        }
+
+        const rawHashes = await Promise.all(
+            normalized.map((tx) => computeSha256CantonHash(11, tx))
+        )
+        const combinedHashes = await computeMultiHashForTopology(rawHashes)
+
+        const computedHash = await computeSha256CantonHash(55, combinedHashes)
+
+        return Buffer.from(computedHash).toString('base64')
     }
 }

--- a/sdk/wallet-sdk/src/wallet/namespace/party/client.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/party/client.ts
@@ -85,6 +85,8 @@ export default class PartyNamespace {
             normalized = preparedTransactions as Uint8Array<ArrayBufferLike>[]
         }
 
+        // Prepending the hash purpose for TopologyTransactionSignature and MultiTopologyTransaction
+        // https://github.com/hyperledger-labs/splice/blob/53738545af6d0714bddff54c3309ecf2fe6d1881/canton/community/base/src/main/scala/com/digitalasset/canton/crypto/HashPurpose.scala#L47
         const rawHashes = await Promise.all(
             normalized.map((tx) => computeSha256CantonHash(11, tx))
         )


### PR DESCRIPTION
Adds a script to show the full offline signing flow, comparable to the[ v0 version ](https://docs.digitalasset.com/integrate/devnet/preparing-and-signing-transactions/index.html#how-to-use-the-sdk-to-offline-sign-a-transaction)