### PR TITLE
fix(wallet-gateway-remote): missing payload for external signed transaction

### DIFF
--- a/core/ledger-client/src/ledger-client.ts
+++ b/core/ledger-client/src/ledger-client.ts
@@ -812,6 +812,7 @@ export class LedgerClient {
             this.logger.warn(
                 `Error in postWithRetry for path ${path} with body retry options ${JSON.stringify(retryOptions)}`
             )
+            this.logger.debug(JSON.stringify(body))
             throw asJsCantonError(e)
         })
     }

--- a/examples/ping/src/commands/createPingCommand.ts
+++ b/examples/ping/src/commands/createPingCommand.ts
@@ -3,7 +3,8 @@
 
 // Corresponds to the built-in canton-builtin-admin-workflow-ping DAR every participant initializes with
 
-const templateId = '#canton-builtin-admin-workflow-ping:Canton.Internal.Ping:Ping'
+const templateId =
+    '#canton-builtin-admin-workflow-ping:Canton.Internal.Ping:Ping'
 
 export const createPingCommand = (party: string) => {
     return {

--- a/examples/ping/src/commands/createPingCommand.ts
+++ b/examples/ping/src/commands/createPingCommand.ts
@@ -3,13 +3,14 @@
 
 // Corresponds to the built-in canton-builtin-admin-workflow-ping DAR every participant initializes with
 
+const templateId = '#canton-builtin-admin-workflow-ping:Canton.Internal.Ping:Ping'
+
 export const createPingCommand = (party: string) => {
-    const packageName = 'canton-builtin-admin-workflow-ping'
     return {
         commands: [
             {
                 CreateCommand: {
-                    templateId: `#${packageName}:Canton.Internal.Ping:Ping`,
+                    templateId: templateId,
                     createArguments: {
                         id: `my-test-${new Date().getTime()}`,
                         initiator: party,
@@ -22,12 +23,11 @@ export const createPingCommand = (party: string) => {
 }
 
 export const exercisePongCommand = (contractId: string) => {
-    const packageName = 'canton-builtin-admin-workflow-ping'
     return {
         commands: [
             {
                 ExerciseCommand: {
-                    templateId: `#${packageName}.Canton.Internal.Ping:Ping`,
+                    templateId: templateId,
                     choice: 'Respond',
                     contractId: `${contractId}`,
                     choiceArgument: {},

--- a/examples/ping/tests/blockdaemon.spec.ts
+++ b/examples/ping/tests/blockdaemon.spec.ts
@@ -85,8 +85,17 @@ test('dApp: execute externally signed tx with Blockdaemon', async ({
         })
     ).toHaveCount(1)
     await expect(
-        dappPage.getByRole('paragraph').filter({
-            hasText: `{ "commandId": "${commandId.commandId}", "status": "executed", "`,
-        })
+        dappPage
+            .getByRole('paragraph')
+            .filter({
+                hasText: `"commandId": "${commandId.commandId}"`,
+            })
+            .filter({
+                hasText: '"status": "executed"',
+            })
+            .filter({
+                hasText:
+                    /"payload": \{[\s\S]*"updateId": "[^"]+"[\s\S]*"completionOffset": \d+/,
+            })
     ).toHaveCount(1)
 })

--- a/examples/ping/tests/example.spec.ts
+++ b/examples/ping/tests/example.spec.ts
@@ -88,9 +88,18 @@ test('dApp: execute externally signed tx', async ({
         })
     ).toHaveCount(1)
     await expect(
-        dappPage.getByRole('paragraph').filter({
-            hasText: `{ "commandId": "${commandId.commandId}", "status": "executed", "`,
-        })
+        dappPage
+            .getByRole('paragraph')
+            .filter({
+                hasText: `"commandId": "${commandId.commandId}"`,
+            })
+            .filter({
+                hasText: '"status": "executed"',
+            })
+            .filter({
+                hasText:
+                    /"payload": \{[\s\S]*"updateId": "[^"]+"[\s\S]*"completionOffset": \d+/,
+            })
     ).toHaveCount(1)
 })
 

--- a/wallet-gateway/remote/src/ledger/transaction-service.ts
+++ b/wallet-gateway/remote/src/ledger/transaction-service.ts
@@ -393,7 +393,7 @@ export class TransactionService {
         const { commandId, partyId, signature, signedBy } = executeParams
 
         const result = await ledgerClient.postWithRetry(
-            '/v2/interactive-submission/execute',
+            '/v2/interactive-submission/executeAndWait',
             {
                 userId,
                 preparedTransaction: transaction.preparedTransaction,


### PR DESCRIPTION
different in logic between participant signed and external signed. External signed used the async method (execute) instead of execute-and-wait, while the internally signed used the submit-and-wait. This resulting in internal parties having correct payload, while external parties does not.


- [X] Fixed exercise Pong command (for testing purposes)
- [X] Changed execution to execute-and-wait
- [X] Added playwright check to ensure we have a valid payload 