### PR TITLE
fix(dapp-sdk): add missing mapping for signMessage

### DIFF
--- a/sdk/dapp-sdk/src/adapter/remote-adapter.ts
+++ b/sdk/dapp-sdk/src/adapter/remote-adapter.ts
@@ -189,6 +189,10 @@ class RemoteMappedProvider implements Provider<DappRpcTypes> {
                 return controller.getActiveNetwork() as Promise<
                     DappRpcTypes[M]['result']
                 >
+            case 'signMessage':
+                return controller.signMessage(args.params) as Promise<
+                    DappRpcTypes[M]['result']
+                >
             default:
                 throw new Error('Unsupported method')
         }


### PR DESCRIPTION
Added missing mapping for CIP-0103 `signMessage` method in remote adapter