### PR TITLE
fix: preapproval test script + fetch status command

### DIFF
--- a/docs/wallet-integration-guide/examples/scripts/05-preapproval.ts
+++ b/docs/wallet-integration-guide/examples/scripts/05-preapproval.ts
@@ -16,6 +16,8 @@ const sdk = await SDK.create({
     amulet: AMULET_NAMESPACE_CONFIG,
 })
 
+await sdk.amulet.tapOperator('1000')
+
 const aliceKeys = sdk.keys.generate()
 
 const alice = await sdk.party.external

--- a/docs/wallet-integration-guide/examples/scripts/05-preapproval.ts
+++ b/docs/wallet-integration-guide/examples/scripts/05-preapproval.ts
@@ -16,7 +16,7 @@ const sdk = await SDK.create({
     amulet: AMULET_NAMESPACE_CONFIG,
 })
 
-await sdk.amulet.tapOperator('1000')
+await sdk.amulet.tapInternal('1000')
 
 const aliceKeys = sdk.keys.generate()
 

--- a/docs/wallet-integration-guide/examples/scripts/05-preapproval.ts
+++ b/docs/wallet-integration-guide/examples/scripts/05-preapproval.ts
@@ -20,7 +20,7 @@ const aliceKeys = sdk.keys.generate()
 
 const alice = await sdk.party.external
     .create(aliceKeys.publicKey, {
-        partyHint: 'v1-05-Alice',
+        partyHint: 'v1-05-alice',
     })
     .sign(aliceKeys.privateKey)
     .execute()
@@ -43,7 +43,7 @@ const bobKeys = sdk.keys.generate()
 
 const bob = await sdk.party.external
     .create(bobKeys.publicKey, {
-        partyHint: 'v1-05-Bob',
+        partyHint: 'v1-05-bob',
     })
     .sign(bobKeys.privateKey)
     .execute()
@@ -75,9 +75,7 @@ logger.info('Successfully registered the preapproval.')
 
 // --- TEST FETCH
 
-logger.info(
-    "Fetching for preapproval status. This might take up to 5 minutes... Why don't you go make some coffee?"
-)
+logger.info('Fetching for preapproval status')
 
 const fetchedPreapprovalStatus = await sdk.amulet.preapproval.fetchStatus(
     bob.partyId
@@ -140,45 +138,38 @@ await sdk.amulet.preapproval.renew({
 })
 
 const fetchedStatusAfterRenew = await sdk.amulet.preapproval.fetchStatus(
-    bob.partyId
+    bob.partyId,
+    {
+        oldCid: fetchedPreapprovalStatus!.contractId,
+    }
 )
 
-if (fetchedPreapprovalStatus?.expiresAt === fetchedStatusAfterRenew?.expiresAt)
-    throw Error("The expiration date hasn't changed")
+const before = fetchedPreapprovalStatus!.expiresAt
+const after = fetchedStatusAfterRenew!.expiresAt
+
+if (!(after.getTime() > before.getTime())) {
+    throw new Error(
+        `Expected expiresAt to increase after renewal. before=${fetchedPreapprovalStatus!.expiresAt.toISOString()} after=${fetchedStatusAfterRenew!.expiresAt.toISOString()}`
+    )
+}
 
 logger.info(
-    fetchedStatusAfterRenew,
-    'Successfully managed to renew preapproval'
+    {
+        before: before.toISOString(),
+        after: after.toISOString(),
+        extendedSeconds: Math.round(
+            (after.getTime() - before.getTime()) / 1000
+        ),
+    },
+    'TransferPreapproval expiry extended, managed to renew preapproval'
 )
 
 // --- TEST CANCEL COMMAND
+logger.info('Testing out cancel command')
 
-if (!fetchedPreapprovalStatus?.templateId) {
+if (!fetchedStatusAfterRenew?.templateId) {
     throw new Error('No preapproval found - fetchedPreapprovalStatus is null')
 }
-
-const fetchACS = async () => {
-    logger.info(
-        { templateId: fetchedPreapprovalStatus.templateId },
-        'Using template ID from fetchedPreapprovalStatus'
-    )
-
-    const preapprovalACS = await sdk.ledger.acs.read({
-        parties: [bob.partyId],
-        templateIds: [fetchedPreapprovalStatus.templateId],
-    })
-
-    const foundPreapproval = preapprovalACS.find(
-        (acs) => acs.contractId === fetchedPreapprovalStatus?.contractId
-    )
-
-    const result = { exists: !!foundPreapproval }
-    logger.info(result, 'Is preapproval in ACS')
-
-    return result.exists
-}
-
-const beforeExists = await fetchACS()
 
 const [cancelPreapprovalCommand, cancelDisclosedContracts] =
     await sdk.amulet.preapproval.command.cancel({
@@ -204,6 +195,17 @@ await sdk.ledger
         partyId: bob.partyId,
     })
 
-const afterExists = await fetchACS()
-if (beforeExists === afterExists || afterExists)
-    throw Error('The preapproval still exists in the ACS')
+logger.info('Submitted cancel command; now polling')
+const cancelled = await sdk.amulet.preapproval.fetchStatus(bob.partyId, {
+    cancelled: true,
+})
+
+const preapprovalACS = await sdk.ledger.acs.read({
+    parties: [bob.partyId],
+    templateIds: [fetchedStatusAfterRenew?.templateId],
+    filterByParty: true,
+})
+
+if (cancelled === null && preapprovalACS.length === 0) {
+    logger.info(`Successfully cancelled`)
+}

--- a/docs/wallet-integration-guide/examples/scripts/utils/upload-dars.ts
+++ b/docs/wallet-integration-guide/examples/scripts/utils/upload-dars.ts
@@ -1,0 +1,61 @@
+import pino from 'pino'
+import { localNetStaticConfig, SDK } from '@canton-network/wallet-sdk'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import fs from 'fs/promises'
+import { TOKEN_PROVIDER_CONFIG_DEFAULT } from './index.js'
+
+/*
+This script is so that the CI can run all the scripts in parallel
+We first run the uploadDars script and then all of the tests
+*/
+
+const logger = pino({ name: 'upload-dars', level: 'info' })
+
+const sdk = await SDK.create({
+    auth: TOKEN_PROVIDER_CONFIG_DEFAULT,
+    ledgerClientUrl: localNetStaticConfig.LOCALNET_APP_USER_LEDGER_URL,
+})
+
+// This example needs uploaded .dar for splice-token-test-trading-app
+// It's in files of localnet, but it's not uploaded to participant, so we need to do this in the script
+// Adjust if to your .localnet location
+const PATH_TO_LOCALNET = '../../../../../.localnet'
+const PATH_TO_TRADING_APP_DAR_IN_LOCALNET =
+    '/dars/splice-token-test-trading-app-1.0.0.dar'
+const TRADING_APP_PACKAGE_ID =
+    'e5c9847d5a88d3b8d65436f01765fc5ba142cc58529692e2dacdd865d9939f71'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+const tradingDarPath = path.join(
+    here,
+    PATH_TO_LOCALNET,
+    PATH_TO_TRADING_APP_DAR_IN_LOCALNET
+)
+
+//upload dar
+const darBytes = await fs.readFile(tradingDarPath)
+await sdk.ledger.dar.upload(darBytes, TRADING_APP_PACKAGE_ID, undefined, false)
+
+const PATH_TO_TOKEN_STANDARD_DAR_IN_LOCALNET =
+    '/dars/splice-util-token-standard-wallet-1.0.0.dar'
+const SPLICE_UTIL_TOKEN_STANDARD_WALLET_PACKAGE_ID =
+    '1da198cb7968fa478cfa12aba9fdf128a63a8af6ab284ea6be238cf92a3733ac'
+
+const spliceUtilTokenStandardWalletDarPath = path.join(
+    here,
+    PATH_TO_LOCALNET,
+    PATH_TO_TOKEN_STANDARD_DAR_IN_LOCALNET
+)
+
+//upload dar
+const tokenStandardDarBytes = await fs.readFile(
+    spliceUtilTokenStandardWalletDarPath
+)
+await sdk.ledger.dar.upload(
+    tokenStandardDarBytes,
+    SPLICE_UTIL_TOKEN_STANDARD_WALLET_PACKAGE_ID
+)
+
+logger.info('upload dars completed')

--- a/docs/wallet-integration-guide/examples/scripts/utils/upload-dars.ts
+++ b/docs/wallet-integration-guide/examples/scripts/utils/upload-dars.ts
@@ -36,7 +36,7 @@ const tradingDarPath = path.join(
 
 //upload dar
 const darBytes = await fs.readFile(tradingDarPath)
-await sdk.ledger.dar.upload(darBytes, TRADING_APP_PACKAGE_ID, undefined, false)
+await sdk.ledger.dar.upload(darBytes, TRADING_APP_PACKAGE_ID)
 
 const PATH_TO_TOKEN_STANDARD_DAR_IN_LOCALNET =
     '/dars/splice-util-token-standard-wallet-1.0.0.dar'

--- a/scripts/src/test-example-scripts.ts
+++ b/scripts/src/test-example-scripts.ts
@@ -100,32 +100,6 @@ const results: Array<{
     script: string
     result: PromiseSettledResult<void>
 }> = []
-// const parallelBatch: string[] = []
-
-// async function flushParallelBatch(): Promise<void> {
-//     if (parallelBatch.length === 0) return
-
-//     const batch = parallelBatch.splice(0, parallelBatch.length)
-//     const batchResults = await Promise.allSettled(
-//         batch.map((script) => executeScript(script))
-//     )
-
-//     results.push(
-//         ...batch.map((script, index) => ({
-//             script,
-//             result: batchResults[index],
-//         }))
-//     )
-// }
-
-// for (const script of scripts) {
-//     parallelBatch.push(script)
-//     if (parallelBatch.length >= BATCH_SIZE) {
-//         await flushParallelBatch()
-//     }
-// }
-
-// await flushParallelBatch()
 
 async function runScriptsConcurrently(scripts: string[], concurrency: number) {
     const queue = [...scripts]

--- a/scripts/src/test-example-scripts.ts
+++ b/scripts/src/test-example-scripts.ts
@@ -21,7 +21,7 @@ const dir = path.join(
 const EXCEPTIONS_DIR_NAMES = ['stress']
 
 // do not run these tests; exceptions can be full filename or just any length subset of its starting characters
-const EXCEPTIONS_FILE_NAMES = ['_', 'utils', 'types.ts']
+const EXCEPTIONS_FILE_NAMES = ['_', 'utils', 'types.ts', 'upload-dars.ts']
 
 function getScriptsRecursive(currentDir: string): string[] {
     return fs.readdirSync(currentDir).flatMap((f) => {
@@ -37,6 +37,9 @@ function getScriptsRecursive(currentDir: string): string[] {
             : []
     })
 }
+
+//upload dars before any other script
+await executeScript('utils/upload-dars.ts')
 
 const scripts = getScriptsRecursive(dir)
 

--- a/scripts/src/test-example-scripts.ts
+++ b/scripts/src/test-example-scripts.ts
@@ -95,37 +95,61 @@ async function cmd(bin: string, args: string[]): Promise<string> {
     return logs
 }
 
-const BATCH_SIZE = 15
+const BATCH_SIZE = 5
 const results: Array<{
     script: string
     result: PromiseSettledResult<void>
 }> = []
-const parallelBatch: string[] = []
+// const parallelBatch: string[] = []
 
-async function flushParallelBatch(): Promise<void> {
-    if (parallelBatch.length === 0) return
+// async function flushParallelBatch(): Promise<void> {
+//     if (parallelBatch.length === 0) return
 
-    const batch = parallelBatch.splice(0, parallelBatch.length)
-    const batchResults = await Promise.allSettled(
-        batch.map((script) => executeScript(script))
-    )
+//     const batch = parallelBatch.splice(0, parallelBatch.length)
+//     const batchResults = await Promise.allSettled(
+//         batch.map((script) => executeScript(script))
+//     )
 
-    results.push(
-        ...batch.map((script, index) => ({
-            script,
-            result: batchResults[index],
-        }))
-    )
-}
+//     results.push(
+//         ...batch.map((script, index) => ({
+//             script,
+//             result: batchResults[index],
+//         }))
+//     )
+// }
 
-for (const script of scripts) {
-    parallelBatch.push(script)
-    if (parallelBatch.length >= BATCH_SIZE) {
-        await flushParallelBatch()
+// for (const script of scripts) {
+//     parallelBatch.push(script)
+//     if (parallelBatch.length >= BATCH_SIZE) {
+//         await flushParallelBatch()
+//     }
+// }
+
+// await flushParallelBatch()
+
+async function runScriptsConcurrently(scripts: string[], concurrency: number) {
+    const queue = [...scripts]
+    async function worker() {
+        while (queue.length > 0) {
+            const script = queue.shift()!
+            const result = await executeScript(script).then(
+                () => ({
+                    script,
+                    result: { status: 'fulfilled', value: undefined } as const,
+                }),
+                (reason) => ({
+                    script,
+                    result: { status: 'rejected', reason } as const,
+                })
+            )
+            results.push(result)
+        }
     }
+
+    await Promise.all(Array.from({ length: concurrency }, () => worker()))
 }
 
-await flushParallelBatch()
+await runScriptsConcurrently(scripts, BATCH_SIZE)
 
 const failedScripts = results.flatMap(({ script, result }) =>
     result.status === 'rejected' ? [{ script, result } as const] : []

--- a/scripts/src/test-example-scripts.ts
+++ b/scripts/src/test-example-scripts.ts
@@ -17,16 +17,11 @@ const dir = path.join(
     'docs/wallet-integration-guide/examples/scripts'
 )
 
-// run these tests sequentially; entries can be full filenames or any length prefix of the starting characters
-const SEQUENTIAL_FILE_NAMES = [
-    //this is here because createRenewTransferPreapproval uses UTXOS from the validatorOperatorParty
-    '14-token-standard',
-]
 // do not run tests from these directory names; full name match
 const EXCEPTIONS_DIR_NAMES = ['stress']
 
 // do not run these tests; exceptions can be full filename or just any length subset of its starting characters
-const EXCEPTIONS_FILE_NAMES = ['01-auth.ts', '13-auth-tls.ts', '05-']
+const EXCEPTIONS_FILE_NAMES = ['_', 'utils', 'types.ts']
 
 function getScriptsRecursive(currentDir: string): string[] {
     return fs.readdirSync(currentDir).flatMap((f) => {
@@ -44,12 +39,6 @@ function getScriptsRecursive(currentDir: string): string[] {
 }
 
 const scripts = getScriptsRecursive(dir)
-
-function shouldRunSequentially(script: string): boolean {
-    return Boolean(
-        SEQUENTIAL_FILE_NAMES.find((prefix) => script.startsWith(prefix))
-    )
-}
 
 async function executeScript(name: string) {
     console.log(success(`\n=== Executing script: ${name} ===`))
@@ -126,22 +115,7 @@ async function flushParallelBatch(): Promise<void> {
     )
 }
 
-if (SEQUENTIAL_FILE_NAMES.length > 0) {
-    console.log(
-        success(
-            `Running matching scripts sequentially for prefixes: ${SEQUENTIAL_FILE_NAMES.join(', ')}`
-        )
-    )
-}
-
 for (const script of scripts) {
-    if (shouldRunSequentially(script)) {
-        await flushParallelBatch()
-        const [result] = await Promise.allSettled([executeScript(script)])
-        results.push({ script, result })
-        continue
-    }
-
     parallelBatch.push(script)
     if (parallelBatch.length >= BATCH_SIZE) {
         await flushParallelBatch()

--- a/sdk/wallet-sdk/src/wallet/namespace/amulet/namespace.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/amulet/namespace.ts
@@ -66,6 +66,22 @@ export class AmuletNamespace {
         return [{ ExerciseCommand: tapCommand }, disclosedContracts]
     }
 
+    async tapOperator(amount: string, synchronizerId?: string) {
+        const [tapCommand, disclosedContracts] = await this.tap(
+            this.sdkContext.validatorParty,
+            amount
+        )
+
+        await this.ledger.internal.submit({
+            commands: [tapCommand],
+            disclosedContracts,
+            synchronizerId:
+                synchronizerId ??
+                this.sdkContext.commonCtx.defaultSynchronizerId,
+            actAs: [this.sdkContext.validatorParty],
+        })
+    }
+
     featuredApp: FeaturedAppNamespace = {
         rights: async (
             options: LookupFeaturedAppRightsOptions

--- a/sdk/wallet-sdk/src/wallet/namespace/amulet/namespace.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/amulet/namespace.ts
@@ -66,19 +66,31 @@ export class AmuletNamespace {
         return [{ ExerciseCommand: tapCommand }, disclosedContracts]
     }
 
-    async tapOperator(amount: string, synchronizerId?: string) {
-        const [tapCommand, disclosedContracts] = await this.tap(
-            this.sdkContext.validatorParty,
-            amount
-        )
+    /**
+     * Creates and submits a tap command for a specified amount for an internal party
+     * This is useful for tests and can only be used locally or against devnet
+     * @param amount The amount to be tapped.
+     * @param options Optional settings.
+     * @param options.synchronizerId defaults to the first connected synchronizer
+     * @param options.partyId optional internal party to receive tap, defaults to validator operator party
+     * @returns the updateId and completionOffset for the submitted tap command
+     */
 
-        await this.ledger.internal.submit({
+    async tapInternal(
+        amount: string,
+        options?: { partyId?: PartyId; synchronizerId?: string }
+    ) {
+        const partyId = options?.partyId ?? this.sdkContext.validatorParty
+        const synchronizerId =
+            options?.synchronizerId ??
+            this.sdkContext.commonCtx.defaultSynchronizerId
+        const [tapCommand, disclosedContracts] = await this.tap(partyId, amount)
+
+        return await this.ledger.internal.submit({
             commands: [tapCommand],
             disclosedContracts,
-            synchronizerId:
-                synchronizerId ??
-                this.sdkContext.commonCtx.defaultSynchronizerId,
-            actAs: [this.sdkContext.validatorParty],
+            synchronizerId,
+            actAs: [partyId],
         })
     }
 

--- a/sdk/wallet-sdk/src/wallet/namespace/amulet/preapproval.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/amulet/preapproval.ts
@@ -192,7 +192,7 @@ export class PreapprovalNamespace {
             oldCid,
             cancelled = false,
             timeoutMs = 5 * 60_000,
-            intervalMs = 15_000,
+            intervalMs = 10_000,
         } = options ?? {}
 
         const deadline = Date.now() + timeoutMs

--- a/sdk/wallet-sdk/src/wallet/namespace/amulet/preapproval.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/amulet/preapproval.ts
@@ -257,7 +257,7 @@ export class PreapprovalNamespace {
 
         this.ctx.commonCtx.error.throw({
             type: 'Unexpected',
-            message: `Timed out after ${Math.floor(timeoutMs / 1000)}, waiting for ${result}`,
+            message: `Timed out after ${Math.floor(timeoutMs / 1000)} seconds, waiting for ${result}`,
         })
     }
 }

--- a/sdk/wallet-sdk/src/wallet/namespace/amulet/preapproval.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/amulet/preapproval.ts
@@ -6,6 +6,7 @@ import { AmuletNamespaceConfig, LedgerTypes } from '../../sdk.js'
 import { PreapprovalParties } from './types.js'
 import { LedgerNamespace } from '../ledger/namespace.js'
 import { fetchAmulet } from './namespace.js'
+import { SDKLogger } from '../../logger/logger.js'
 
 const EMPTY_COMMAND_RESULT = [null, []] as const
 
@@ -32,8 +33,12 @@ export class PreapprovalNamespace {
         >
     }
     private readonly ledger: LedgerNamespace
+    private readonly logger: SDKLogger
 
     constructor(private readonly ctx: AmuletNamespaceConfig) {
+        this.logger = ctx.commonCtx.logger.child({
+            namespace: 'AmuletNamespace',
+        })
         this.ledger = new LedgerNamespace(ctx.commonCtx)
         this.command = {
             create: async (args) => {
@@ -68,7 +73,7 @@ export class PreapprovalNamespace {
                     !preapprovalStatus.contractId ||
                     !preapprovalStatus.templateId
                 ) {
-                    this.ctx.commonCtx.logger.warn(
+                    this.logger.warn(
                         'Cannot create cancel command since no preapprovals have been found'
                     )
                     return EMPTY_COMMAND_RESULT
@@ -154,34 +159,119 @@ export class PreapprovalNamespace {
     }
 
     /**
-     * Fetches the current status of a transfer preapproval for a given receiver party.
-     * Polls the amulet service for up to 5 minutes to find the preapproval.
+     * Wait for Scan Proxy to show a receiver's TransferPreapproval, or for its CID to change after renewal,
+     * or for it to disappear after cancel.
      *
-     * @param receiverParty - The party ID of the receiver to check for preapproval status
-     * @returns
-     * - a promise that resolves to the preapproval status including expiration date, DSO party, contract ID, and template ID
-     * - null when no results have been found
+     * Why: right after renew or cancel, the ledger is up to date, but Scan Proxy can lag. Poll until the
+     * preapproval appears (create), its CID changes (renew), or it disappears (cancel).
+     *
+     * Usage:
+     *  - After create: call without oldCid.
+     *  - After renew: pass oldCid.
+     *  - After cancel: set cancelled = true.
+     *
+     * @param receiverParty Receiver party id.
+     * @param options Optional settings.
+     * @param options.oldCid Resolve only when CID differs from this value (post-renew).
+     * @param options.expectGone Set true to resolve when no preapproval is returned (post-cancel).
+     * @param options.intervalMs Poll interval in milliseconds. Default is 15000.
+     * @param options.timeoutMs Maximum wait time in milliseconds. Default is 300000.
+     * @returns Resolves with the preapproval (for create/renew) or null (for cancelled).
+     * @throws If the timeout elapses before the condition is met.
      */
-    public async fetchStatus(receiverParty: PartyId) {
-        const deadline = Date.now() + 5 * 60_000
-        while (Date.now() < deadline) {
-            const rawPreapproval = await this.ctx.amuletService
-                .getTransferPreApprovalByParty(receiverParty)
-                .catch(() => {})
-            if (rawPreapproval) {
-                const { dso, expiresAt } = rawPreapproval.contract.payload
-                const contractId = rawPreapproval?.contract?.contract_id
-                const templateId = rawPreapproval?.contract?.template_id
+    public async fetchStatus(
+        receiverParty: PartyId,
+        options?: {
+            oldCid?: string
+            cancelled?: boolean
+            timeoutMs?: number
+            intervalMs?: number
+        }
+    ) {
+        const {
+            oldCid,
+            cancelled = false,
+            timeoutMs = 5 * 60_000,
+            intervalMs = 15_000,
+        } = options ?? {}
 
-                return {
-                    expiresAt: new Date(expiresAt),
-                    dso,
-                    contractId,
-                    templateId,
+        const deadline = Date.now() + timeoutMs
+
+        while (Date.now() < deadline) {
+            try {
+                const rawPreapproval =
+                    await this.ctx.amuletService.getTransferPreApprovalByParty(
+                        receiverParty
+                    )
+
+                if (cancelled) {
+                    this.logger.debug(
+                        'Preapproval is still visible, polling again'
+                    )
+                } else {
+                    const contractId = rawPreapproval.contract.contract_id
+                    const templateId = rawPreapproval.contract.template_id
+                    const { dso, expiresAt } = rawPreapproval.contract.payload
+                    const result = {
+                        expiresAt: new Date(expiresAt),
+                        dso,
+                        contractId,
+                        templateId,
+                    }
+
+                    if (!oldCid) {
+                        this.logger.info(
+                            `New preapproval is visible with contractId: ${contractId}`
+                        )
+                        return result
+                    }
+                    if (contractId && contractId !== oldCid) {
+                        this.logger.info(
+                            `Rewewed preapproval is visible with new contractId: ${contractId}`
+                        )
+                        return result
+                    }
+
+                    this.logger.debug(
+                        `Preapproval is visible but cId is unchanged, polling again.`
+                    )
                 }
+            } catch (e) {
+                if (cancelled && isNotFoundError(e)) {
+                    this.logger.info('Preapproval is no longer visible')
+                    return null
+                }
+                this.logger.debug(
+                    'Fetch preapproval status failed, retrying agian. '
+                )
+
+                await new Promise((resolve) => setTimeout(resolve, intervalMs))
             }
         }
-        this.ctx.commonCtx.logger.warn('No preapproval found')
-        return null
+
+        const result = cancelled
+            ? 'preapproval to disappear'
+            : oldCid
+              ? `preapproval cId to change from ${oldCid}`
+              : 'preapproval to appear'
+
+        this.ctx.commonCtx.error.throw({
+            type: 'Unexpected',
+            message: `Timed out after ${Math.floor(timeoutMs / 1000)}, waiting for ${result}`,
+        })
     }
+}
+
+// The scan proxy emits an unstructured error object, so this determines whether the preapproval is actually not found
+// Whereas sometimes there can be other server errors
+function isNotFoundError(e: unknown): boolean {
+    return (
+        typeof e === 'object' &&
+        e !== null &&
+        'error' in e &&
+        typeof (e as { error: unknown }).error === 'string' &&
+        (e as { error: string }).error.startsWith(
+            'No TransferPreapproval found for party'
+        )
+    )
 }


### PR DESCRIPTION
We were previously ignoring the preapproval script in CI (this was leftover from the wallet sdk v0.

The test was falsely succeeding during the renewal step because `fetchedPreapprovalStatus?.expiresAt === fetchedStatusAfterRenew?.expiresAt` was always not equal to each other (even if is the same time) and failing at the `fetchStatus` step when checking for the cancellation. This updates fetchStatus to check for different conditions (create, renewal or cancel) and adds the tapInternal, which is required for the CI otherwise there will not be enough funds to create the transfer preapproval. 

Additionally, this updates the batch test execution to batches of 5 and modified the function slightly so that the tests can run concurrently. Previously, we would need batch 1 to all finish before the batch 2 scripts could start, now once one script finishes then the next one can start.