### PR TITLE
chore: cache yarn

### DIFF
--- a/.github/actions/setup_yarn/action.yml
+++ b/.github/actions/setup_yarn/action.yml
@@ -13,16 +13,16 @@ runs:
               node-version: 'v24.9.0'
               cache: 'yarn'
 
-        - name: Install dependencies
-          shell: bash
-          run: yarn install --immutable
-
         - name: Download build artifacts
           id: download_build_artifacts
           continue-on-error: true
           uses: actions/download-artifact@v4
           with:
               name: build-dist-${{ github.run_id }}
+
+        - name: Install dependencies
+          shell: bash
+          run: yarn install --immutable
 
         - name: generate all
           if: ${{ steps.download_build_artifacts.outcome == 'failure' || steps.download_build_artifacts.outputs.download-path == '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,11 @@ jobs:
               with:
                   name: build-dist-${{ github.run_id }}
                   path: |
+                      .yarn/cache/
+                      .yarn/unplugged/
+                      .yarn/install-state.gz
+                      .pnp.cjs
+                      .pnp.loader.mjs
                       core/*/dist/
                       sdk/*/dist/
                       sdk-support/*/dist/


### PR DESCRIPTION
caches the yarn related files as part of the build artifacts.