### PR TITLE
fix: merge utxos stress test and ensure the precision of merge amount doesn't go over 10

### DIFF
--- a/docs/wallet-integration-guide/examples/package.json
+++ b/docs/wallet-integration-guide/examples/package.json
@@ -48,6 +48,7 @@
         "@canton-network/core-wallet-auth": "workspace:^",
         "@canton-network/wallet-sdk": "workspace:^",
         "bip39": "^3.1.0",
+        "decimal.js": "^10.6.0",
         "pino": "10.3.1",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1",

--- a/docs/wallet-integration-guide/examples/package.json
+++ b/docs/wallet-integration-guide/examples/package.json
@@ -26,7 +26,8 @@
         "run-12": "tsx ./scripts/12-subscribe-to-events.ts | pino-pretty",
         "run-13": "tsx ./scripts/13-rewards-for-deposits/index.ts | pino-pretty",
         "run-14": "tsx ./scripts/14-offline-signing.ts | pino-pretty",
-        "stress-run-01": "tsx ./scripts/stress/01-merge-utxos.ts | pino-pretty"
+        "stress-run-01": "tsx ./scripts/stress/01-merge-utxos.ts | pino-pretty",
+        "stress-run-02": "tsx ./scripts/stress/02-merge-utxos-delegate.ts | pino-pretty"
     },
     "devDependencies": {
         "@canton-network/core-signing-lib": "workspace:^",

--- a/docs/wallet-integration-guide/examples/package.json
+++ b/docs/wallet-integration-guide/examples/package.json
@@ -25,7 +25,8 @@
         "run-11": "tsx ./scripts/11-hashing.ts | pino-pretty",
         "run-12": "tsx ./scripts/12-subscribe-to-events.ts | pino-pretty",
         "run-13": "tsx ./scripts/13-rewards-for-deposits/index.ts | pino-pretty",
-        "run-14": "tsx ./scripts/14-offline-signing.ts | pino-pretty"
+        "run-14": "tsx ./scripts/14-offline-signing.ts | pino-pretty",
+        "stress-run-01": "tsx ./scripts/stress/01-merge-utxos.ts | pino-pretty"
     },
     "devDependencies": {
         "@canton-network/core-signing-lib": "workspace:^",

--- a/docs/wallet-integration-guide/examples/scripts/stress/01-merge-utxos.ts
+++ b/docs/wallet-integration-guide/examples/scripts/stress/01-merge-utxos.ts
@@ -1,0 +1,95 @@
+import pino from 'pino'
+import { localNetStaticConfig, SDK } from '@canton-network/wallet-sdk'
+import {
+    TOKEN_NAMESPACE_CONFIG,
+    TOKEN_PROVIDER_CONFIG_DEFAULT,
+    AMULET_NAMESPACE_CONFIG,
+} from '../utils/index.js'
+
+const logger = pino({ name: 'v1-06-merge-utxos', level: 'info' })
+
+const sdk = await SDK.create({
+    auth: TOKEN_PROVIDER_CONFIG_DEFAULT,
+    ledgerClientUrl: localNetStaticConfig.LOCALNET_APP_USER_LEDGER_URL,
+    token: TOKEN_NAMESPACE_CONFIG,
+    amulet: AMULET_NAMESPACE_CONFIG,
+})
+
+const aliceKeys = sdk.keys.generate()
+
+const alice = await sdk.party.external
+    .create(aliceKeys.publicKey, {
+        partyHint: 'v1-06-alice',
+    })
+    .sign(aliceKeys.privateKey)
+    .execute()
+
+// Mint holdings for alice
+
+const TOTAL_TAPS = 115
+const BATCH_SIZE = 10
+
+const tapIndices = Array.from({ length: TOTAL_TAPS })
+
+for (let i = 0; i < tapIndices.length; i += BATCH_SIZE) {
+    const batch = tapIndices.slice(i, i + BATCH_SIZE)
+    const batchNumber = Math.floor(i / BATCH_SIZE)
+    const batchEnd = Math.min(i + BATCH_SIZE, TOTAL_TAPS)
+    logger.info(
+        `Running tap batch  ${batchNumber}:${i + 1}=${batchEnd} of ${TOTAL_TAPS}`
+    )
+
+    const randomAmount = () => Math.floor(Math.random() * 1000) + 1000
+
+    await Promise.all(
+        batch.map(async () => {
+            const [amuletTapCommand, amuletTapDisclosedContracts] =
+                await sdk.amulet.tap(alice.partyId, randomAmount().toString())
+
+            return sdk.ledger
+                .prepare({
+                    partyId: alice.partyId,
+                    commands: amuletTapCommand,
+                    disclosedContracts: amuletTapDisclosedContracts,
+                })
+                .sign(aliceKeys.privateKey)
+                .execute({ partyId: alice.partyId })
+        })
+    )
+
+    logger.info(`Tap batch ${batchNumber} complete`)
+}
+
+const utxosAlice = await sdk.token.utxos.list({
+    partyId: alice.partyId,
+})
+
+logger.info(`number of unlocked utxos for alice ${utxosAlice.length}`)
+
+const [mergeUtxoCommands, mergedDisclosedContracts] =
+    await sdk.token.utxos.merge({
+        partyId: alice.partyId,
+    })
+
+const mergePromises = mergeUtxoCommands.map((mergeCommand) => {
+    return sdk.ledger
+        .prepare({
+            partyId: alice.partyId,
+            commands: mergeCommand,
+            disclosedContracts: mergedDisclosedContracts,
+        })
+        .sign(aliceKeys.privateKey)
+        .execute({ partyId: alice.partyId })
+})
+
+await Promise.all(mergePromises)
+
+const utxosAliceMerged = await sdk.token.utxos.list({
+    partyId: alice.partyId,
+})
+
+if (utxosAliceMerged.length === 2) {
+    logger.info(`utxos successfully merged from ${utxosAlice.length} to 2`)
+} else {
+    throw new Error(`utxos not successfully merged`)
+}

--- a/docs/wallet-integration-guide/examples/scripts/stress/01-merge-utxos.ts
+++ b/docs/wallet-integration-guide/examples/scripts/stress/01-merge-utxos.ts
@@ -6,6 +6,7 @@ import {
     AMULET_NAMESPACE_CONFIG,
 } from '../utils/index.js'
 import { batchTap } from './utils.js'
+import Decimal from 'decimal.js'
 
 const logger = pino({ name: 'v1-01-merge-utxos', level: 'info' })
 
@@ -30,7 +31,7 @@ const alice = await sdk.party.external
 const TOTAL_TAPS = 115
 const BATCH_SIZE = 10
 
-await batchTap(
+const totalSum = await batchTap(
     TOTAL_TAPS,
     BATCH_SIZE,
     sdk,
@@ -67,8 +68,13 @@ const utxosAliceMerged = await sdk.token.utxos.list({
     partyId: alice.partyId,
 })
 
-if (utxosAliceMerged.length === 2) {
-    logger.info(`utxos successfully merged from ${utxosAlice.length} to 2`)
-} else {
-    throw new Error(`utxos not successfully merged`)
+const result = {
+    length: utxosAliceMerged.length,
+    amount: utxosAliceMerged.reduce(
+        (acc, utxo) => acc.plus(new Decimal(utxo.interfaceViewValue.amount)),
+        new Decimal(0)
+    ),
 }
+
+if (result.length !== 2 || !result.amount.equals(totalSum))
+    throw Error('Utxos were not merged successfully')

--- a/docs/wallet-integration-guide/examples/scripts/stress/01-merge-utxos.ts
+++ b/docs/wallet-integration-guide/examples/scripts/stress/01-merge-utxos.ts
@@ -5,8 +5,9 @@ import {
     TOKEN_PROVIDER_CONFIG_DEFAULT,
     AMULET_NAMESPACE_CONFIG,
 } from '../utils/index.js'
+import { batchTap } from './utils.js'
 
-const logger = pino({ name: 'v1-06-merge-utxos', level: 'info' })
+const logger = pino({ name: 'v1-01-merge-utxos', level: 'info' })
 
 const sdk = await SDK.create({
     auth: TOKEN_PROVIDER_CONFIG_DEFAULT,
@@ -29,36 +30,14 @@ const alice = await sdk.party.external
 const TOTAL_TAPS = 115
 const BATCH_SIZE = 10
 
-const tapIndices = Array.from({ length: TOTAL_TAPS })
-
-for (let i = 0; i < tapIndices.length; i += BATCH_SIZE) {
-    const batch = tapIndices.slice(i, i + BATCH_SIZE)
-    const batchNumber = Math.floor(i / BATCH_SIZE)
-    const batchEnd = Math.min(i + BATCH_SIZE, TOTAL_TAPS)
-    logger.info(
-        `Running tap batch  ${batchNumber}:${i + 1}=${batchEnd} of ${TOTAL_TAPS}`
-    )
-
-    const randomAmount = () => Math.floor(Math.random() * 1000) + 1000
-
-    await Promise.all(
-        batch.map(async () => {
-            const [amuletTapCommand, amuletTapDisclosedContracts] =
-                await sdk.amulet.tap(alice.partyId, randomAmount().toString())
-
-            return sdk.ledger
-                .prepare({
-                    partyId: alice.partyId,
-                    commands: amuletTapCommand,
-                    disclosedContracts: amuletTapDisclosedContracts,
-                })
-                .sign(aliceKeys.privateKey)
-                .execute({ partyId: alice.partyId })
-        })
-    )
-
-    logger.info(`Tap batch ${batchNumber} complete`)
-}
+await batchTap(
+    TOTAL_TAPS,
+    BATCH_SIZE,
+    sdk,
+    alice.partyId,
+    aliceKeys.privateKey,
+    logger
+)
 
 const utxosAlice = await sdk.token.utxos.list({
     partyId: alice.partyId,

--- a/docs/wallet-integration-guide/examples/scripts/stress/02-merge-utxos-delegate.ts
+++ b/docs/wallet-integration-guide/examples/scripts/stress/02-merge-utxos-delegate.ts
@@ -1,0 +1,147 @@
+import pino from 'pino'
+import { localNetStaticConfig, SDK } from '@canton-network/wallet-sdk'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { existsSync } from 'fs'
+import { readFile } from 'fs/promises'
+import {
+    TOKEN_NAMESPACE_CONFIG,
+    TOKEN_PROVIDER_CONFIG_DEFAULT,
+    AMULET_NAMESPACE_CONFIG,
+} from '../utils/index.js'
+
+const logger = pino({ name: 'v1-08-merge-delegation', level: 'info' })
+
+const PATH_TO_LOCALNET = '../../../../../.localnet'
+const PATH_TO_DAR_IN_LOCALNET =
+    '/dars/splice-util-token-standard-wallet-1.0.0.dar'
+const SPLICE_UTIL_TOKEN_STANDARD_WALLET_PACKAGE_ID =
+    '1da198cb7968fa478cfa12aba9fdf128a63a8af6ab284ea6be238cf92a3733ac'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+const spliceUtilTokenStandardWalletDarPath = path.join(
+    here,
+    PATH_TO_LOCALNET,
+    PATH_TO_DAR_IN_LOCALNET
+)
+if (!existsSync(spliceUtilTokenStandardWalletDarPath)) {
+    throw Error(`DAR NOT FOUND AT ${spliceUtilTokenStandardWalletDarPath}.`)
+}
+
+const sdk = await SDK.create({
+    auth: TOKEN_PROVIDER_CONFIG_DEFAULT,
+    ledgerClientUrl: localNetStaticConfig.LOCALNET_APP_USER_LEDGER_URL,
+    token: TOKEN_NAMESPACE_CONFIG,
+    amulet: AMULET_NAMESPACE_CONFIG,
+})
+
+const darBytes = await readFile(spliceUtilTokenStandardWalletDarPath)
+await sdk.ledger.dar.upload(
+    darBytes,
+    SPLICE_UTIL_TOKEN_STANDARD_WALLET_PACKAGE_ID
+)
+
+logger.info(`DAR ${PATH_TO_DAR_IN_LOCALNET} successfully uploaded`)
+
+const aliceKeys = sdk.keys.generate()
+
+const alice = await sdk.party.external
+    .create(aliceKeys.publicKey, {
+        partyHint: 'v1-08-alice',
+    })
+    .sign(aliceKeys.privateKey)
+    .execute()
+
+const TOTAL_TAPS = 115
+const BATCH_SIZE = 10
+const tapIndices = Array.from({ length: TOTAL_TAPS })
+
+for (let i = 0; i < tapIndices.length; i += BATCH_SIZE) {
+    const batch = tapIndices.slice(i, i + BATCH_SIZE)
+    const batchNumber = Math.floor(i / BATCH_SIZE)
+    const batchEnd = Math.min(i + BATCH_SIZE, TOTAL_TAPS)
+    logger.info(
+        `Running tap batch  ${batchNumber}:${i + 1}=${batchEnd} of ${TOTAL_TAPS}`
+    )
+
+    const randomAmount = () => Math.floor(Math.random() * 1000) + 1000
+    await Promise.all(
+        batch.map(async () => {
+            const [amuletTapCommand, amuletTapDisclosedContracts] =
+                await sdk.amulet.tap(alice.partyId, randomAmount().toString())
+
+            return sdk.ledger
+                .prepare({
+                    partyId: alice.partyId,
+                    commands: amuletTapCommand,
+                    disclosedContracts: amuletTapDisclosedContracts,
+                })
+                .sign(aliceKeys.privateKey)
+                .execute({ partyId: alice.partyId })
+        })
+    )
+
+    logger.info(`Tap batch ${batchNumber} complete`)
+}
+
+logger.info('All taps successfully parsed')
+
+const batchMergingUtility = await sdk.token.utxos.delegatedMerge.setup()
+
+logger.info({ batchMergingUtility })
+
+const mergeDelegationProposalCommand =
+    sdk.token.utxos.delegatedMerge.command.propose({
+        owner: alice.partyId,
+    })
+
+const mergeDelegationProposalResult = await sdk.ledger
+    .prepare({
+        partyId: alice.partyId,
+        commands: mergeDelegationProposalCommand,
+    })
+    .sign(aliceKeys.privateKey)
+    .execute({
+        partyId: alice.partyId,
+    })
+
+logger.info(
+    mergeDelegationProposalResult,
+    'Successfully executed mergeDelegationProposalCommand'
+)
+
+const approveMergeDelegationProposalResult =
+    await sdk.token.utxos.delegatedMerge.approve({
+        owner: alice.partyId,
+    })
+
+logger.info(
+    approveMergeDelegationProposalResult,
+    'Successfully executed approveDelegationProposalCommand'
+)
+
+const mergeDelegationResult = await sdk.token.utxos.delegatedMerge.execute({
+    party: alice.partyId,
+})
+
+logger.info(
+    mergeDelegationResult,
+    'Successfully executed useMergeDelegationsCommand'
+)
+
+const utxosAlice = await sdk.token.utxos.list({
+    partyId: alice.partyId,
+})
+
+const result = {
+    length: utxosAlice.length,
+    amount: utxosAlice.reduce(
+        (acc, utxo) => acc + +utxo.interfaceViewValue.amount,
+        0
+    ),
+}
+
+logger.info({ result }, 'Result from the script')
+
+if (result.length !== 2) throw Error('Utxos were not merged successfully')

--- a/docs/wallet-integration-guide/examples/scripts/stress/02-merge-utxos-delegate.ts
+++ b/docs/wallet-integration-guide/examples/scripts/stress/02-merge-utxos-delegate.ts
@@ -9,8 +9,8 @@ import {
     TOKEN_PROVIDER_CONFIG_DEFAULT,
     AMULET_NAMESPACE_CONFIG,
 } from '../utils/index.js'
-
-const logger = pino({ name: 'v1-08-merge-delegation', level: 'info' })
+import { batchTap } from './utils.js'
+const logger = pino({ name: 'v1-02-merge-delegation', level: 'info' })
 
 const PATH_TO_LOCALNET = '../../../../../.localnet'
 const PATH_TO_DAR_IN_LOCALNET =
@@ -53,38 +53,7 @@ const alice = await sdk.party.external
     .sign(aliceKeys.privateKey)
     .execute()
 
-const TOTAL_TAPS = 115
-const BATCH_SIZE = 10
-const tapIndices = Array.from({ length: TOTAL_TAPS })
-
-for (let i = 0; i < tapIndices.length; i += BATCH_SIZE) {
-    const batch = tapIndices.slice(i, i + BATCH_SIZE)
-    const batchNumber = Math.floor(i / BATCH_SIZE)
-    const batchEnd = Math.min(i + BATCH_SIZE, TOTAL_TAPS)
-    logger.info(
-        `Running tap batch  ${batchNumber}:${i + 1}=${batchEnd} of ${TOTAL_TAPS}`
-    )
-
-    const randomAmount = () => Math.floor(Math.random() * 1000) + 1000
-    await Promise.all(
-        batch.map(async () => {
-            const [amuletTapCommand, amuletTapDisclosedContracts] =
-                await sdk.amulet.tap(alice.partyId, randomAmount().toString())
-
-            return sdk.ledger
-                .prepare({
-                    partyId: alice.partyId,
-                    commands: amuletTapCommand,
-                    disclosedContracts: amuletTapDisclosedContracts,
-                })
-                .sign(aliceKeys.privateKey)
-                .execute({ partyId: alice.partyId })
-        })
-    )
-
-    logger.info(`Tap batch ${batchNumber} complete`)
-}
-
+await batchTap(115, 10, sdk, alice.partyId, aliceKeys.privateKey, logger)
 logger.info('All taps successfully parsed')
 
 const batchMergingUtility = await sdk.token.utxos.delegatedMerge.setup()

--- a/docs/wallet-integration-guide/examples/scripts/stress/02-merge-utxos-delegate.ts
+++ b/docs/wallet-integration-guide/examples/scripts/stress/02-merge-utxos-delegate.ts
@@ -10,6 +10,7 @@ import {
     AMULET_NAMESPACE_CONFIG,
 } from '../utils/index.js'
 import { batchTap } from './utils.js'
+import Decimal from 'decimal.js'
 const logger = pino({ name: 'v1-02-merge-delegation', level: 'info' })
 
 const PATH_TO_LOCALNET = '../../../../../.localnet'
@@ -53,8 +54,15 @@ const alice = await sdk.party.external
     .sign(aliceKeys.privateKey)
     .execute()
 
-await batchTap(115, 10, sdk, alice.partyId, aliceKeys.privateKey, logger)
-logger.info('All taps successfully parsed')
+const totalSum = await batchTap(
+    115,
+    10,
+    sdk,
+    alice.partyId,
+    aliceKeys.privateKey,
+    logger
+)
+logger.info(`All taps successfully parsed with totalTapped: ${totalSum}`)
 
 const batchMergingUtility = await sdk.token.utxos.delegatedMerge.setup()
 
@@ -106,11 +114,12 @@ const utxosAlice = await sdk.token.utxos.list({
 const result = {
     length: utxosAlice.length,
     amount: utxosAlice.reduce(
-        (acc, utxo) => acc + +utxo.interfaceViewValue.amount,
-        0
+        (acc, utxo) => acc.plus(new Decimal(utxo.interfaceViewValue.amount)),
+        new Decimal(0)
     ),
 }
 
 logger.info({ result }, 'Result from the script')
 
-if (result.length !== 2) throw Error('Utxos were not merged successfully')
+if (result.length !== 2 || !result.amount.equals(totalSum))
+    throw Error('Utxos were not merged successfully')

--- a/docs/wallet-integration-guide/examples/scripts/stress/utils.ts
+++ b/docs/wallet-integration-guide/examples/scripts/stress/utils.ts
@@ -1,0 +1,44 @@
+import { PrivateKey } from '@canton-network/core-signing-lib'
+import { PartyId } from '@canton-network/core-types'
+import { SDKInterface } from '@canton-network/wallet-sdk'
+import { Logger } from 'pino'
+
+export async function batchTap(
+    totalTaps: number,
+    batchSize: number,
+    sdk: SDKInterface<'amulet'>,
+    partyId: PartyId,
+    privateKey: PrivateKey,
+    logger: Logger
+) {
+    const tapIndices = Array.from({ length: totalTaps })
+
+    for (let i = 0; i < tapIndices.length; i += batchSize) {
+        const batch = tapIndices.slice(i, i + batchSize)
+        const batchNumber = Math.floor(i / batchSize)
+        const batchEnd = Math.min(i + batchSize, totalTaps)
+        logger.info(
+            `Running tap batch  ${batchNumber}:${i + 1}-${batchEnd} of ${totalTaps}`
+        )
+
+        const randomAmount = () => Math.floor(Math.random() * 1000) + 1000
+
+        await Promise.all(
+            batch.map(async () => {
+                const [amuletTapCommand, amuletTapDisclosedContracts] =
+                    await sdk.amulet.tap(partyId, randomAmount().toString())
+
+                return sdk.ledger
+                    .prepare({
+                        partyId: partyId,
+                        commands: amuletTapCommand,
+                        disclosedContracts: amuletTapDisclosedContracts,
+                    })
+                    .sign(privateKey)
+                    .execute({ partyId: partyId })
+            })
+        )
+
+        logger.info(`Tap batch ${batchNumber} complete`)
+    }
+}

--- a/docs/wallet-integration-guide/examples/scripts/stress/utils.ts
+++ b/docs/wallet-integration-guide/examples/scripts/stress/utils.ts
@@ -1,6 +1,7 @@
 import { PrivateKey } from '@canton-network/core-signing-lib'
 import { PartyId } from '@canton-network/core-types'
 import { SDKInterface } from '@canton-network/wallet-sdk'
+import Decimal from 'decimal.js'
 import { Logger } from 'pino'
 
 export async function batchTap(
@@ -12,6 +13,8 @@ export async function batchTap(
     logger: Logger
 ) {
     const tapIndices = Array.from({ length: totalTaps })
+    const randomAmount = () => Math.random() * 100 + 1000
+    let totalTapped = new Decimal(0)
 
     for (let i = 0; i < tapIndices.length; i += batchSize) {
         const batch = tapIndices.slice(i, i + batchSize)
@@ -20,12 +23,12 @@ export async function batchTap(
         logger.info(
             `Running tap batch  ${batchNumber}:${i + 1}-${batchEnd} of ${totalTaps}`
         )
+        const amounts = batch.map(() => new Decimal(randomAmount()).toFixed(10))
 
-        const randomAmount = () => Math.random() * 100 + 1000
         await Promise.all(
-            batch.map(async () => {
+            amounts.map(async (amount) => {
                 const [amuletTapCommand, amuletTapDisclosedContracts] =
-                    await sdk.amulet.tap(partyId, randomAmount().toString())
+                    await sdk.amulet.tap(partyId, amount.toString())
 
                 return sdk.ledger
                     .prepare({
@@ -38,6 +41,12 @@ export async function batchTap(
             })
         )
 
+        totalTapped = amounts.reduce(
+            (acc, amount) => acc.plus(amount),
+            totalTapped
+        )
+
         logger.info(`Tap batch ${batchNumber} complete`)
     }
+    return totalTapped
 }

--- a/docs/wallet-integration-guide/examples/scripts/stress/utils.ts
+++ b/docs/wallet-integration-guide/examples/scripts/stress/utils.ts
@@ -21,8 +21,7 @@ export async function batchTap(
             `Running tap batch  ${batchNumber}:${i + 1}-${batchEnd} of ${totalTaps}`
         )
 
-        const randomAmount = () => Math.floor(Math.random() * 1000) + 1000
-
+        const randomAmount = () => Math.random() * 100 + 1000
         await Promise.all(
             batch.map(async () => {
                 const [amuletTapCommand, amuletTapDisclosedContracts] =

--- a/sdk/wallet-sdk/src/wallet/namespace/amulet/namespace.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/amulet/namespace.ts
@@ -59,7 +59,7 @@ export class AmuletNamespace {
         const [tapCommand, disclosedContracts] =
             await this.sdkContext.amuletService.createTap(
                 partyId,
-                amount,
+                new Decimal(amount).toFixed(10),
                 amulet.admin,
                 amulet.id,
                 amulet.registryUrl

--- a/sdk/wallet-sdk/src/wallet/namespace/amulet/namespace.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/amulet/namespace.ts
@@ -85,11 +85,7 @@ export class AmuletNamespace {
         const synchronizerId =
             options?.synchronizerId ??
             this.sdkContext.commonCtx.defaultSynchronizerId
-
-        const [tapCommand, disclosedContracts] = await this.tap(
-            partyId,
-            new Decimal(amount).toDecimalPlaces(10).toFixed(10)
-        )
+        const [tapCommand, disclosedContracts] = await this.tap(partyId, amount)
 
         return await this.ledger.internal.submit({
             commands: [tapCommand],

--- a/sdk/wallet-sdk/src/wallet/namespace/amulet/namespace.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/amulet/namespace.ts
@@ -14,6 +14,7 @@ import { TokenStandardService } from '@canton-network/core-token-standard-servic
 import { TrafficNamespace } from './traffic.js'
 import { LedgerNamespace } from '../ledger/namespace.js'
 import { PreapprovalNamespace } from './preapproval.js'
+import { Decimal } from 'decimal.js'
 
 const defaultMaxRetries = 10
 const defaultDelayMs = 5000
@@ -84,7 +85,11 @@ export class AmuletNamespace {
         const synchronizerId =
             options?.synchronizerId ??
             this.sdkContext.commonCtx.defaultSynchronizerId
-        const [tapCommand, disclosedContracts] = await this.tap(partyId, amount)
+
+        const [tapCommand, disclosedContracts] = await this.tap(
+            partyId,
+            new Decimal(amount).toDecimalPlaces(10).toFixed(10)
+        )
 
         return await this.ledger.internal.submit({
             commands: [tapCommand],

--- a/sdk/wallet-sdk/src/wallet/namespace/token/utxos/service.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/token/utxos/service.ts
@@ -85,7 +85,12 @@ export class UtxoNamespace {
                     const inputUtxos = group.slice(start, end)
 
                     const accumulatedAmount = inputUtxos.reduce(
-                        (a, b) => a.plus(b.interfaceViewValue.amount),
+                        (a, b) =>
+                            a.plus(
+                                new Decimal(
+                                    b.interfaceViewValue.amount
+                                ).toDecimalPlaces(10)
+                            ),
                         new Decimal(0)
                     )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10397,6 +10397,7 @@ __metadata:
     "@types/node": "npm:^25.3.3"
     "@vitest/coverage-v8": "npm:^4.1.2"
     bip39: "npm:^3.1.0"
+    decimal.js: "npm:^10.6.0"
     pino: "npm:10.3.1"
     pino-pretty: "npm:^13.1.3"
     tsx: "npm:^4.21.0"


### PR DESCRIPTION
Adds stress tests for merging utxos with and without a delegate. Ensures that the merge amount and tap amount is always capped at 10 decimal places to avoid the following canton error:

```
code: 'COMMAND_PREPROCESSING_FAILED',
cause: 'Cannot represent 222.63899999999998 as (Numeric 10) without loss of precision',
```