### PR TITLE
fix(wallet-gateway-remote): support scp scoping in jwt

### DIFF
--- a/mock-oauth2/src/index.ts
+++ b/mock-oauth2/src/index.ts
@@ -144,7 +144,8 @@ async function main() {
             process.env.BLOCKDAEMON_API_EMAIL ||
             'phillip.olesen@digitalasset.com'
         token.payload.aud = aud
-        token.payload.scope = 'daml_ledger_api'
+        //alternative to scope claim
+        token.payload.scp = ['daml_ledger_api']
 
         // Set token expiration to 1 hour from now
         const now = Math.floor(Date.now() / 1000)

--- a/wallet-gateway/remote/src/auth/jwt-auth-service.ts
+++ b/wallet-gateway/remote/src/auth/jwt-auth-service.ts
@@ -45,10 +45,14 @@ export const jwtAuthService = (store: Store, logger: Logger): AuthService => ({
                 return undefined
             }
 
-            const scope = decoded.scope
+            let scope = decoded.scope
             if (!scope) {
-                logger.warn('JWT does not contain a scope')
-                return undefined
+                const scopeAlternate = decoded.scp
+                if (!scopeAlternate) {
+                    logger.warn('JWT does not contain a scope claim')
+                    return undefined
+                }
+                scope = scopeAlternate
             }
 
             if (idp.type == 'self_signed') {

--- a/wallet-gateway/remote/src/auth/jwt-auth-service.ts
+++ b/wallet-gateway/remote/src/auth/jwt-auth-service.ts
@@ -45,14 +45,9 @@ export const jwtAuthService = (store: Store, logger: Logger): AuthService => ({
                 return undefined
             }
 
-            let scope = decoded.scope
-            if (!scope) {
-                const scopeAlternate = decoded.scp
-                if (!scopeAlternate) {
-                    logger.warn('JWT does not contain a scope claim')
-                    return undefined
-                }
-                scope = scopeAlternate
+            if (!decoded.scope && !decoded.scp) {
+                logger.warn('JWT does not contain a scope claim')
+                return undefined
             }
 
             if (idp.type == 'self_signed') {


### PR DESCRIPTION
enables support for scp as an alternative to scope