### PR TITLE
chore: rename hyperledger labs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Wallet Gateway maintainers (Default)
-*                  @hyperledger-labs/splice-wallet-kernel-admins @hyperledger-labs/splice-wallet-kernel-contributors
+*                      @canton-network/wallet-gateway-admins @canton-network/wallet-gateway-maintainers
 
 # Wallet Gateway admins
-.github/*              @hyperledger-labs/splice-wallet-kernel-admins
-.vscode/*              @hyperledger-labs/splice-wallet-kernel-admins
-CODEOWNERS             @hyperledger-labs/splice-wallet-kernel-admins
-LICENSE                @hyperledger-labs/splice-wallet-kernel-admins
+.github/*              @canton-network/wallet-gateway-admins
+.vscode/*              @canton-network/wallet-gateway-admins
+CODEOWNERS             @canton-network/wallet-gateway-admins
+LICENSE                @canton-network/wallet-gateway-admins

--- a/canton/README.md
+++ b/canton/README.md
@@ -4,4 +4,4 @@ This directory contains configuration for a local Canton setup. It starts a part
 
 ## Usage
 
-To run the Canton setup yourself, follow the steps from the [canton](https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/docs/CONTRIBUTING.md#canton) section of the CONTRIBUTING.md guide.
+To run the Canton setup yourself, follow the steps from the [canton](https://github.com/canton-network/wallet-gateway/blob/main/docs/CONTRIBUTING.md#canton) section of the CONTRIBUTING.md guide.

--- a/core/acs-reader/package.json
+++ b/core/acs-reader/package.json
@@ -53,7 +53,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/acs-reader"
     }
 }

--- a/core/amulet-service/package.json
+++ b/core/amulet-service/package.json
@@ -55,7 +55,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/amulet-service"
     }
 }

--- a/core/asyncapi-client/package.json
+++ b/core/asyncapi-client/package.json
@@ -50,7 +50,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/asyncapi-client"
     }
 }

--- a/core/daml-codegen-helpers/package.json
+++ b/core/daml-codegen-helpers/package.json
@@ -41,7 +41,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/daml-codegen-helpers"
     }
 }

--- a/core/ledger-client-types/package.json
+++ b/core/ledger-client-types/package.json
@@ -50,7 +50,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/ledger-client-types"
     }
 }

--- a/core/ledger-client/package.json
+++ b/core/ledger-client/package.json
@@ -56,7 +56,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/ledger-client"
     }
 }

--- a/core/ledger-proto/package.json
+++ b/core/ledger-proto/package.json
@@ -48,7 +48,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/ledger-proto"
     }
 }

--- a/core/provider-dapp/package.json
+++ b/core/provider-dapp/package.json
@@ -49,7 +49,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/provider-dapp"
     }
 }

--- a/core/provider-ledger/README.md
+++ b/core/provider-ledger/README.md
@@ -1,6 +1,6 @@
 # provider-ledger
 
-This package provides a SpliceProvider (see https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/core/splice-provider) implementation intended for direct Ledger usage. It is suitable for both NodeJS and browser environments, but if you are building a Canton dApp, then you likely want to use the [`dapp-sdk`](https://www.npmjs.com/package/@canton-network/dapp-sdk) instead, which gives a `DappProvider`.
+This package provides a SpliceProvider (see https://github.com/canton-network/wallet-gateway/tree/main/core/splice-provider) implementation intended for direct Ledger usage. It is suitable for both NodeJS and browser environments, but if you are building a Canton dApp, then you likely want to use the [`dapp-sdk`](https://www.npmjs.com/package/@canton-network/dapp-sdk) instead, which gives a `DappProvider`.
 
 This provider only supports a single method, `ledgerApi`, which proxies request through to an underlying Ledger JSON-API client. Due to the nature of the Canton Ledger JSON-API, the only supported transport is HTTP.
 

--- a/core/provider-ledger/package.json
+++ b/core/provider-ledger/package.json
@@ -47,7 +47,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/provider-ledger"
     }
 }

--- a/core/rpc-errors/package.json
+++ b/core/rpc-errors/package.json
@@ -42,7 +42,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/rpc-errors"
     }
 }

--- a/core/rpc-generator/src/components/client.ts
+++ b/core/rpc-generator/src/components/client.ts
@@ -143,7 +143,7 @@ const hooks: IHooks = {
                 if (repositoryDirectory) {
                     updatedPkgObj.repository = {
                         type: 'git',
-                        url: 'git+https://github.com/hyperledger-labs/splice-wallet-kernel.git',
+                        url: 'git+https://github.com/canton-network/wallet-gateway.git',
                         directory: repositoryDirectory,
                     }
                 }

--- a/core/rpc-generator/templates/client/typescript/_package.json
+++ b/core/rpc-generator/templates/client/typescript/_package.json
@@ -48,5 +48,5 @@
         "typedoc": "^0.28.17",
         "typescript": "^5.9.3"
     },
-    "repository": "github:hyperledger-labs/splice-wallet-kernel"
+    "repository": "github:canton-network/wallet-gateway"
 }

--- a/core/rpc-transport/package.json
+++ b/core/rpc-transport/package.json
@@ -45,7 +45,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/rpc-transport"
     }
 }

--- a/core/signing-blockdaemon/package.json
+++ b/core/signing-blockdaemon/package.json
@@ -41,7 +41,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/signing-blockdaemon"
     }
 }

--- a/core/signing-dfns/package.json
+++ b/core/signing-dfns/package.json
@@ -52,7 +52,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/signing-dfns"
     }
 }

--- a/core/signing-fireblocks/package.json
+++ b/core/signing-fireblocks/package.json
@@ -53,7 +53,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/signing-fireblocks"
     }
 }

--- a/core/signing-internal/package.json
+++ b/core/signing-internal/package.json
@@ -51,7 +51,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/signing-internal"
     }
 }

--- a/core/signing-lib/package.json
+++ b/core/signing-lib/package.json
@@ -51,7 +51,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/signing-lib"
     }
 }

--- a/core/signing-participant/package.json
+++ b/core/signing-participant/package.json
@@ -46,7 +46,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/signing-participant"
     }
 }

--- a/core/signing-store-sql/package.json
+++ b/core/signing-store-sql/package.json
@@ -57,7 +57,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/signing-store-sql"
     }
 }

--- a/core/splice-client/package.json
+++ b/core/splice-client/package.json
@@ -47,7 +47,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/splice-client"
     }
 }

--- a/core/splice-provider/package.json
+++ b/core/splice-provider/package.json
@@ -47,7 +47,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/splice-provider"
     }
 }

--- a/core/token-standard-service/package.json
+++ b/core/token-standard-service/package.json
@@ -58,7 +58,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/token-standard-service"
     }
 }

--- a/core/token-standard/package.json
+++ b/core/token-standard/package.json
@@ -59,7 +59,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/token-standard"
     }
 }

--- a/core/tx-parser/package.json
+++ b/core/tx-parser/package.json
@@ -56,7 +56,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/tx-parser"
     }
 }

--- a/core/tx-visualizer/package.json
+++ b/core/tx-visualizer/package.json
@@ -45,7 +45,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/tx-visualizer"
     }
 }

--- a/core/types/package.json
+++ b/core/types/package.json
@@ -45,7 +45,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/types"
     }
 }

--- a/core/wallet-auth/package.json
+++ b/core/wallet-auth/package.json
@@ -47,7 +47,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/wallet-auth"
     }
 }

--- a/core/wallet-dapp-remote-rpc-client/package.json
+++ b/core/wallet-dapp-remote-rpc-client/package.json
@@ -52,7 +52,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/wallet-dapp-remote-rpc-client"
     }
 }

--- a/core/wallet-dapp-rpc-client/package.json
+++ b/core/wallet-dapp-rpc-client/package.json
@@ -52,7 +52,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/wallet-dapp-rpc-client"
     }
 }

--- a/core/wallet-discovery/package.json
+++ b/core/wallet-discovery/package.json
@@ -45,7 +45,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/wallet-discovery"
     }
 }

--- a/core/wallet-store-inmemory/package.json
+++ b/core/wallet-store-inmemory/package.json
@@ -41,7 +41,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/wallet-store-inmemory"
     }
 }

--- a/core/wallet-store-sql/package.json
+++ b/core/wallet-store-sql/package.json
@@ -56,7 +56,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/wallet-store-sql"
     }
 }

--- a/core/wallet-store/package.json
+++ b/core/wallet-store/package.json
@@ -36,7 +36,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/wallet-store"
     }
 }

--- a/core/wallet-ui-components/package.json
+++ b/core/wallet-ui-components/package.json
@@ -63,7 +63,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/wallet-ui-components"
     }
 }

--- a/core/wallet-user-rpc-client/package.json
+++ b/core/wallet-user-rpc-client/package.json
@@ -52,7 +52,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "core/wallet-user-rpc-client"
     }
 }

--- a/docs/dapp-building/README.md
+++ b/docs/dapp-building/README.md
@@ -3,7 +3,7 @@
 Build decentralized applications (dApps) that interact with the **Canton Network** through the **Wallet Gateway**. Use the **dApp SDK** in your frontend to connect users to their wallets, and the Wallet Gateway to mediate between your dApp, Canton validator nodes, and signing providers.
 
 > [!IMPORTANT]
-> This project is under active development and may introduce breaking changes until version 1.0.0. Migration guides for each release are published in [Discussions](https://github.com/hyperledger-labs/splice-wallet-kernel/discussions).
+> This project is under active development and may introduce breaking changes until version 1.0.0. Migration guides for each release are published in [Discussions](https://github.com/canton-network/wallet-gateway/discussions).
 
 ## Contents
 

--- a/docs/dapp-building/dapp-sdk/api-reference.md
+++ b/docs/dapp-building/dapp-sdk/api-reference.md
@@ -8,8 +8,8 @@ The dApp API exists in two variants, each targeting a different deployment model
 
 The machine-readable API specifications are maintained in the repository:
 
-- **Sync API**: [openrpc-dapp-api.json](https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/api-specs/openrpc-dapp-api.json)
-- **Async API**: [openrpc-dapp-remote-api.json](https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/api-specs/openrpc-dapp-remote-api.json)
+- **Sync API**: [openrpc-dapp-api.json](https://github.com/canton-network/wallet-gateway/blob/main/api-specs/openrpc-dapp-api.json)
+- **Async API**: [openrpc-dapp-remote-api.json](https://github.com/canton-network/wallet-gateway/blob/main/api-specs/openrpc-dapp-remote-api.json)
 
 ## Synchronous dApp API (Sync API)
 

--- a/docs/dapp-building/examples/index.md
+++ b/docs/dapp-building/examples/index.md
@@ -1,6 +1,6 @@
 # Examples
 
-The following example dApps demonstrate how to use the dApp SDK and Wallet Gateway. You can find them in the [`/examples`](https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/examples) directory of the repository.
+The following example dApps demonstrate how to use the dApp SDK and Wallet Gateway. You can find them in the [`/examples`](https://github.com/canton-network/wallet-gateway/tree/main/examples) directory of the repository.
 
 ## Ping
 
@@ -13,7 +13,7 @@ yarn install
 yarn dev
 ```
 
-[Source code](https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/examples/ping)
+[Source code](https://github.com/canton-network/wallet-gateway/tree/main/examples/ping)
 
 ## Portfolio
 
@@ -29,4 +29,4 @@ yarn start:all   # this service lives at http://localhost:8081
 yarn stop:all
 ```
 
-[Source code](https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/examples/portfolio)
+[Source code](https://github.com/canton-network/wallet-gateway/tree/main/examples/portfolio)

--- a/docs/dapp-building/wallet-gateway/apis/index.md
+++ b/docs/dapp-building/wallet-gateway/apis/index.md
@@ -23,7 +23,7 @@ Authorization: Bearer <jwt-token>
 
 **Full API Specification:**
 
-The complete OpenRPC specification is available at [openrpc-dapp-api.json](https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/api-specs/openrpc-dapp-api.json).
+The complete OpenRPC specification is available at [openrpc-dapp-api.json](https://github.com/canton-network/wallet-gateway/blob/main/api-specs/openrpc-dapp-api.json).
 
 ## User API Reference
 
@@ -63,7 +63,7 @@ Most User API methods require authentication via JWT token. However, the followi
 
 **Full API Specification:**
 
-The complete OpenRPC specification is available at [openrpc-user-api.json](https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/api-specs/openrpc-user-api.json).
+The complete OpenRPC specification is available at [openrpc-user-api.json](https://github.com/canton-network/wallet-gateway/blob/main/api-specs/openrpc-user-api.json).
 
 ## Server-Sent Events (SSE) Support
 

--- a/docs/dapp-building/wallet-gateway/signing-providers/index.md
+++ b/docs/dapp-building/wallet-gateway/signing-providers/index.md
@@ -47,7 +47,7 @@ Fireblocks is a third-party crypto custody service provider that offers enterpri
 
 **Setup:**
 
-1. Complete steps 1-3 from the [Fireblocks signing documentation](https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/core/signing-fireblocks)
+1. Complete steps 1-3 from the [Fireblocks signing documentation](https://github.com/canton-network/wallet-gateway/tree/main/core/signing-fireblocks)
 
 2. Supply an environment variable named `FIREBLOCKS_API_KEY` containing your Fireblocks API key (from the `API User (ID)` column in the Fireblocks API users table).
 

--- a/docs/wallet-integration-guide/src/exchange-integration/extensions.rst
+++ b/docs/wallet-integration-guide/src/exchange-integration/extensions.rst
@@ -174,7 +174,7 @@ are compromised, your party is still secured. Common setups are:
 Party Setup
 ^^^^^^^^^^^
 
-.. TODO:: https://github.com/hyperledger-labs/splice-wallet-kernel/issues/272 Update this when wallet SDK support is available
+.. TODO:: https://github.com/canton-network/wallet-gateway/issues/272 Update this when wallet SDK support is available
 
 As part of the :ref:`initial treasury party setup
 <create-an-external-party>`, you generate the ``PartyToParticipant``
@@ -219,7 +219,7 @@ is only performed by the executing node so if you submit across nodes
 you cannot rely on it. It is therefore recommend _not_ to rely on
 command deduplication at all in favor of :ref:`UTXO and max record time based deuplication <withdrawal-automation>`.
 
-.. TODO:: Link to recommended deduplication strategy https://github.com/hyperledger-labs/splice-wallet-kernel/issues/423
+.. TODO:: Link to recommended deduplication strategy https://github.com/canton-network/wallet-gateway/issues/423
 
 Changing the set of Confirming Nodes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/wallet-integration-guide/src/exchange-integration/txingestion.rst
+++ b/docs/wallet-integration-guide/src/exchange-integration/txingestion.rst
@@ -84,7 +84,7 @@ Note that you need to adjust the ``auth-token``, ``update-id`` and ``treasury-pa
 .. literalinclude:: 1-step-transfer.json
     :language: json
 
-You can parse such transactions using the `token standard history parser <https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/core/ledger-client/src/txparse/parser.ts>`_ provided in the wallet SDK to extract the deposit amount, account and holding contract ids. Note that one-step deposits are more complex to parse than two-step transfers as the token standard does not provide an interface choice visible to the receiver. If you prefer implementing your own implementation, you can parse this as follows:
+You can parse such transactions using the `token standard history parser <https://github.com/canton-network/wallet-gateway/blob/main/core/ledger-client/src/txparse/parser.ts>`_ provided in the wallet SDK to extract the deposit amount, account and holding contract ids. Note that one-step deposits are more complex to parse than two-step transfers as the token standard does not provide an interface choice visible to the receiver. If you prefer implementing your own implementation, you can parse this as follows:
 
 1. Go over the list of events ordered by ``nodeId`` that you see in the transaction.
 2. For each exercised event, check the exercise result. If it has a
@@ -197,7 +197,7 @@ Note that you need to adjust the ``auth-token``, ``update-id`` and ``treasury-pa
 .. literalinclude:: transfer-instruction-create.json
     :language: json
 
-You can parse such transactions using the `token standard history parser <https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/core/ledger-client/src/txparse/parser.ts>`_ provided in the wallet SDK to extract the deposit amount, account and holding contract ids. If you prefer implementing your own implementation, you can parse this as follows:
+You can parse such transactions using the `token standard history parser <https://github.com/canton-network/wallet-gateway/blob/main/core/ledger-client/src/txparse/parser.ts>`_ provided in the wallet SDK to extract the deposit amount, account and holding contract ids. If you prefer implementing your own implementation, you can parse this as follows:
 
 1. Go over the list of events ordered by ``nodeId`` that you see in the transaction.
 2. Look for all ``CreatedEvents`` of the ``TransferInstruction`` interface with ``"receiver": "<treasury-party>"``. Each of these represents a deposit offer that can be accepted or rejected.

--- a/docs/wallet-integration-guide/src/finding-and-reading-data/index.rst
+++ b/docs/wallet-integration-guide/src/finding-and-reading-data/index.rst
@@ -44,7 +44,7 @@ Visualizing a Transaction
 -------------------------
 
 The Wallet SDK uses a transaction parsing transform a fully fledged transaction tree into human recognizable transaction view. The full code
-for the transaction parsing can be found at `parser typescript class <https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/core/ledger-client/src/txparse/parser.ts>`__.
+for the transaction parsing can be found at `parser typescript class <https://github.com/canton-network/wallet-gateway/blob/main/core/ledger-client/src/txparse/parser.ts>`__.
 
 The Wallet SDK uses this parser to transform all transaction tree interacted with into PrettyTransactions.
 

--- a/docs/wallet-integration-guide/src/release-notes/index.rst
+++ b/docs/wallet-integration-guide/src/release-notes/index.rst
@@ -261,7 +261,7 @@ and secondly there is an upper limit of 100 inputs per transaction so to facilit
 * merge utxos delegation
 
 *instead of manually monitor and act you can set up utxos merge delegation as described at* `merge-delegation <https://docs.dev.sync.global/app_dev/token_standard/index.html#setting-up-mergedelegations>`__
-*using the new functionality like. An example of the complete setup can be found here:* `Wallet SDK example 18 <https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/docs/wallet-integration-guide/examples/scripts/18-merge-delegation-proposal.ts>`__
+*using the new functionality like. An example of the complete setup can be found here:* `Wallet SDK example 18 <https://github.com/canton-network/wallet-gateway/blob/main/docs/wallet-integration-guide/examples/scripts/18-merge-delegation-proposal.ts>`__
 
 * create party with preapproval
 
@@ -1391,7 +1391,7 @@ now instead using ledger api:
     const allUtxos = await sdk.tokenStandard?.listHoldingUtxos()
 
 * Include some small bug fixes. The most noteable are:
-    * ``Contract not found`` error when listing holdings (https://github.com/hyperledger-labs/splice-wallet-kernel/issues/357)
+    * ``Contract not found`` error when listing holdings (https://github.com/canton-network/wallet-gateway/issues/357)
     * Requirements to have extra import (like @protobuf-ts/runtime-rpc) resolved
 
 

--- a/docs/wallet-integration-guide/src/signing-transactions-from-dapps/index.rst
+++ b/docs/wallet-integration-guide/src/signing-transactions-from-dapps/index.rst
@@ -4,7 +4,7 @@ Signing Transactions from third party dApps
 A normal flow on blockchain applications is to have dApps that interact with the blockchain on the clients behalf,
 these flows usually require the user to sign transactions that the dApp prepares and submit it. To faciliate this in
 Canton it is required that the prepared transaction is sent to the wallet for signing. An easy way of supporting this
-is to expose a dApp API (OpenRPC spec can be found here: https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/api-specs/openrpc-dapp-api.json ).
+is to expose a dApp API (OpenRPC spec can be found here: https://github.com/canton-network/wallet-gateway/blob/main/api-specs/openrpc-dapp-api.json ).
 
 *The specs are in OpenRPC to conform with traditional standards like for ethereum.*
 
@@ -31,7 +31,7 @@ is applied the transaction can be considered valid (and executed). The easiest w
 a JSON representation of the transaction. The Json for a prepared transaction (before signature is applied) can be obtained
 using the Wallet SDK:
 
-.. Relies on https://github.com/hyperledger-labs/splice-wallet-kernel/issues/1538
+.. Relies on https://github.com/canton-network/wallet-gateway/issues/1538
 .. .. literalinclude:: ../../examples/snippets/convert-transaction-to-json.ts
 ..     :language: typescript
 ..     :dedent:

--- a/package.json
+++ b/package.json
@@ -125,6 +125,6 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git"
+        "url": "git+https://github.com/canton-network/wallet-gateway.git"
     }
 }

--- a/sdk-support/provider-adapter-loop/package.json
+++ b/sdk-support/provider-adapter-loop/package.json
@@ -41,7 +41,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "sdk-support/provider-adapter-loop"
     }
 }

--- a/sdk/dapp-sdk/README.md
+++ b/sdk/dapp-sdk/README.md
@@ -3,7 +3,7 @@
 **`@canton-network/dapp-sdk`** — TypeScript SDK for building decentralized applications on the [Canton Network](https://www.canton.network/). Connect users to Canton wallets, manage accounts, sign messages, and execute transactions — all through a vendor-neutral interface defined by [CIP-0103](https://github.com/canton-foundation/cips/blob/main/cip-0103/cip-0103.md).
 
 > [!IMPORTANT]
-> This project is under active development and may introduce breaking changes until version 1.0.0. Migration guides for each release are published in [Discussions](https://github.com/hyperledger-labs/splice-wallet-kernel/discussions).
+> This project is under active development and may introduce breaking changes until version 1.0.0. Migration guides for each release are published in [Discussions](https://github.com/canton-network/wallet-gateway/discussions).
 
 ## Features
 
@@ -89,7 +89,7 @@ The SDK is built around three layers:
 
 ## Wallet providers
 
-Wallet and extension authors: see **[Wallet providers (discovery)](https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/docs/dapp-building/dapp-sdk/provider.md)** in the dApp Building docs for how to appear in the picker (`RemoteAdapter`, `window.*` scan, `canton:announceProvider`, and `additionalAdapters`).
+Wallet and extension authors: see **[Wallet providers (discovery)](https://github.com/canton-network/wallet-gateway/blob/main/docs/dapp-building/dapp-sdk/provider.md)** in the dApp Building docs for how to appear in the picker (`RemoteAdapter`, `window.*` scan, `canton:announceProvider`, and `additionalAdapters`).
 
 ## Usage
 
@@ -221,22 +221,22 @@ provider.removeListener('statusChanged', listener)
 
 ### Built-in Adapters
 
-| Adapter            | Provider Type | Transport        | Description                                                                                                                                                                                      |
-| ------------------ | ------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ExtensionAdapter` | `'browser'`   | `postMessage`    | Browser extensions (announced wallets or dApp-registered; optional explicit slot).                                                                                                               |
-| `InjectedAdapter`  | `'browser'`   | in-page `window` | Created when namespace scan finds a provider on `window` ([Wallet providers guide](https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/docs/dapp-building/dapp-sdk/provider.md)). |
-| `RemoteAdapter`    | `'remote'`    | HTTP/SSE         | CIP-103 Wallet Gateways over the network.                                                                                                                                                        |
+| Adapter            | Provider Type | Transport        | Description                                                                                                                                                                              |
+| ------------------ | ------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ExtensionAdapter` | `'browser'`   | `postMessage`    | Browser extensions (announced wallets or dApp-registered; optional explicit slot).                                                                                                       |
+| `InjectedAdapter`  | `'browser'`   | in-page `window` | Created when namespace scan finds a provider on `window` ([Wallet providers guide](https://github.com/canton-network/wallet-gateway/blob/main/docs/dapp-building/dapp-sdk/provider.md)). |
+| `RemoteAdapter`    | `'remote'`    | HTTP/SSE         | CIP-103 Wallet Gateways over the network.                                                                                                                                                |
 
 ## Documentation
 
 Full documentation, including detailed usage guides, API reference, and configuration for the Wallet Gateway:
 
-- [dApp Building Guide](https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/docs/dapp-building)
-- [dApp SDK Documentation](https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/docs/dapp-building/dapp-sdk)
-- [Wallet providers (discovery)](https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/docs/dapp-building/dapp-sdk/provider.md)
-- [API Specifications (OpenRPC)](https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/api-specs)
-- [Example dApps](https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/examples)
+- [dApp Building Guide](https://github.com/canton-network/wallet-gateway/tree/main/docs/dapp-building)
+- [dApp SDK Documentation](https://github.com/canton-network/wallet-gateway/tree/main/docs/dapp-building/dapp-sdk)
+- [Wallet providers (discovery)](https://github.com/canton-network/wallet-gateway/blob/main/docs/dapp-building/dapp-sdk/provider.md)
+- [API Specifications (OpenRPC)](https://github.com/canton-network/wallet-gateway/tree/main/api-specs)
+- [Example dApps](https://github.com/canton-network/wallet-gateway/tree/main/examples)
 
 ## License
 
-[Apache-2.0](https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/LICENSE)
+[Apache-2.0](https://github.com/canton-network/wallet-gateway/blob/main/LICENSE)

--- a/sdk/dapp-sdk/package.json
+++ b/sdk/dapp-sdk/package.json
@@ -68,7 +68,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "sdk/dapp-sdk"
     }
 }

--- a/sdk/wallet-sdk/package.json
+++ b/sdk/wallet-sdk/package.json
@@ -65,7 +65,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "sdk/wallet-sdk"
     }
 }

--- a/wallet-gateway/extension/package.json
+++ b/wallet-gateway/extension/package.json
@@ -32,7 +32,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "wallet-gateway/extension"
     }
 }

--- a/wallet-gateway/remote/README.md
+++ b/wallet-gateway/remote/README.md
@@ -59,7 +59,7 @@ Dfns provisions and activates Canton wallets through its validator integration, 
 
 ## Fireblocks
 
-1. Complete steps 1–3 from the instructions at https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/core/signing-fireblocks
+1. Complete steps 1–3 from the instructions at https://github.com/canton-network/wallet-gateway/tree/main/core/signing-fireblocks
 
 2. set the environment variable `FIREBLOCKS_API_KEY` (get it from `API User (ID)` column in fireblocks api users table).
 

--- a/wallet-gateway/remote/package.json
+++ b/wallet-gateway/remote/package.json
@@ -96,7 +96,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hyperledger-labs/splice-wallet-kernel.git",
+        "url": "git+https://github.com/canton-network/wallet-gateway.git",
         "directory": "wallet-gateway/remote"
     }
 }


### PR DESCRIPTION
renames all mentions of "hyperledger-labs/splice-wallet-kernel" to the new "canton-network/wallet-gateway".


Mainterners and admins have been adjusted accordingly in CODEOWNERS.md