### PR TITLE
fix(wallet-gateway-remote): enable bootstrapping with existing db

### DIFF
--- a/wallet-gateway/remote/src/init.ts
+++ b/wallet-gateway/remote/src/init.ts
@@ -80,6 +80,59 @@ async function initializeDatabase(
                 .execute(db)
                 .catch(() => {})
             exists = false
+        } else {
+            const appDb = connection(config.store)
+            try {
+                const idpsTable = await sql
+                    .raw<{
+                        exists: boolean
+                    }>(`select exists(select 1 from information_schema.tables where table_schema='public' and table_name='idps') as exists;`)
+                    .execute(appDb)
+                const networksTable = await sql
+                    .raw<{
+                        exists: boolean
+                    }>(`select exists(select 1 from information_schema.tables where table_schema='public' and table_name='networks') as exists;`)
+                    .execute(appDb)
+
+                const idpsExists = Boolean(idpsTable.rows[0]?.exists)
+                const networksExists = Boolean(networksTable.rows[0]?.exists)
+
+                let idpsHasRows = false
+                let networksHasRows = false
+
+                if (idpsExists) {
+                    const idpsCount = await sql
+                        .raw<{
+                            rowCount: number | string
+                        }>(`select count(*) as "rowCount" from idps;`)
+                        .execute(appDb)
+                    idpsHasRows = Number(idpsCount.rows[0]?.rowCount ?? 0) > 0
+                }
+
+                if (networksExists) {
+                    const networksCount = await sql
+                        .raw<{
+                            rowCount: number | string
+                        }>(`select count(*) as "rowCount" from networks;`)
+                        .execute(appDb)
+                    networksHasRows =
+                        Number(networksCount.rows[0]?.rowCount ?? 0) > 0
+                }
+
+                if (
+                    !idpsExists ||
+                    !networksExists ||
+                    !idpsHasRows ||
+                    !networksHasRows
+                ) {
+                    logger.warn(
+                        'Database exists but required tables are missing or empty. Attempting to bootstrap...'
+                    )
+                    exists = false
+                }
+            } finally {
+                await appDb.destroy()
+            }
         }
         await db.destroy()
     }


### PR DESCRIPTION
normally in a production setup you would not give an app full access to the root database, instead you will create the database and let it control its own environment. This allow bootstrapping even if the database connection is not a root admin by checking for existing of tables (and values) and rerun bootstrap if they are empty.