### PR TITLE
fix: cache hydration

### DIFF
--- a/.github/actions/setup_canton/action.yml
+++ b/.github/actions/setup_canton/action.yml
@@ -7,6 +7,14 @@ inputs:
     instance:
         description: 'Instance type: canton or localnet'
         required: true
+    canton_version:
+        description: 'Resolved Canton version (optional override)'
+        required: false
+        default: ''
+    splice_version:
+        description: 'Resolved Splice version (optional override)'
+        required: false
+        default: ''
     start_services:
         description: 'Whether to start canton/localnet services after setup'
         required: false
@@ -14,13 +22,14 @@ inputs:
 runs:
     using: 'composite'
     steps:
-        - name: Read version config
+        - name: Resolve versions
           id: version-config
           shell: bash
           run: |
-              CONFIG=$(cat scripts/src/lib/version-config.json)
               NETWORK="${{ inputs.network }}"
               INSTANCE="${{ inputs.instance }}"
+              CANTON_VERSION="${{ inputs.canton_version }}"
+              SPLICE_VERSION="${{ inputs.splice_version }}"
 
               if [ "$NETWORK" != "devnet" ] && [ "$NETWORK" != "mainnet" ]; then
                 echo "Invalid network '$NETWORK'. Expected one of: devnet, mainnet" >&2
@@ -32,13 +41,22 @@ runs:
                 exit 1
               fi
 
-              CANTON_VERSION=$(echo "$CONFIG" | jq -r --arg net "$NETWORK" '.SUPPORTED_VERSIONS[$net].canton.version')
+              if [ -z "$CANTON_VERSION" ] || { [ "$INSTANCE" == "localnet" ] && [ -z "$SPLICE_VERSION" ]; }; then
+                CONFIG=$(cat scripts/src/lib/version-config.json)
+              fi
+
+              if [ -z "$CANTON_VERSION" ]; then
+                CANTON_VERSION=$(echo "$CONFIG" | jq -r --arg net "$NETWORK" '.SUPPORTED_VERSIONS[$net].canton.version')
+              fi
+
+              if [ "$INSTANCE" == "localnet" ] && [ -z "$SPLICE_VERSION" ]; then
+                SPLICE_VERSION=$(echo "$CONFIG" | jq -r --arg net "$NETWORK" '.SUPPORTED_VERSIONS[$net].splice.version')
+              fi
 
               if [ "$INSTANCE" == "canton" ]; then
                 SPLICE_VERSION=""
-              else
-                SPLICE_VERSION=$(echo "$CONFIG" | jq -r --arg net "$NETWORK" '.SUPPORTED_VERSIONS[$net].splice.version')
               fi
+
               echo "canton_version=$CANTON_VERSION" >> $GITHUB_OUTPUT
               echo "splice_version=$SPLICE_VERSION" >> $GITHUB_OUTPUT
 

--- a/.github/actions/setup_canton/action.yml
+++ b/.github/actions/setup_canton/action.yml
@@ -16,6 +16,10 @@ inputs:
         description: 'Whether to save the Canton cache on a cache miss'
         required: false
         default: 'false'
+    lookup_only:
+        description: 'Whether to only check if the Canton cache exists without restoring it'
+        required: false
+        default: 'false'
 runs:
     using: 'composite'
     steps:
@@ -44,6 +48,7 @@ runs:
           with:
               path: .canton
               key: ${{ runner.os }}-canton-${{ steps.version-config.outputs.canton_version }}
+              lookup-only: ${{ inputs.lookup_only == 'true' }}
 
         - name: Download Canton
           if: steps.canton-cache.outputs.cache-hit != 'true'

--- a/.github/actions/setup_canton/action.yml
+++ b/.github/actions/setup_canton/action.yml
@@ -1,105 +1,57 @@
-name: 'Setup Canton/Localnet'
-description: 'Cache, download and prepare Canton or Localnet environment'
+name: 'Setup Canton'
+description: 'Cache, download and optionally start Canton environment'
 inputs:
     network:
         description: 'Network type: devnet or mainnet'
-        required: true
-    instance:
-        description: 'Instance type: canton or localnet'
         required: true
     canton_version:
         description: 'Resolved Canton version (optional override)'
         required: false
         default: ''
-    splice_version:
-        description: 'Resolved Splice version (optional override)'
-        required: false
-        default: ''
     start_services:
-        description: 'Whether to start canton/localnet services after setup'
+        description: 'Whether to start canton services after setup'
         required: false
         default: 'true'
+    save_cache:
+        description: 'Whether to save the Canton cache on a cache miss'
+        required: false
+        default: 'false'
 runs:
     using: 'composite'
     steps:
-        - name: Resolve versions
+        - name: Resolve Canton version
           id: version-config
           shell: bash
           run: |
               NETWORK="${{ inputs.network }}"
-              INSTANCE="${{ inputs.instance }}"
               CANTON_VERSION="${{ inputs.canton_version }}"
-              SPLICE_VERSION="${{ inputs.splice_version }}"
 
               if [ "$NETWORK" != "devnet" ] && [ "$NETWORK" != "mainnet" ]; then
                 echo "Invalid network '$NETWORK'. Expected one of: devnet, mainnet" >&2
                 exit 1
               fi
 
-              if [ "$INSTANCE" != "canton" ] && [ "$INSTANCE" != "localnet" ]; then
-                echo "Invalid instance '$INSTANCE'. Expected one of: canton, localnet" >&2
-                exit 1
-              fi
-
-              if [ -z "$CANTON_VERSION" ] || { [ "$INSTANCE" == "localnet" ] && [ -z "$SPLICE_VERSION" ]; }; then
-                CONFIG=$(cat scripts/src/lib/version-config.json)
-              fi
-
               if [ -z "$CANTON_VERSION" ]; then
+                CONFIG=$(cat scripts/src/lib/version-config.json)
                 CANTON_VERSION=$(echo "$CONFIG" | jq -r --arg net "$NETWORK" '.SUPPORTED_VERSIONS[$net].canton.version')
               fi
 
-              if [ "$INSTANCE" == "localnet" ] && [ -z "$SPLICE_VERSION" ]; then
-                SPLICE_VERSION=$(echo "$CONFIG" | jq -r --arg net "$NETWORK" '.SUPPORTED_VERSIONS[$net].splice.version')
-              fi
-
-              if [ "$INSTANCE" == "canton" ]; then
-                SPLICE_VERSION=""
-              fi
-
               echo "canton_version=$CANTON_VERSION" >> $GITHUB_OUTPUT
-              echo "splice_version=$SPLICE_VERSION" >> $GITHUB_OUTPUT
 
         - name: Cache Canton binaries
-          if: inputs.instance == 'canton'
           uses: actions/cache/restore@v5
           id: canton-cache
           with:
               path: .canton
               key: ${{ runner.os }}-canton-${{ steps.version-config.outputs.canton_version }}
 
-        - name: Cache Localnet files
-          if: inputs.instance == 'localnet'
-          uses: actions/cache/restore@v5
-          id: localnet-cache
-          with:
-              path: |
-                  .localnet/docker-compose/localnet
-                  .localnet/dars
-                  /tmp/docker-images
-              key: ${{ runner.os }}-localnet-${{ steps.version-config.outputs.splice_version }}
-
-        - name: Load cached Docker images
-          if: inputs.instance == 'localnet' && steps.localnet-cache.outputs.cache-hit == 'true'
-          shell: bash
-          run: |
-              if [ -f /tmp/docker-images/images.tar ]; then
-                docker load -i /tmp/docker-images/images.tar
-                echo "Docker images loaded from cache."
-              fi
-
         - name: Download Canton
-          if: inputs.instance == 'canton' && steps.canton-cache.outputs.cache-hit != 'true'
+          if: steps.canton-cache.outputs.cache-hit != 'true'
           shell: bash
           run: yarn script:fetch:canton --network=${{ inputs.network }}
 
-        - name: Download Localnet
-          if: inputs.instance == 'localnet' && steps.localnet-cache.outputs.cache-hit != 'true'
-          shell: bash
-          run: yarn script:fetch:localnet --network=${{ inputs.network }}
-
         - name: Start Canton
-          if: inputs.instance == 'canton' && inputs.start_services == 'true'
+          if: inputs.start_services == 'true'
           shell: bash
           run: |
               set -e
@@ -124,36 +76,9 @@ runs:
                 exit 1
               '
 
-        - name: Start Localnet
-          if: inputs.instance == 'localnet' && inputs.start_services == 'true'
-          shell: bash
-          run: yarn start:localnet -- --network=${{ inputs.network }}
-
-        - name: Save Docker images to cache
-          if: ${{ inputs.instance == 'localnet' && steps.localnet-cache.outputs.cache-hit != 'true' }}
-          shell: bash
-          run: |
-              mkdir -p /tmp/docker-images
-              images=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v "<none>" || true)
-              if [ -n "$images" ]; then
-                echo "$images" | xargs -r docker save -o /tmp/docker-images/images.tar
-              else
-                echo "No Docker images found to save."
-              fi
-
         - name: Save Canton cache
-          if: ${{ inputs.instance == 'canton' && steps.canton-cache.outputs.cache-hit != 'true' }}
+          if: ${{ inputs.save_cache == 'true' && steps.canton-cache.outputs.cache-hit != 'true' }}
           uses: actions/cache/save@v5
           with:
               path: .canton
               key: ${{ runner.os }}-canton-${{ steps.version-config.outputs.canton_version }}
-
-        - name: Save Localnet cache
-          if: ${{ inputs.instance == 'localnet' && steps.localnet-cache.outputs.cache-hit != 'true' }}
-          uses: actions/cache/save@v5
-          with:
-              path: |
-                  .localnet/docker-compose/localnet
-                  .localnet/dars
-                  /tmp/docker-images
-              key: ${{ runner.os }}-localnet-${{ steps.version-config.outputs.splice_version }}

--- a/.github/actions/setup_canton/action.yml
+++ b/.github/actions/setup_canton/action.yml
@@ -7,6 +7,10 @@ inputs:
     instance:
         description: 'Instance type: canton or localnet'
         required: true
+    start_services:
+        description: 'Whether to start canton/localnet services after setup'
+        required: false
+        default: 'true'
 runs:
     using: 'composite'
     steps:
@@ -77,7 +81,7 @@ runs:
           run: yarn script:fetch:localnet --network=${{ inputs.network }}
 
         - name: Start Canton
-          if: inputs.instance == 'canton'
+          if: inputs.instance == 'canton' && inputs.start_services == 'true'
           shell: bash
           run: |
               set -e
@@ -103,7 +107,7 @@ runs:
               '
 
         - name: Start Localnet
-          if: inputs.instance == 'localnet'
+          if: inputs.instance == 'localnet' && inputs.start_services == 'true'
           shell: bash
           run: yarn start:localnet -- --network=${{ inputs.network }}
 

--- a/.github/actions/setup_localnet/action.yml
+++ b/.github/actions/setup_localnet/action.yml
@@ -63,7 +63,8 @@ runs:
           run: yarn script:fetch:localnet --network=${{ inputs.network }}
 
         - name: Start Localnet
-          if: inputs.start_services == 'true'
+          # We start the localnet on a cache miss to download docker images
+          if: ${{ steps.localnet-cache.outputs.cache-hit != 'true' || inputs.start_services == 'true' }}
           shell: bash
           run: yarn start:localnet -- --network=${{ inputs.network }}
 

--- a/.github/actions/setup_localnet/action.yml
+++ b/.github/actions/setup_localnet/action.yml
@@ -16,6 +16,10 @@ inputs:
         description: 'Whether to save the Localnet cache on a cache miss'
         required: false
         default: 'false'
+    lookup_only:
+        description: 'Whether to only check if the Localnet cache exists without restoring it'
+        required: false
+        default: 'false'
 runs:
     using: 'composite'
     steps:
@@ -47,6 +51,7 @@ runs:
                   .localnet/dars
                   /tmp/docker-images
               key: ${{ runner.os }}-localnet-${{ steps.version-config.outputs.splice_version }}
+              lookup-only: ${{ inputs.lookup_only == 'true' }}
 
         - name: Load cached Docker images
           if: steps.localnet-cache.outputs.cache-hit == 'true'

--- a/.github/actions/setup_localnet/action.yml
+++ b/.github/actions/setup_localnet/action.yml
@@ -1,0 +1,90 @@
+name: 'Setup Localnet'
+description: 'Cache, download and optionally start Localnet environment'
+inputs:
+    network:
+        description: 'Network type: devnet or mainnet'
+        required: true
+    splice_version:
+        description: 'Resolved Splice version (optional override)'
+        required: false
+        default: ''
+    start_services:
+        description: 'Whether to start localnet services after setup'
+        required: false
+        default: 'true'
+    save_cache:
+        description: 'Whether to save the Localnet cache on a cache miss'
+        required: false
+        default: 'false'
+runs:
+    using: 'composite'
+    steps:
+        - name: Resolve Splice version
+          id: version-config
+          shell: bash
+          run: |
+              NETWORK="${{ inputs.network }}"
+              SPLICE_VERSION="${{ inputs.splice_version }}"
+
+              if [ "$NETWORK" != "devnet" ] && [ "$NETWORK" != "mainnet" ]; then
+                echo "Invalid network '$NETWORK'. Expected one of: devnet, mainnet" >&2
+                exit 1
+              fi
+
+              if [ -z "$SPLICE_VERSION" ]; then
+                CONFIG=$(cat scripts/src/lib/version-config.json)
+                SPLICE_VERSION=$(echo "$CONFIG" | jq -r --arg net "$NETWORK" '.SUPPORTED_VERSIONS[$net].splice.version')
+              fi
+
+              echo "splice_version=$SPLICE_VERSION" >> $GITHUB_OUTPUT
+
+        - name: Cache Localnet files
+          uses: actions/cache/restore@v5
+          id: localnet-cache
+          with:
+              path: |
+                  .localnet/docker-compose/localnet
+                  .localnet/dars
+                  /tmp/docker-images
+              key: ${{ runner.os }}-localnet-${{ steps.version-config.outputs.splice_version }}
+
+        - name: Load cached Docker images
+          if: steps.localnet-cache.outputs.cache-hit == 'true'
+          shell: bash
+          run: |
+              if [ -f /tmp/docker-images/images.tar ]; then
+                docker load -i /tmp/docker-images/images.tar
+                echo "Docker images loaded from cache."
+              fi
+
+        - name: Download Localnet
+          if: steps.localnet-cache.outputs.cache-hit != 'true'
+          shell: bash
+          run: yarn script:fetch:localnet --network=${{ inputs.network }}
+
+        - name: Start Localnet
+          if: inputs.start_services == 'true'
+          shell: bash
+          run: yarn start:localnet -- --network=${{ inputs.network }}
+
+        - name: Save Docker images to cache
+          if: ${{ inputs.save_cache == 'true' && steps.localnet-cache.outputs.cache-hit != 'true' }}
+          shell: bash
+          run: |
+              mkdir -p /tmp/docker-images
+              images=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v "<none>" || true)
+              if [ -n "$images" ]; then
+                echo "$images" | xargs -r docker save -o /tmp/docker-images/images.tar
+              else
+                echo "No Docker images found to save."
+              fi
+
+        - name: Save Localnet cache
+          if: ${{ inputs.save_cache == 'true' && steps.localnet-cache.outputs.cache-hit != 'true' }}
+          uses: actions/cache/save@v5
+          with:
+              path: |
+                  .localnet/docker-compose/localnet
+                  .localnet/dars
+                  /tmp/docker-images
+              key: ${{ runner.os }}-localnet-${{ steps.version-config.outputs.splice_version }}

--- a/.github/actions/setup_yarn/action.yml
+++ b/.github/actions/setup_yarn/action.yml
@@ -1,5 +1,9 @@
 name: Setup Yarn
 description: 'Setup Yarn for the project'
+inputs:
+    daml_release_version:
+        description: 'Resolved DAML release version from workflow metadata job'
+        required: true
 runs:
     using: composite
     steps:
@@ -13,20 +17,13 @@ runs:
               node-version: 'v24.9.0'
               cache: 'yarn'
 
-        - name: Resolve DAML release version
-          id: daml_release_version
-          shell: bash
-          run: |
-              VERSION=$(jq -r '.DAML_RELEASE_VERSION' scripts/src/lib/version-config.json | tr -d '\r\n')
-              echo "value=$VERSION" >> "$GITHUB_OUTPUT"
-
         - name: Restore DPM cache
           id: dpm_cache
           uses: actions/cache/restore@v5
           with:
               path: |
                   ~/.dpm
-              key: dpm-${{ runner.os }}-${{ steps.daml_release_version.outputs.value }}
+              key: dpm-${{ runner.os }}-${{ inputs.daml_release_version }}
 
         - name: Add DPM to PATH
           shell: bash

--- a/.github/actions/setup_yarn/action.yml
+++ b/.github/actions/setup_yarn/action.yml
@@ -54,7 +54,7 @@ runs:
         - name: Download build artifacts
           id: download_build_artifacts
           continue-on-error: true
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@v5
           with:
               name: build-dist-${{ github.run_id }}
 

--- a/.github/actions/setup_yarn/action.yml
+++ b/.github/actions/setup_yarn/action.yml
@@ -4,6 +4,10 @@ inputs:
     daml_release_version:
         description: 'Resolved DAML release version from workflow metadata job'
         required: true
+    save_cache:
+        description: 'Whether to save the DPM cache on a cache miss'
+        required: false
+        default: 'false'
 runs:
     using: composite
     steps:
@@ -40,7 +44,7 @@ runs:
           run: rm -rf ~/.dpm/cache/oci-layout
 
         - name: Save DPM cache
-          if: ${{ steps.dpm_cache.outputs.cache-hit != 'true' }}
+          if: ${{ inputs.save_cache == 'true' && steps.dpm_cache.outputs.cache-hit != 'true' }}
           uses: actions/cache/save@v5
           with:
               path: |

--- a/.github/actions/setup_yarn/action.yml
+++ b/.github/actions/setup_yarn/action.yml
@@ -17,7 +17,7 @@ runs:
           id: daml_release_version
           shell: bash
           run: |
-              VERSION=$(jq -r '.DAML_RELEASE_VERSION' scripts/src/lib/version-config.json)
+              VERSION=$(jq -r '.DAML_RELEASE_VERSION' scripts/src/lib/version-config.json | tr -d '\r\n')
               echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
         - name: Restore DPM cache

--- a/.github/actions/setup_yarn/action.yml
+++ b/.github/actions/setup_yarn/action.yml
@@ -43,7 +43,7 @@ runs:
           run: rm -rf ~/.dpm/cache/oci-layout
 
         - name: Save DPM cache
-          if: ${{ github.workflow == 'build' && steps.dpm_cache.outputs.cache-hit != 'true' }}
+          if: ${{ steps.dpm_cache.outputs.cache-hit != 'true' }}
           uses: actions/cache/save@v5
           with:
               path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,39 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    version-config:
+        runs-on: ubuntu-latest
+        outputs:
+            daml_release_version: ${{ steps.version.outputs.daml_release_version }}
+            devnet_canton_version: ${{ steps.version.outputs.devnet_canton_version }}
+            mainnet_canton_version: ${{ steps.version.outputs.mainnet_canton_version }}
+            devnet_splice_version: ${{ steps.version.outputs.devnet_splice_version }}
+            mainnet_splice_version: ${{ steps.version.outputs.mainnet_splice_version }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Resolve version config outputs
+              id: version
+              shell: bash
+              run: |
+                  CONFIG=$(cat scripts/src/lib/version-config.json)
+                  echo "daml_release_version=$(echo "$CONFIG" | jq -r '.DAML_RELEASE_VERSION' | tr -d '\r\n')" >> "$GITHUB_OUTPUT"
+                  echo "devnet_canton_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.devnet.canton.version')" >> "$GITHUB_OUTPUT"
+                  echo "mainnet_canton_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.mainnet.canton.version')" >> "$GITHUB_OUTPUT"
+                  echo "devnet_splice_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.devnet.splice.version')" >> "$GITHUB_OUTPUT"
+                  echo "mainnet_splice_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.mainnet.splice.version')" >> "$GITHUB_OUTPUT"
+
     build:
         runs-on: ubuntu-latest
+        needs: version-config
         steps:
             - name: Checkout
               uses: actions/checkout@v6
 
             - uses: ./.github/actions/setup_yarn
+              with:
+                  daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - name: run codegen
               run: yarn generate:all
@@ -49,7 +75,7 @@ jobs:
     hydrate-canton-caches:
         name: hydrate-canton-caches (${{ matrix.network }}, ${{ matrix.instance }})
         runs-on: ubuntu-latest
-        needs: build
+        needs: [version-config, build]
         strategy:
             fail-fast: false
             matrix:
@@ -60,12 +86,16 @@ jobs:
               uses: actions/checkout@v6
 
             - uses: ./.github/actions/setup_yarn
+              with:
+                  daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - uses: ./.github/actions/setup_canton
               with:
                   network: ${{ matrix.network }}
                   instance: ${{ matrix.instance }}
                   start_services: 'false'
+                  canton_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
+                  splice_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
     clear-blockdaemon-policies:
         runs-on: ubuntu-latest
@@ -127,12 +157,14 @@ jobs:
 
     test-static:
         runs-on: ubuntu-latest
-        needs: build
+        needs: [version-config, build]
         steps:
             - name: Checkout
               uses: actions/checkout@v6
 
             - uses: ./.github/actions/setup_yarn
+              with:
+                  daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - name: Validate current PR title with commitlint
               run: echo "$TITLE" | yarn commitlint --verbose
@@ -159,7 +191,7 @@ jobs:
 
     test-unit:
         runs-on: ubuntu-latest
-        needs: build
+        needs: [version-config, build]
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -167,6 +199,8 @@ jobs:
                   fetch-depth: 0
 
             - uses: ./.github/actions/setup_yarn
+              with:
+                  daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - uses: ./.github/actions/setup_playwright
 
@@ -180,7 +214,7 @@ jobs:
     ping-e2e:
         name: ping-e2e (${{ matrix.network }})
         runs-on: ubuntu-latest
-        needs: hydrate-canton-caches
+        needs: [version-config, hydrate-canton-caches]
         strategy:
             fail-fast: false
             matrix:
@@ -190,11 +224,15 @@ jobs:
               uses: actions/checkout@v6
 
             - uses: ./.github/actions/setup_yarn
+              with:
+                  daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - uses: ./.github/actions/setup_canton
               with:
                   network: ${{ matrix.network }}
                   instance: canton
+                  canton_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
+                  splice_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - name: Start remote WK
               run: |
@@ -244,7 +282,7 @@ jobs:
     portfolio-e2e:
         name: portfolio-e2e (${{ matrix.network }})
         runs-on: ubuntu-latest
-        needs: hydrate-canton-caches
+        needs: [version-config, hydrate-canton-caches]
         strategy:
             fail-fast: false
             matrix:
@@ -253,11 +291,15 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
             - uses: ./.github/actions/setup_yarn
+              with:
+                  daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - uses: ./.github/actions/setup_canton
               with:
                   network: ${{ matrix.network }}
                   instance: localnet
+                  canton_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
+                  splice_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - name: Start remote WK
               run: yarn pm2 start ecosystem.ci.config.js --env development
@@ -301,7 +343,7 @@ jobs:
     wallet-sdk-snippets-e2e:
         name: wallet-sdk-snippets-e2e (${{ matrix.network }})
         runs-on: ubuntu-latest
-        needs: hydrate-canton-caches
+        needs: [version-config, hydrate-canton-caches]
         strategy:
             fail-fast: false
             matrix:
@@ -312,11 +354,15 @@ jobs:
               uses: actions/checkout@v6
 
             - uses: ./.github/actions/setup_yarn
+              with:
+                  daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - uses: ./.github/actions/setup_canton
               with:
                   network: ${{ matrix.network }}
                   instance: localnet
+                  canton_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
+                  splice_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - uses: ./.github/actions/check_resources
 
@@ -349,7 +395,7 @@ jobs:
     wallet-sdk-scripts-e2e:
         name: wallet-sdk-scripts-e2e (${{ matrix.network }})
         runs-on: ubuntu-latest
-        needs: hydrate-canton-caches
+        needs: [version-config, hydrate-canton-caches]
         strategy:
             fail-fast: false
             matrix:
@@ -360,11 +406,15 @@ jobs:
               uses: actions/checkout@v6
 
             - uses: ./.github/actions/setup_yarn
+              with:
+                  daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - uses: ./.github/actions/setup_canton
               with:
                   network: ${{ matrix.network }}
                   instance: localnet
+                  canton_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
+                  splice_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - uses: ./.github/actions/check_resources
 
@@ -420,11 +470,13 @@ jobs:
 
     wallet-sdk-pkg:
         runs-on: ubuntu-latest
-        needs: build
+        needs: [version-config, build]
         steps:
             - name: Checkout
               uses: actions/checkout@v6
             - uses: ./.github/actions/setup_yarn
+              with:
+                  daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - name: Validate SDK package install
               run: yarn script:validate:package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
     ping-e2e:
         name: ping-e2e (${{ matrix.network }})
         runs-on: ubuntu-latest
-        needs: build
+        needs: hydrate-canton-caches
         strategy:
             fail-fast: false
             matrix:
@@ -244,7 +244,7 @@ jobs:
     portfolio-e2e:
         name: portfolio-e2e (${{ matrix.network }})
         runs-on: ubuntu-latest
-        needs: build
+        needs: hydrate-canton-caches
         strategy:
             fail-fast: false
             matrix:
@@ -301,7 +301,7 @@ jobs:
     wallet-sdk-snippets-e2e:
         name: wallet-sdk-snippets-e2e (${{ matrix.network }})
         runs-on: ubuntu-latest
-        needs: build
+        needs: hydrate-canton-caches
         strategy:
             fail-fast: false
             matrix:
@@ -349,7 +349,7 @@ jobs:
     wallet-sdk-scripts-e2e:
         name: wallet-sdk-scripts-e2e (${{ matrix.network }})
         runs-on: ubuntu-latest
-        needs: build
+        needs: hydrate-canton-caches
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,9 +47,6 @@ jobs:
                   daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
                   save_cache: 'true'
 
-            - name: run codegen
-              run: yarn generate:all
-
             - name: Build project
               run: yarn build:all
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
                   start_services: 'false'
                   canton_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
                   save_cache: 'true'
+                  lookup_only: 'true'
 
             - uses: ./.github/actions/setup_localnet
               if: matrix.instance == 'localnet'
@@ -102,6 +103,7 @@ jobs:
                   start_services: 'false'
                   splice_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
                   save_cache: 'true'
+                  lookup_only: 'true'
 
     clear-blockdaemon-policies:
         runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
             - uses: ./.github/actions/setup_yarn
               with:
                   daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
+                  save_cache: 'true'
 
             - name: run codegen
               run: yarn generate:all
@@ -90,12 +91,20 @@ jobs:
                   daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - uses: ./.github/actions/setup_canton
+              if: matrix.instance == 'canton'
               with:
                   network: ${{ matrix.network }}
-                  instance: ${{ matrix.instance }}
                   start_services: 'false'
                   canton_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
+                  save_cache: 'true'
+
+            - uses: ./.github/actions/setup_localnet
+              if: matrix.instance == 'localnet'
+              with:
+                  network: ${{ matrix.network }}
+                  start_services: 'false'
                   splice_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
+                  save_cache: 'true'
 
     clear-blockdaemon-policies:
         runs-on: ubuntu-latest
@@ -230,9 +239,7 @@ jobs:
             - uses: ./.github/actions/setup_canton
               with:
                   network: ${{ matrix.network }}
-                  instance: canton
                   canton_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
-                  splice_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - name: Start remote WK
               run: |
@@ -294,11 +301,9 @@ jobs:
               with:
                   daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
-            - uses: ./.github/actions/setup_canton
+            - uses: ./.github/actions/setup_localnet
               with:
                   network: ${{ matrix.network }}
-                  instance: localnet
-                  canton_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
                   splice_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - name: Start remote WK
@@ -357,11 +362,9 @@ jobs:
               with:
                   daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
-            - uses: ./.github/actions/setup_canton
+            - uses: ./.github/actions/setup_localnet
               with:
                   network: ${{ matrix.network }}
-                  instance: localnet
-                  canton_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
                   splice_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - uses: ./.github/actions/check_resources
@@ -409,11 +412,9 @@ jobs:
               with:
                   daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
-            - uses: ./.github/actions/setup_canton
+            - uses: ./.github/actions/setup_localnet
               with:
                   network: ${{ matrix.network }}
-                  instance: localnet
-                  canton_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
                   splice_version: ${{ matrix.network == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - uses: ./.github/actions/check_resources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,27 @@ jobs:
                   if-no-files-found: error
                   retention-days: 1
 
+    hydrate-canton-caches:
+        name: hydrate-canton-caches (${{ matrix.network }}, ${{ matrix.instance }})
+        runs-on: ubuntu-latest
+        needs: build
+        strategy:
+            fail-fast: false
+            matrix:
+                network: [devnet, mainnet]
+                instance: [canton, localnet]
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - uses: ./.github/actions/setup_yarn
+
+            - uses: ./.github/actions/setup_canton
+              with:
+                  network: ${{ matrix.network }}
+                  instance: ${{ matrix.instance }}
+                  start_services: 'false'
+
     clear-blockdaemon-policies:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/examples-under-stress.yml
+++ b/.github/workflows/examples-under-stress.yml
@@ -58,7 +58,7 @@ jobs:
     stress-e2e:
         runs-on: ubuntu-latest
         timeout-minutes: 120
-        needs: version-config
+        needs: [version-config, hydrate-canton-caches]
 
         steps:
             - name: Checkout
@@ -69,12 +69,6 @@ jobs:
             - uses: ./.github/actions/setup_yarn
               with:
                   daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
-
-            - name: run codegen
-              run: yarn generate:all
-
-            - name: Build project
-              run: yarn build:all
 
             - uses: ./.github/actions/setup_localnet
               with:

--- a/.github/workflows/examples-under-stress.yml
+++ b/.github/workflows/examples-under-stress.yml
@@ -76,11 +76,9 @@ jobs:
             - name: Build project
               run: yarn build:all
 
-            - uses: ./.github/actions/setup_canton
+            - uses: ./.github/actions/setup_localnet
               with:
                   network: ${{ github.event.inputs.network || 'devnet' }}
-                  instance: localnet
-                  canton_version: ${{ (github.event.inputs.network || 'devnet') == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
                   splice_version: ${{ (github.event.inputs.network || 'devnet') == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - uses: ./.github/actions/check_resources

--- a/.github/workflows/examples-under-stress.yml
+++ b/.github/workflows/examples-under-stress.yml
@@ -30,9 +30,35 @@ on:
                 default: ''
 
 jobs:
+    version-config:
+        runs-on: ubuntu-latest
+        outputs:
+            daml_release_version: ${{ steps.version.outputs.daml_release_version }}
+            devnet_canton_version: ${{ steps.version.outputs.devnet_canton_version }}
+            mainnet_canton_version: ${{ steps.version.outputs.mainnet_canton_version }}
+            devnet_splice_version: ${{ steps.version.outputs.devnet_splice_version }}
+            mainnet_splice_version: ${{ steps.version.outputs.mainnet_splice_version }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ github.event.inputs.ref || github.ref }}
+
+            - name: Resolve version config outputs
+              id: version
+              shell: bash
+              run: |
+                  CONFIG=$(cat scripts/src/lib/version-config.json)
+                  echo "daml_release_version=$(echo "$CONFIG" | jq -r '.DAML_RELEASE_VERSION' | tr -d '\r\n')" >> "$GITHUB_OUTPUT"
+                  echo "devnet_canton_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.devnet.canton.version')" >> "$GITHUB_OUTPUT"
+                  echo "mainnet_canton_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.mainnet.canton.version')" >> "$GITHUB_OUTPUT"
+                  echo "devnet_splice_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.devnet.splice.version')" >> "$GITHUB_OUTPUT"
+                  echo "mainnet_splice_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.mainnet.splice.version')" >> "$GITHUB_OUTPUT"
+
     stress-e2e:
         runs-on: ubuntu-latest
         timeout-minutes: 120
+        needs: version-config
 
         steps:
             - name: Checkout
@@ -41,6 +67,8 @@ jobs:
                   ref: ${{ github.event.inputs.ref || github.ref }}
 
             - uses: ./.github/actions/setup_yarn
+              with:
+                  daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - name: run codegen
               run: yarn generate:all
@@ -52,6 +80,8 @@ jobs:
               with:
                   network: ${{ github.event.inputs.network || 'devnet' }}
                   instance: localnet
+                  canton_version: ${{ (github.event.inputs.network || 'devnet') == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
+                  splice_version: ${{ (github.event.inputs.network || 'devnet') == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - uses: ./.github/actions/check_resources
 

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -14,9 +14,35 @@ on:
                 options: [devnet, mainnet]
                 default: devnet
 jobs:
+    version-config:
+        runs-on: ubuntu-latest
+        outputs:
+            daml_release_version: ${{ steps.version.outputs.daml_release_version }}
+            devnet_canton_version: ${{ steps.version.outputs.devnet_canton_version }}
+            mainnet_canton_version: ${{ steps.version.outputs.mainnet_canton_version }}
+            devnet_splice_version: ${{ steps.version.outputs.devnet_splice_version }}
+            mainnet_splice_version: ${{ steps.version.outputs.mainnet_splice_version }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ github.event.inputs.ref || github.ref }}
+
+            - name: Resolve version config outputs
+              id: version
+              shell: bash
+              run: |
+                  CONFIG=$(cat scripts/src/lib/version-config.json)
+                  echo "daml_release_version=$(echo "$CONFIG" | jq -r '.DAML_RELEASE_VERSION' | tr -d '\r\n')" >> "$GITHUB_OUTPUT"
+                  echo "devnet_canton_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.devnet.canton.version')" >> "$GITHUB_OUTPUT"
+                  echo "mainnet_canton_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.mainnet.canton.version')" >> "$GITHUB_OUTPUT"
+                  echo "devnet_splice_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.devnet.splice.version')" >> "$GITHUB_OUTPUT"
+                  echo "mainnet_splice_version=$(echo "$CONFIG" | jq -r '.SUPPORTED_VERSIONS.mainnet.splice.version')" >> "$GITHUB_OUTPUT"
+
     stress-tests:
         runs-on: ubuntu-latest
         timeout-minutes: 120
+        needs: version-config
 
         steps:
             - name: Checkout
@@ -25,6 +51,8 @@ jobs:
                   ref: ${{ github.event.inputs.ref || github.ref }}
 
             - uses: ./.github/actions/setup_yarn
+              with:
+                  daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
 
             - name: run codegen
               run: yarn generate:all
@@ -35,6 +63,9 @@ jobs:
             - uses: ./.github/actions/setup_canton
               with:
                   network: ${{ github.event.inputs.network || 'devnet' }}
+                  instance: localnet
+                  canton_version: ${{ (github.event.inputs.network || 'devnet') == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
+                  splice_version: ${{ (github.event.inputs.network || 'devnet') == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - uses: ./.github/actions/check_resources
 

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -42,7 +42,7 @@ jobs:
     stress-tests:
         runs-on: ubuntu-latest
         timeout-minutes: 120
-        needs: version-config
+        needs: [version-config, hydrate-canton-caches]
 
         steps:
             - name: Checkout
@@ -53,12 +53,6 @@ jobs:
             - uses: ./.github/actions/setup_yarn
               with:
                   daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
-
-            - name: run codegen
-              run: yarn generate:all
-
-            - name: Build project
-              run: yarn build:all
 
             - uses: ./.github/actions/setup_localnet
               with:

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -60,11 +60,9 @@ jobs:
             - name: Build project
               run: yarn build:all
 
-            - uses: ./.github/actions/setup_canton
+            - uses: ./.github/actions/setup_localnet
               with:
                   network: ${{ github.event.inputs.network || 'devnet' }}
-                  instance: localnet
-                  canton_version: ${{ (github.event.inputs.network || 'devnet') == 'devnet' && needs.version-config.outputs.devnet_canton_version || needs.version-config.outputs.mainnet_canton_version }}
                   splice_version: ${{ (github.event.inputs.network || 'devnet') == 'devnet' && needs.version-config.outputs.devnet_splice_version || needs.version-config.outputs.mainnet_splice_version }}
 
             - uses: ./.github/actions/check_resources

--- a/core/wallet-dapp-remote-rpc-client/src/index.ts
+++ b/core/wallet-dapp-remote-rpc-client/src/index.ts
@@ -608,7 +608,7 @@ export type RpcTypes = {
     }
 }
 
-export class SpliceWalletJSONRPCRemoteDAppAPI {
+export class WalletJSONRPCRemoteDAppAPI {
     public transport: RpcTransport
 
     constructor(transport: RpcTransport) {
@@ -632,4 +632,4 @@ export class SpliceWalletJSONRPCRemoteDAppAPI {
         }
     }
 }
-export default SpliceWalletJSONRPCRemoteDAppAPI
+export default WalletJSONRPCRemoteDAppAPI

--- a/core/wallet-dapp-remote-rpc-client/src/openrpc.json
+++ b/core/wallet-dapp-remote-rpc-client/src/openrpc.json
@@ -1,7 +1,7 @@
 {
     "openrpc": "1.2.6",
     "info": {
-        "title": "Splice Wallet JSON-RPC Remote dApp API",
+        "title": "Wallet JSON-RPC Remote dApp API",
         "version": "0.1.0",
         "description": "An OpenRPC specification for remotely hosted Wallet Providers. Due to the remote nature, an implementing provider must bridge certain functionality on the client-side to satisfy the general dApp API spec."
     },

--- a/core/wallet-dapp-rpc-client/src/index.ts
+++ b/core/wallet-dapp-rpc-client/src/index.ts
@@ -594,7 +594,7 @@ export type RpcTypes = {
     }
 }
 
-export class SpliceWalletJSONRPCDAppAPI {
+export class WalletJSONRPCDAppAPI {
     public transport: RpcTransport
 
     constructor(transport: RpcTransport) {
@@ -618,4 +618,4 @@ export class SpliceWalletJSONRPCDAppAPI {
         }
     }
 }
-export default SpliceWalletJSONRPCDAppAPI
+export default WalletJSONRPCDAppAPI

--- a/core/wallet-dapp-rpc-client/src/openrpc.json
+++ b/core/wallet-dapp-rpc-client/src/openrpc.json
@@ -1,7 +1,7 @@
 {
     "openrpc": "1.2.6",
     "info": {
-        "title": "Splice Wallet JSON-RPC dApp API",
+        "title": "Wallet JSON-RPC dApp API",
         "version": "0.5.0",
         "description": "An OpenRPC specification for the dapp to interact with a Wallet Provider."
     },

--- a/core/wallet-user-rpc-client/src/index.ts
+++ b/core/wallet-user-rpc-client/src/index.ts
@@ -679,7 +679,7 @@ export type RpcTypes = {
     }
 }
 
-export class SpliceWalletJSONRPCUserAPI {
+export class WalletJSONRPCUserAPI {
     public transport: RpcTransport
 
     constructor(transport: RpcTransport) {
@@ -703,4 +703,4 @@ export class SpliceWalletJSONRPCUserAPI {
         }
     }
 }
-export default SpliceWalletJSONRPCUserAPI
+export default WalletJSONRPCUserAPI

--- a/core/wallet-user-rpc-client/src/openrpc.json
+++ b/core/wallet-user-rpc-client/src/openrpc.json
@@ -1,7 +1,7 @@
 {
     "openrpc": "1.2.6",
     "info": {
-        "title": "Splice Wallet JSON-RPC User API",
+        "title": "Wallet JSON-RPC User API",
         "version": "0.1.0",
         "description": "An OpenRPC specification for the user to interact with the Wallet Gateway."
     },


### PR DESCRIPTION
this contains a serious of fixes:

- [X] include a hydration step for caches, it looks if caches are present and if not it fills the cache. This prevents multiple caches of the same content (and thereby reduce cache eviction).
- [X] split the start canton and start localnet into its own smaller flows.
- [X] loads the version config once in the start to make same valuables accessible across the run.
- [X] leaves the saving of caches only to the build and hydration step.
- [X] removed double generation and build steps in a few areas.
- [X] also ran generate:all since files did not match specs.

outstanding (will come in follow up PRs):
- reduce the cache size of dpm
- check if localnet cache size can be reduced as well