### PR TITLE
fix: minor exception case

### DIFF
--- a/sdk/wallet-sdk/src/wallet/sdk.ts
+++ b/sdk/wallet-sdk/src/wallet/sdk.ts
@@ -98,6 +98,7 @@ export class SDK {
             .catch((err) => {
                 if (
                     //this is only the cause if authentication is completely disabled on the ledger.
+                    err?.cause &&
                     (err.cause as string).includes(
                         'The submitted request is missing a user-id'
                     )


### PR DESCRIPTION
if error is not a canton error (but a 404 for instance) then this area of the code fails.