### PR TITLE
fix(wallet-gateway-remote): dont use req.ip directly for rate limit key

### DIFF
--- a/wallet-gateway/remote/src/middleware/rateLimit.test.ts
+++ b/wallet-gateway/remote/src/middleware/rateLimit.test.ts
@@ -14,6 +14,24 @@ describe('ipRateLimitKeyGenerator', () => {
 
         expect(ipRateLimitKeyGenerator(req)).toBe('ip:198.51.100.42')
     })
+
+    test('leaves IPv4 request ip address unchanged', () => {
+        const req = {
+            ip: '198.51.100.42',
+            socket: { remoteAddress: '10.0.0.1' },
+        } as Request
+
+        expect(ipRateLimitKeyGenerator(req)).toBe('ip:198.51.100.42')
+    })
+
+    test('normalizes IPv6 request ip address to a subnet key', () => {
+        const req = {
+            ip: '2001:db8:abcd:0012:1111:2222:3333:4444',
+            socket: { remoteAddress: '10.0.0.1' },
+        } as Request
+
+        expect(ipRateLimitKeyGenerator(req)).toBe('ip:2001:db8:abcd::/56')
+    })
 })
 
 describe('rateLimitKeyGenerator', () => {

--- a/wallet-gateway/remote/src/middleware/rateLimit.ts
+++ b/wallet-gateway/remote/src/middleware/rateLimit.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import rateLimit from 'express-rate-limit'
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit'
 import type { Request } from 'express'
 
 function hasBearerToken(req: Request): boolean {
@@ -14,7 +14,7 @@ function hasBearerToken(req: Request): boolean {
 }
 
 export function ipRateLimitKeyGenerator(req: Request): string {
-    return `ip:${req.ip || req.socket.remoteAddress || 'unknown'}`
+    return `ip:${ipKeyGenerator(req.ip || req.socket.remoteAddress || 'unknown')}`
 }
 
 export function rateLimitKeyGenerator(req: Request): string {


### PR DESCRIPTION
While running WG locally, I saw these in logs

```log
  ValidationError: Custom keyGenerator appears to use request IP without calling the ipKeyGenerator helper function for IPv6 addresses. This could allow IPv6 users to bypass limits. See https://express-rate-limit.github.io/ERR_ERL_KEY_GEN_IPV6/ for more information.
0|remote   |     at Object.keyGeneratorIpFallback (file:///home/fayi/Code/digital-asset/wallet-gateway/.yarn/__virtual__/express-rate-limit-virtual-e8de2f85a6/4/.local/share/yarn/berry/cache/express-rate-limit-npm-8.3.0-90798fb73e-10c0.zip/node_modules/express-rate-limit/dist/index.mjs:613:13)
0|remote   |     at wrappedValidations.<computed> [as keyGeneratorIpFallback] (file:///home/fayi/Code/digital-asset/wallet-gateway/.yarn/__virtual__/express-rate-limit-virtual-e8de2f85a6/4/.local/share/yarn/berry/cache/express-rate-limit-npm-8.3.0-90798fb73e-10c0.zip/node_modules/express-rate-limit/dist/index.mjs:656:22)
0|remote   |     at parseOptions (file:///home/fayi/Code/digital-asset/wallet-gateway/.yarn/__virtual__/express-rate-limit-virtual-e8de2f85a6/4/.local/share/yarn/berry/cache/express-rate-limit-npm-8.3.0-90798fb73e-10c0.zip/node_modules/express-rate-limit/dist/index.mjs:726:16)
0|remote   |     at rateLimit (file:///home/fayi/Code/digital-asset/wallet-gateway/.yarn/__virtual__/express-rate-limit-virtual-e8de2f85a6/4/.local/share/yarn/berry/cache/express-rate-limit-npm-8.3.0-90798fb73e-10c0.zip/node_modules/express-rate-limit/dist/index.mjs:807:18)
0|remote   |     at preAuthIpRateLimiter (/home/fayi/Code/digital-asset/wallet-gateway/wallet-gateway/remote/src/middleware/rateLimit.ts:40:12)
0|remote   |     at initialize (/home/fayi/Code/digital-asset/wallet-gateway/wallet-gateway/remote/src/init.ts:250:30)
0|remote   |     at Command.<anonymous> (/home/fayi/Code/digital-asset/wallet-gateway/wallet-gateway/remote/src/index.ts:78:9)
0|remote   |     at Command.listener [as _actionHandler] (/home/fayi/.local/share/yarn/berry/cache/commander-npm-14.0.3-93ab31471d-10c0.zip/node_modules/commander/lib/command.js:568:17)
0|remote   |     at /home/fayi/.local/share/yarn/berry/cache/commander-npm-14.0.3-93ab31471d-10c0.zip/node_modules/commander/lib/command.js:1604:14
0|remote   |     at Command._chainOrCall (/home/fayi/.local/share/yarn/berry/cache/commander-npm-14.0.3-93ab31471d-10c0.zip/node_modules/commander/lib/command.js:1488:12) {
0|remote   |   code: 'ERR_ERL_KEY_GEN_IPV6',
0|remote   |   help: 'https://express-rate-limit.github.io/ERR_ERL_KEY_GEN_IPV6/'
0|remote   | }
```

The important part is this:

```
 ValidationError: Custom keyGenerator appears to use request IP without calling the ipKeyGenerator helper function for IPv6 addresses. 
This could allow IPv6 users to bypass limits. 
See https://express-rate-limit.github.io/ERR_ERL_KEY_GEN_IPV6/ for more information.
```

express-rate-limit rejects custom rate-limit key generators that use req.ip directly which is unsafe for IPv6 because users can rotate IPv6 addresses to bypass limits.

