### PR TITLE
fix: fix js doc

### DIFF
--- a/sdk/wallet-sdk/src/wallet/namespace/amulet/preapproval.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/amulet/preapproval.ts
@@ -173,7 +173,7 @@ export class PreapprovalNamespace {
      * @param receiverParty Receiver party id.
      * @param options Optional settings.
      * @param options.oldCid Resolve only when CID differs from this value (post-renew).
-     * @param options.expectGone Set true to resolve when no preapproval is returned (post-cancel).
+     * @param options.cancelled Set true to resolve when no preapproval is returned (post-cancel).
      * @param options.intervalMs Poll interval in milliseconds. Default is 15000.
      * @param options.timeoutMs Maximum wait time in milliseconds. Default is 300000.
      * @returns Resolves with the preapproval (for create/renew) or null (for cancelled).


### PR DESCRIPTION
When creating v1, we renamed the `expectGone` to `cancelled` but this did not get updated in the js doc. 

Closes: https://github.com/canton-network/wallet-gateway/issues/1796