### PR TITLE
feat: deliver CIP-103 push events through DappSyncProvider

### DIFF
--- a/core/provider-dapp/src/DappSyncProvider.notification-demux.test.ts
+++ b/core/provider-dapp/src/DappSyncProvider.notification-demux.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { WalletEvent } from '@canton-network/core-types'
+import { WindowTransport } from '@canton-network/core-rpc-transport'
+import { DappSyncProvider } from './DappSyncProvider'
+
+// Companion to DappSyncProvider.push-events.test.ts: exercises the always-on
+// notification demux against the *announced-provider* construction path.
+//
+// Discovery hands the dApp a routing key, not a provider object
+// (requestAnnouncedProviders → AnnouncedProvider.target), and the SDK then
+// builds DappSyncProvider(new WindowTransport(window, { target })). In that
+// future every transport is targeted, so event delivery must honor the same
+// target gating as extension detection — otherwise a page with two wallets
+// cross-delivers one wallet's events to the other wallet's provider.
+describe('DappSyncProvider notification demux (announced-provider path)', () => {
+    const flushMessageQueue = () => new Promise((r) => setTimeout(r, 100))
+
+    const notification = (target?: string) => ({
+        type: WalletEvent.SPLICE_WALLET_REQUEST,
+        request: {
+            jsonrpc: '2.0',
+            method: 'txChanged',
+            params: { status: 'executed', commandId: 'cmd-demux-1' },
+        },
+        ...(target !== undefined ? { target } : {}),
+    })
+
+    it('delivers notifications stamped with the provider announced routing key', async () => {
+        const provider = new DappSyncProvider(
+            new WindowTransport(window, { target: 'wallet-a' })
+        )
+        const received: unknown[] = []
+        provider.on('txChanged', (payload: unknown) => received.push(payload))
+
+        window.postMessage(notification('wallet-a'), '*')
+        await flushMessageQueue()
+
+        expect(received).toHaveLength(1)
+    })
+
+    it('does not cross-deliver notifications addressed to another wallet', async () => {
+        const provider = new DappSyncProvider(
+            new WindowTransport(window, { target: 'wallet-a' })
+        )
+        const received: unknown[] = []
+        provider.on('txChanged', (payload: unknown) => received.push(payload))
+
+        window.postMessage(notification('wallet-b'), '*')
+        // An unstamped frame is also undeliverable to a targeted provider:
+        // with multiple announced wallets there is no way to attribute it.
+        window.postMessage(notification(), '*')
+        await flushMessageQueue()
+
+        expect(received).toHaveLength(0)
+    })
+
+    it('does not echo the dApp own id-carrying requests into the event path', async () => {
+        const provider = new DappSyncProvider()
+        const received: unknown[] = []
+        provider.on('ping', (payload: unknown) => received.push(payload))
+
+        // request() posts an id-carrying SPLICE_WALLET_REQUEST into the same
+        // window the demux listens on; it must be treated as an outbound call,
+        // not a wallet notification. No wallet responds in this harness, so
+        // the returned promise intentionally never settles.
+        void provider.request({ method: 'ping' } as never)
+        await flushMessageQueue()
+
+        expect(received).toHaveLength(0)
+    })
+})

--- a/core/provider-dapp/src/DappSyncProvider.push-events.test.ts
+++ b/core/provider-dapp/src/DappSyncProvider.push-events.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { WalletEvent } from '@canton-network/core-types'
+import { DappSyncProvider } from './DappSyncProvider'
+
+// Regression coverage for https://github.com/canton-network/wallet/issues/1815.
+//
+// The CIP-103 Provider API requires wallets to deliver txChanged /
+// accountsChanged / statusChanged / connected through
+// provider.on(event, listener). On the sync (postMessage) path the wire
+// shape for a wallet-pushed event is a JSON-RPC 2.0 notification — the
+// existing SPLICE_WALLET_REQUEST envelope with no `id`, method = event
+// name. WindowTransport demuxes those frames on an always-on listener and
+// DappSyncProvider bridges them to AbstractProvider.emit.
+//
+// Targeted (announced-provider) delivery is covered in
+// DappSyncProvider.notification-demux.test.ts; this file pins the envelope
+// semantics themselves.
+describe('DappSyncProvider push events (CIP-103 Provider API)', () => {
+    const flushMessageQueue = () => new Promise((r) => setTimeout(r, 100))
+
+    // The canonical envelope: id-less request frame, method = event name.
+    // Reuses upstream's own wire vocabulary instead of introducing a new
+    // message type, per the JSON-RPC 2.0 notification definition (§4.1).
+    it('delivers events shaped as JSON-RPC notifications (id-less request envelope)', async () => {
+        const provider = new DappSyncProvider()
+        const received: unknown[] = []
+        provider.on('txChanged', (payload: unknown) => received.push(payload))
+
+        window.postMessage(
+            {
+                type: WalletEvent.SPLICE_WALLET_REQUEST,
+                request: {
+                    jsonrpc: '2.0',
+                    method: 'txChanged',
+                    params: {
+                        status: 'executed',
+                        commandId: 'cmd-push-1',
+                        updateId: 'update-push-1',
+                    },
+                },
+            },
+            '*'
+        )
+        await flushMessageQueue()
+
+        expect(received).toHaveLength(1)
+    })
+
+    // The demux must not become a sink for arbitrary window traffic: only
+    // the canonical notification shape is delivered. A frame in any other
+    // envelope (e.g. a wallet-invented event message type) is ignored, so
+    // the provider's event surface stays bound to the specified wire shape.
+    it('does not deliver frames in non-canonical envelopes', async () => {
+        const provider = new DappSyncProvider()
+        const received: unknown[] = []
+        provider.on('txChanged', (payload: unknown) => received.push(payload))
+
+        window.postMessage(
+            {
+                type: 'WALLET_EVENT',
+                event: 'txChanged',
+                payload: { status: 'executed', commandId: 'cmd-push-2' },
+            },
+            '*'
+        )
+        await flushMessageQueue()
+
+        expect(received).toHaveLength(0)
+    })
+})

--- a/core/provider-dapp/src/DappSyncProvider.ts
+++ b/core/provider-dapp/src/DappSyncProvider.ts
@@ -16,9 +16,17 @@ export class DappSyncProvider extends AbstractProvider<DappRpcTypes> {
 
     constructor(transport?: RpcTransport) {
         super()
-        this.client = new SpliceWalletJSONRPCDAppAPI(
-            transport ?? new WindowTransport(window)
-        )
+        const rpcTransport = transport ?? new WindowTransport(window)
+        this.client = new SpliceWalletJSONRPCDAppAPI(rpcTransport)
+        // CIP-103 events (txChanged, accountsChanged, statusChanged,
+        // connected) arrive as wallet-pushed notifications on the window
+        // transport; bridge them into the AbstractProvider listener map so
+        // provider.on(event, listener) delivers them as the CIP requires.
+        if (rpcTransport instanceof WindowTransport) {
+            rpcTransport.onNotification((method, params) => {
+                this.emit(method, params)
+            })
+        }
     }
 
     public async request<M extends keyof DappRpcTypes>(

--- a/core/rpc-transport/src/index.ts
+++ b/core/rpc-transport/src/index.ts
@@ -40,6 +40,12 @@ export interface RpcTransport {
     submit: (payload: RequestPayload) => Promise<ResponsePayload>
 }
 
+/**
+ * Handler for wallet-pushed JSON-RPC notifications (CIP-103 events such as
+ * txChanged / accountsChanged / statusChanged / connected).
+ */
+export type NotificationHandler = (method: string, params?: unknown) => void
+
 export type WindowTransportOptions = {
     /**
      * Optional routing key for browser-extension messaging. When set, extensions
@@ -49,10 +55,69 @@ export type WindowTransportOptions = {
 }
 
 export class WindowTransport implements RpcTransport {
+    private notificationHandlers = new Set<NotificationHandler>()
+    private notificationListener: ((event: MessageEvent) => void) | undefined
+
     constructor(
         private win: Window,
         private options: WindowTransportOptions = {}
     ) {}
+
+    /**
+     * Subscribe to wallet-pushed JSON-RPC notifications: SPLICE_WALLET_REQUEST
+     * frames with no `id` (JSON-RPC 2.0 §4.1). The window listener must be
+     * always-on for the transport's lifetime — CIP-103 events arrive between
+     * requests, where a per-request listener can never observe them.
+     */
+    onNotification = (handler: NotificationHandler): (() => void) => {
+        this.notificationHandlers.add(handler)
+        if (!this.notificationListener) {
+            this.notificationListener = (event: MessageEvent) => {
+                if (
+                    !isSpliceMessageEvent(event) ||
+                    event.data.type !== WalletEvent.SPLICE_WALLET_REQUEST
+                ) {
+                    return
+                }
+                // Requests submitted by this transport always carry a uuid id,
+                // so an id-less request can only be a wallet-originated
+                // notification — this also keeps the dApp's own outgoing
+                // frames (posted to the same window) out of the event path.
+                if (event.data.request.id != null) {
+                    return
+                }
+                // Same gating as extension detection: a transport constructed
+                // from an announced provider's routing key only accepts frames
+                // stamped with that key, so multi-wallet pages do not
+                // cross-deliver events between providers.
+                if (
+                    this.options.target &&
+                    event.data.target !== this.options.target
+                ) {
+                    return
+                }
+                const { method, params } = event.data.request
+                this.notificationHandlers.forEach((h) => h(method, params))
+            }
+            this.win.addEventListener('message', this.notificationListener)
+        }
+        return () => {
+            this.notificationHandlers.delete(handler)
+            // Drop the DOM listener with the last subscriber so an abandoned
+            // transport leaves nothing attached to the window; a later
+            // subscribe re-installs it.
+            if (
+                this.notificationHandlers.size === 0 &&
+                this.notificationListener
+            ) {
+                this.win.removeEventListener(
+                    'message',
+                    this.notificationListener
+                )
+                this.notificationListener = undefined
+            }
+        }
+    }
 
     submit = async (payload: RequestPayload) => {
         const message: SpliceMessage = {


### PR DESCRIPTION
## Summary

CIP-103 requires wallets to deliver `txChanged` / `accountsChanged` / `statusChanged` / `connected` through `provider.on(event, listener)`. On the sync (postMessage) path used by `ExtensionAdapter`, no wire shape a wallet posts results in delivery: `WindowTransport` only installs per-request, response-only listeners, so every wallet-pushed event is silently dropped — tracked in #1815.

End-user symptom (reported in public Slack, repro'd against `examples/ping`):

> "I sign the transaction successfully, but the transaction never seems to go through."

The transaction *does* land on the ledger; the dApp's `sdk.onTxChanged(listener)` just never fires, so the UI never updates.

## Envelope: JSON-RPC 2.0 notification (revised)

An earlier revision of this PR introduced a new `SPLICE_WALLET_EVENT` message type and asked for feedback on the envelope shape. This revision settles on the shape proposed in #1815: a **JSON-RPC 2.0 notification (§4.1)** — the existing `SPLICE_WALLET_REQUEST` frame with no `id`, `method` = event name. Reusing the existing wire vocabulary means **no new message type and no `SpliceMessage` union change**; the `core/types` diff from the earlier revision is gone entirely.

Requests submitted by the transport always carry a uuid `id`, so an id-less request is unambiguously a wallet-originated notification — this also keeps the dApp's own outbound frames (posted to the same window) out of the event path.

## Changes (sync flow only; HTTP/SSE untouched)

| File | What |
| --- | --- |
| `core/rpc-transport/src/index.ts` | `WindowTransport.onNotification(handler)`: a **single always-on** window `message` listener (installed on first subscription, removed with the last unsubscribe) demuxing id-less `SPLICE_WALLET_REQUEST` frames to subscribers. Delivery is gated on the transport's `target` routing key — the announced provider's key from `requestAnnouncedProviders` — so multi-wallet pages don't cross-deliver events between providers. |
| `core/provider-dapp/src/DappSyncProvider.ts` | Constructor subscribes to transport notifications and forwards each `(method, params)` to `this.emit(method, params)`, making `provider.on(event, listener)` deliver as CIP-103 requires. |
| `core/provider-dapp/src/DappSyncProvider.push-events.test.ts` | Envelope semantics: the canonical id-less notification is delivered; frames in any other envelope are ignored (the demux cannot become a sink for arbitrary window traffic). |
| `core/provider-dapp/src/DappSyncProvider.notification-demux.test.ts` | Announced-provider path: targeted delivery, cross-wallet isolation (wrong-target and unstamped frames dropped by a targeted transport), and no echo of the dApp's own id-carrying requests. |

`RpcTransport` itself is unchanged — `onNotification` is a `WindowTransport` member and `DappSyncProvider` feature-detects it, so `HttpTransport` / `DappAsyncProvider` (which already deliver events via SSE) are unaffected.

## Test plan

- [x] Unit/integration: 12/12 in `core/provider-dapp` (7 pre-existing + 5 new), vitest browser mode (chromium). The new coverage is exactly what the earlier revision deferred pending envelope consensus.
- [x] End-to-end red/green at the dApp UI, against a production CIP-103 extension wallet (Send Connect) on a Canton localnet: a Playwright spec connects `examples/ping` through the **announced** provider, creates a Ping contract, and asserts the Post Events panel (rendered solely from `sdk.onTxChanged` subscriptions). With the stock dapp-sdk the wallet's notifications are observably posted into the window but the panel stays empty; with this patch the same spec passes and the panel renders the `txChanged` lifecycle (pending → signed → executed).
- [x] HTTP/SSE flow regression: no code change on `DappAsyncProvider` / `HttpTransport`.

## Links

- Closes #1815 (sync-path event delivery)
- CIP-0103 Provider API event contract (`provider.on`)
