### PR TITLE
fix: rename JsCommands to Commands

### DIFF
--- a/api-specs/openrpc-dapp-api.json
+++ b/api-specs/openrpc-dapp-api.json
@@ -261,7 +261,7 @@
                         "$ref": "api-specs/openrpc-dapp-api.json#/components/schemas/CommandId"
                     },
                     "commands": {
-                        "$ref": "api-specs/openrpc-dapp-api.json#/components/schemas/JsCommands"
+                        "$ref": "api-specs/openrpc-dapp-api.json#/components/schemas/Commands"
                     },
                     "actAs": {
                         "title": "actAs",
@@ -409,8 +409,8 @@
                     }
                 ]
             },
-            "JsCommands": {
-                "title": "JsCommands",
+            "Commands": {
+                "title": "Commands",
                 "type": "array",
                 "minItems": 1,
                 "description": "Non-empty array of Daml command atoms to submit atomically as a single transaction.",

--- a/core/wallet-dapp-remote-rpc-client/src/index.ts
+++ b/core/wallet-dapp-remote-rpc-client/src/index.ts
@@ -71,7 +71,7 @@ export type Command =
  * Non-empty array of Daml command atoms to submit atomically as a single transaction.
  *
  */
-export type JsCommands = Command[]
+export type Commands = Command[]
 /**
  *
  * The party that signed the transaction.
@@ -509,7 +509,7 @@ export interface MessageSignatureFailedEvent {
  */
 export interface PrepareExecuteParams {
     commandId?: CommandId
-    commands: JsCommands
+    commands: Commands
     actAs?: ActAs
     readAs?: ReadAs
     disclosedContracts?: DisclosedContracts

--- a/core/wallet-dapp-rpc-client/src/index.ts
+++ b/core/wallet-dapp-rpc-client/src/index.ts
@@ -71,7 +71,7 @@ export type Command =
  * Non-empty array of Daml command atoms to submit atomically as a single transaction.
  *
  */
-export type JsCommands = Command[]
+export type Commands = Command[]
 /**
  *
  * The party that signed the transaction.
@@ -501,7 +501,7 @@ export interface MessageSignatureFailedEvent {
  */
 export interface PrepareExecuteParams {
     commandId?: CommandId
-    commands: JsCommands
+    commands: Commands
     actAs?: ActAs
     readAs?: ReadAs
     disclosedContracts?: DisclosedContracts

--- a/core/wallet-dapp-rpc-client/src/openrpc.json
+++ b/core/wallet-dapp-rpc-client/src/openrpc.json
@@ -261,7 +261,7 @@
                         "$ref": "api-specs/openrpc-dapp-api.json#/components/schemas/CommandId"
                     },
                     "commands": {
-                        "$ref": "api-specs/openrpc-dapp-api.json#/components/schemas/JsCommands"
+                        "$ref": "api-specs/openrpc-dapp-api.json#/components/schemas/Commands"
                     },
                     "actAs": {
                         "title": "actAs",
@@ -409,8 +409,8 @@
                     }
                 ]
             },
-            "JsCommands": {
-                "title": "JsCommands",
+            "Commands": {
+                "title": "Commands",
                 "type": "array",
                 "minItems": 1,
                 "description": "Non-empty array of Daml command atoms to submit atomically as a single transaction.",

--- a/sdk/dapp-sdk/src/dapp-api/rpc-gen/typings.ts
+++ b/sdk/dapp-sdk/src/dapp-api/rpc-gen/typings.ts
@@ -70,7 +70,7 @@ export type Command =
  * Non-empty array of Daml command atoms to submit atomically as a single transaction.
  *
  */
-export type JsCommands = Command[]
+export type Commands = Command[]
 /**
  *
  * The party that signed the transaction.
@@ -500,7 +500,7 @@ export interface MessageSignatureFailedEvent {
  */
 export interface PrepareExecuteParams {
     commandId?: CommandId
-    commands: JsCommands
+    commands: Commands
     actAs?: ActAs
     readAs?: ReadAs
     disclosedContracts?: DisclosedContracts

--- a/wallet-gateway/extension/src/dapp-api/rpc-gen/typings.ts
+++ b/wallet-gateway/extension/src/dapp-api/rpc-gen/typings.ts
@@ -70,7 +70,7 @@ export type Command =
  * Non-empty array of Daml command atoms to submit atomically as a single transaction.
  *
  */
-export type JsCommands = Command[]
+export type Commands = Command[]
 /**
  *
  * The party that signed the transaction.
@@ -500,7 +500,7 @@ export interface MessageSignatureFailedEvent {
  */
 export interface PrepareExecuteParams {
     commandId?: CommandId
-    commands: JsCommands
+    commands: Commands
     actAs?: ActAs
     readAs?: ReadAs
     disclosedContracts?: DisclosedContracts

--- a/wallet-gateway/remote/src/dapp-api/rpc-gen/typings.ts
+++ b/wallet-gateway/remote/src/dapp-api/rpc-gen/typings.ts
@@ -70,7 +70,7 @@ export type Command =
  * Non-empty array of Daml command atoms to submit atomically as a single transaction.
  *
  */
-export type JsCommands = Command[]
+export type Commands = Command[]
 /**
  *
  * The party that signed the transaction.
@@ -508,7 +508,7 @@ export interface MessageSignatureFailedEvent {
  */
 export interface PrepareExecuteParams {
     commandId?: CommandId
-    commands: JsCommands
+    commands: Commands
     actAs?: ActAs
     readAs?: ReadAs
     disclosedContracts?: DisclosedContracts

--- a/wallet-gateway/remote/src/utils.ts
+++ b/wallet-gateway/remote/src/utils.ts
@@ -5,7 +5,7 @@ import { v4 } from 'uuid'
 import { LedgerClient, Types } from '@canton-network/core-ledger-client'
 import type {
     DisclosedContracts,
-    JsCommands,
+    Commands,
     PackageIdSelectionPreference,
 } from './dapp-api/rpc-gen/typings.js'
 
@@ -34,7 +34,7 @@ export async function networkStatus(
 
 export interface PrepareParams {
     commandId?: string
-    commands?: JsCommands
+    commands?: Commands
     actAs?: string[]
     readAs?: string[]
     disclosedContracts?: DisclosedContracts


### PR DESCRIPTION
Follow-up to: #1726  

Makes the naming more consistent with the Ledger API definition of the prepare submission request params. 