### PR TITLE
fix: normalize config urls

### DIFF
--- a/docs/dapp-building/README.md
+++ b/docs/dapp-building/README.md
@@ -2,8 +2,8 @@
 
 Build decentralized applications (dApps) that interact with the **Canton Network** through the **Wallet Gateway**. Use the **dApp SDK** in your frontend to connect users to their wallets, and the Wallet Gateway to mediate between your dApp, Canton validator nodes, and signing providers.
 
-> [!IMPORTANT]
-> This project is under active development and may introduce breaking changes until version 1.0.0. Migration guides for each release are published in [Discussions](https://github.com/canton-network/wallet/discussions).
+> [!NOTE]
+> Migration guides for each release are published in [Discussions](https://github.com/canton-network/wallet/discussions).
 
 ## Contents
 

--- a/docs/dapp-building/wallet-gateway/deployment/index.md
+++ b/docs/dapp-building/wallet-gateway/deployment/index.md
@@ -4,10 +4,10 @@ This section outlines some recommendations for production deployments of the Wal
 
 The service is available in both Docker and Helm variants:
 
-- **Docker Registry**: `ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway:0.20.0`
-- **Helm Repository**: `ghcr.io/digital-asset/wallet-gateway/helm/wallet-gateway:0.20.0`
+- **Docker Registry**: `ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway:<VERSION>`
+- **Helm Repository**: `ghcr.io/digital-asset/wallet-gateway/helm/wallet-gateway:<VERSION>`
 
-Note that we don't currently publish `latest` tags. To determine which version to use, check either
+Replace `<VERSION>` with the version you want to deploy. We don't currently publish `latest` tags. To determine which version to use, check either
 
 - The latest version displayed on the GHCR repo: https://github.com/digital-asset/wallet-gateway/pkgs/container/wallet-gateway%2Fdocker%2Fwallet-gateway
 - The version corresponding to the NPM package: https://www.npmjs.com/package/@canton-network/wallet-gateway-remote
@@ -18,10 +18,10 @@ To run the Docker container, a configuration file must be supplied for the Walle
 
 ```shell
 # via Docker
-docker run --rm ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway:0.20.0 --config-example > config.json
+docker run --rm ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway:<VERSION> --config-example > config.json
 
 # alternatively, generate a sample config file via NPM
-npx @canton-network/wallet-gateway-remote@0.20.0 --config-example > config.json
+npx @canton-network/wallet-gateway-remote@<VERSION> --config-example > config.json
 ```
 
 With the default config file, start the service:
@@ -29,7 +29,7 @@ With the default config file, start the service:
 ```shell
 docker run -p 3030:3030 \
     -v ${PWD}/config.json:/app/config.json:ro \
-    ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway:0.20.0
+    ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway:<VERSION>
 ```
 
 If all went well, the Wallet Gateway login page can be opened in a browser at http://localhost:3030.
@@ -91,7 +91,7 @@ The following config is incomplete, but highlights specific fields of note to co
 ```yaml
 kernel:
     # Set the publically accessible URL that users would use to connect to the deployed Wallet Gateway.
-    # Subpath routing is also supported as of v0.20.0
+    # Subpath routing is also supported as of v1.3.1
     publicUrl: 'https://wallet.example.com/subpath'
 server:
     # In a Helm/k8s setup, we recommend leaving the port set to the default `3030` value,
@@ -161,7 +161,7 @@ Then start the container with the volume mount
 docker run -p 3030:3030 \
     -v ${PWD}/config.json:/app/config.json:ro \
     -v ${PWD}/data:/data \
-    ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway:0.20.0
+    ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway:<VERSION>
 ```
 
 ### PostgreSQL
@@ -187,6 +187,6 @@ JSON logging can be enabled via the `--log-format` CLI flag (values: `"pretty" (
 ```shell
 docker run -p 3030:3030 \
     -v ${PWD}/config.json:/app/config.json:ro \
-    ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway:0.20.0 \
+    ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway:<VERSION> \
     --log-format=json
 ```

--- a/docs/dapp-building/wallet-gateway/deployment/index.md
+++ b/docs/dapp-building/wallet-gateway/deployment/index.md
@@ -91,7 +91,7 @@ The following config is incomplete, but highlights specific fields of note to co
 ```yaml
 kernel:
     # Set the publically accessible URL that users would use to connect to the deployed Wallet Gateway.
-    # Subpath routing is also supported as of v1.3.1
+    # Subpath routing is also supported
     publicUrl: 'https://wallet.example.com/subpath'
 server:
     # In a Helm/k8s setup, we recommend leaving the port set to the default `3030` value,

--- a/sdk/dapp-sdk/README.md
+++ b/sdk/dapp-sdk/README.md
@@ -2,8 +2,8 @@
 
 **`@canton-network/dapp-sdk`** — TypeScript SDK for building decentralized applications on the [Canton Network](https://www.canton.network/). Connect users to Canton wallets, manage accounts, sign messages, and execute transactions — all through a vendor-neutral interface defined by [CIP-0103](https://github.com/canton-foundation/cips/blob/main/cip-0103/cip-0103.md).
 
-> [!IMPORTANT]
-> This project is under active development and may introduce breaking changes until version 1.0.0. Migration guides for each release are published in [Discussions](https://github.com/canton-network/wallet/discussions).
+> [!NOTE]
+> Migration guides for each release are published in [Discussions](https://github.com/canton-network/wallet/discussions).
 
 ## Features
 

--- a/wallet-gateway/remote/src/config/Config.test.ts
+++ b/wallet-gateway/remote/src/config/Config.test.ts
@@ -3,6 +3,9 @@
 
 import { expect, test } from 'vitest'
 import { ConfigUtils } from './ConfigUtils.js'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 test('config from json file', async () => {
     const resp = ConfigUtils.loadConfigFile('../test/config.json')
@@ -26,5 +29,28 @@ test('config from json file', async () => {
         expect(resp.bootstrap.networks[4].adminAuth.clientSecret).toBe(
             'devnet_secret_testval'
         )
+    }
+})
+
+test('normalizes host-only or partial ledgerApi.baseUrl values', async () => {
+    const config = JSON.parse(readFileSync('../test/config.json', 'utf-8'))
+
+    const inputToExpected: Array<[string, string]> = [
+        ['127.0.0.1', 'http://127.0.0.1:80'],
+        ['http://127.0.0.1', 'http://127.0.0.1:80'],
+        ['https://127.0.0.1', 'https://127.0.0.1:443'],
+        ['127.0.0.1:5003', 'http://127.0.0.1:5003'],
+    ]
+
+    for (const [input, expected] of inputToExpected) {
+        const tempConfig = structuredClone(config)
+        tempConfig.bootstrap.networks[0].ledgerApi.baseUrl = input
+
+        const tempDir = mkdtempSync(join(tmpdir(), 'wg-config-'))
+        const tempFile = join(tempDir, 'config.json')
+        writeFileSync(tempFile, JSON.stringify(tempConfig), 'utf-8')
+
+        const loaded = ConfigUtils.loadConfigFile(tempFile)
+        expect(loaded.bootstrap.networks[0].ledgerApi.baseUrl).toBe(expected)
     }
 })

--- a/wallet-gateway/remote/src/config/Config.test.ts
+++ b/wallet-gateway/remote/src/config/Config.test.ts
@@ -54,3 +54,41 @@ test('normalizes host-only or partial ledgerApi.baseUrl values', async () => {
         expect(loaded.bootstrap.networks[0].ledgerApi.baseUrl).toBe(expected)
     }
 })
+
+test('normalizes host-only or partial OAuth IDP issuer values', async () => {
+    const config = JSON.parse(readFileSync('../test/config.json', 'utf-8'))
+
+    const inputToExpected: Array<[string, string]> = [
+        ['127.0.0.1', 'http://127.0.0.1:80'],
+        ['http://127.0.0.1', 'http://127.0.0.1:80'],
+        ['https://127.0.0.1', 'https://127.0.0.1:443'],
+        ['127.0.0.1:5003', 'http://127.0.0.1:5003'],
+    ]
+
+    for (const [input, expected] of inputToExpected) {
+        const tempConfig = structuredClone(config)
+        tempConfig.bootstrap.idps[0].issuer = input
+
+        const tempDir = mkdtempSync(join(tmpdir(), 'wg-config-'))
+        const tempFile = join(tempDir, 'config.json')
+        writeFileSync(tempFile, JSON.stringify(tempConfig), 'utf-8')
+
+        const loaded = ConfigUtils.loadConfigFile(tempFile)
+        expect(loaded.bootstrap.idps[0].issuer).toBe(expected)
+    }
+})
+
+test('keeps non-url self-signed IDP issuer unchanged', async () => {
+    const config = JSON.parse(readFileSync('../test/config.json', 'utf-8'))
+    const expectedIssuer = 'unsafe-auth'
+
+    const tempConfig = structuredClone(config)
+    tempConfig.bootstrap.idps[2].issuer = expectedIssuer
+
+    const tempDir = mkdtempSync(join(tmpdir(), 'wg-config-'))
+    const tempFile = join(tempDir, 'config.json')
+    writeFileSync(tempFile, JSON.stringify(tempConfig), 'utf-8')
+
+    const loaded = ConfigUtils.loadConfigFile(tempFile)
+    expect(loaded.bootstrap.idps[2].issuer).toBe(expectedIssuer)
+})

--- a/wallet-gateway/remote/src/config/ConfigUtils.ts
+++ b/wallet-gateway/remote/src/config/ConfigUtils.ts
@@ -9,7 +9,7 @@ export class ConfigUtils {
     static loadConfigFile(filePath: string): Config {
         if (existsSync(filePath)) {
             const rawJson = JSON.parse(readFileSync(filePath, 'utf-8'))
-            const normalizedJson = normalizeLedgerApiBaseUrls(rawJson)
+            const normalizedJson = normalizeConfigUrls(rawJson)
 
             const rawConfig = rawConfigSchema.parse(normalizedJson)
 
@@ -63,28 +63,54 @@ export class ConfigUtils {
     }
 }
 
-function normalizeLedgerApiBaseUrls(input: unknown): unknown {
+function normalizeConfigUrls(input: unknown): unknown {
     if (!input || typeof input !== 'object') {
         return input
     }
 
     const candidate = input as {
-        bootstrap?: { networks?: Array<{ ledgerApi?: { baseUrl?: string } }> }
+        bootstrap?: {
+            idps?: Array<{ issuer?: string }>
+            networks?: Array<{ ledgerApi?: { baseUrl?: string } }>
+        }
+    }
+
+    const idps = candidate.bootstrap?.idps
+    if (Array.isArray(idps)) {
+        for (const idp of idps) {
+            const issuer = idp.issuer
+            if (typeof issuer === 'string' && shouldNormalizeAsUrl(issuer)) {
+                idp.issuer = normalizeBaseUrl(issuer)
+            }
+        }
     }
 
     const networks = candidate.bootstrap?.networks
-    if (!Array.isArray(networks)) {
-        return input
-    }
-
-    for (const network of networks) {
-        const baseUrl = network.ledgerApi?.baseUrl
-        if (typeof baseUrl === 'string') {
-            network.ledgerApi!.baseUrl = normalizeBaseUrl(baseUrl)
+    if (Array.isArray(networks)) {
+        for (const network of networks) {
+            const baseUrl = network.ledgerApi?.baseUrl
+            if (typeof baseUrl === 'string') {
+                network.ledgerApi!.baseUrl = normalizeBaseUrl(baseUrl)
+            }
         }
     }
 
     return input
+}
+
+function shouldNormalizeAsUrl(value: string): boolean {
+    const trimmed = value.trim()
+
+    // Preserve non-URL issuers for self-signed setups, e.g. "unsafe-auth".
+    if (
+        !trimmed.includes('://') &&
+        !trimmed.includes('.') &&
+        !trimmed.includes(':')
+    ) {
+        return trimmed.toLowerCase() === 'localhost'
+    }
+
+    return true
 }
 
 function normalizeBaseUrl(baseUrl: string): string {

--- a/wallet-gateway/remote/src/config/ConfigUtils.ts
+++ b/wallet-gateway/remote/src/config/ConfigUtils.ts
@@ -8,9 +8,10 @@ import { Env } from '../env.js'
 export class ConfigUtils {
     static loadConfigFile(filePath: string): Config {
         if (existsSync(filePath)) {
-            const rawConfig = rawConfigSchema.parse(
-                JSON.parse(readFileSync(filePath, 'utf-8'))
-            )
+            const rawJson = JSON.parse(readFileSync(filePath, 'utf-8'))
+            const normalizedJson = normalizeLedgerApiBaseUrls(rawJson)
+
+            const rawConfig = rawConfigSchema.parse(normalizedJson)
 
             const config = resolveRawConfig(rawConfig)
 
@@ -60,6 +61,77 @@ export class ConfigUtils {
             throw new Error("Supplied file path doesn't exist " + filePath)
         }
     }
+}
+
+function normalizeLedgerApiBaseUrls(input: unknown): unknown {
+    if (!input || typeof input !== 'object') {
+        return input
+    }
+
+    const candidate = input as {
+        bootstrap?: { networks?: Array<{ ledgerApi?: { baseUrl?: string } }> }
+    }
+
+    const networks = candidate.bootstrap?.networks
+    if (!Array.isArray(networks)) {
+        return input
+    }
+
+    for (const network of networks) {
+        const baseUrl = network.ledgerApi?.baseUrl
+        if (typeof baseUrl === 'string') {
+            network.ledgerApi!.baseUrl = normalizeBaseUrl(baseUrl)
+        }
+    }
+
+    return input
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+    const trimmed = baseUrl.trim()
+
+    if (trimmed.length === 0) {
+        return baseUrl
+    }
+
+    if (trimmed.includes('://')) {
+        return normalizeUrlWithProtocol(new URL(trimmed))
+    }
+
+    const withDefaultProtocol = new URL(`http://${trimmed}`)
+    const hasExplicitPort = hasPortInAuthority(trimmed)
+    if (!hasExplicitPort) {
+        withDefaultProtocol.port = '80'
+    }
+
+    return normalizeUrlWithProtocol(withDefaultProtocol)
+}
+
+function hasPortInAuthority(rawValue: string): boolean {
+    const authority = rawValue.split(/[/?#]/)[0]
+
+    // IPv6 literal with explicit port, e.g. [::1]:5003
+    if (authority.startsWith('[')) {
+        return authority.includes(']:')
+    }
+
+    return authority.includes(':')
+}
+
+function normalizeUrlWithProtocol(url: URL): string {
+    const defaultPort =
+        url.protocol === 'http:' ? '80' : url.protocol === 'https:' ? '443' : ''
+    const port = url.port || defaultPort
+    const hostname = url.hostname.includes(':')
+        ? `[${url.hostname}]`
+        : url.hostname
+    const authority = port ? `${hostname}:${port}` : hostname
+    const path =
+        url.pathname === '/' && !url.search && !url.hash
+            ? ''
+            : `${url.pathname}${url.search}${url.hash}`
+
+    return `${url.protocol}//${authority}${path}`
 }
 
 type RawNetworkAuth = NonNullable<


### PR DESCRIPTION
**Problem**
some times people put simplified urls into the config files. This should be working from a user perspect (i.e. they don't need to provide transport as it should default to http and they should not need to provide port if api is exposed on default ports like 80 or 443 for ssl)