### PR TITLE
fix: normalize urls for config

### DIFF
--- a/wallet-gateway/remote/src/config/Config.test.ts
+++ b/wallet-gateway/remote/src/config/Config.test.ts
@@ -3,6 +3,9 @@
 
 import { expect, test } from 'vitest'
 import { ConfigUtils } from './ConfigUtils.js'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 test('config from json file', async () => {
     const resp = ConfigUtils.loadConfigFile('../test/config.json')
@@ -26,5 +29,28 @@ test('config from json file', async () => {
         expect(resp.bootstrap.networks[4].adminAuth.clientSecret).toBe(
             'devnet_secret_testval'
         )
+    }
+})
+
+test('normalizes host-only or partial ledgerApi.baseUrl values', async () => {
+    const config = JSON.parse(readFileSync('../test/config.json', 'utf-8'))
+
+    const inputToExpected: Array<[string, string]> = [
+        ['127.0.0.1', 'http://127.0.0.1:80'],
+        ['http://127.0.0.1', 'http://127.0.0.1:80'],
+        ['https://127.0.0.1', 'https://127.0.0.1:443'],
+        ['127.0.0.1:5003', 'http://127.0.0.1:5003'],
+    ]
+
+    for (const [input, expected] of inputToExpected) {
+        const tempConfig = structuredClone(config)
+        tempConfig.bootstrap.networks[0].ledgerApi.baseUrl = input
+
+        const tempDir = mkdtempSync(join(tmpdir(), 'wg-config-'))
+        const tempFile = join(tempDir, 'config.json')
+        writeFileSync(tempFile, JSON.stringify(tempConfig), 'utf-8')
+
+        const loaded = ConfigUtils.loadConfigFile(tempFile)
+        expect(loaded.bootstrap.networks[0].ledgerApi.baseUrl).toBe(expected)
     }
 })

--- a/wallet-gateway/remote/src/config/Config.test.ts
+++ b/wallet-gateway/remote/src/config/Config.test.ts
@@ -54,3 +54,41 @@ test('normalizes host-only or partial ledgerApi.baseUrl values', async () => {
         expect(loaded.bootstrap.networks[0].ledgerApi.baseUrl).toBe(expected)
     }
 })
+
+test('normalizes host-only or partial OAuth IDP issuer values', async () => {
+    const config = JSON.parse(readFileSync('../test/config.json', 'utf-8'))
+
+    const inputToExpected: Array<[string, string]> = [
+        ['127.0.0.1', 'http://127.0.0.1:80'],
+        ['http://127.0.0.1', 'http://127.0.0.1:80'],
+        ['https://127.0.0.1', 'https://127.0.0.1:443'],
+        ['127.0.0.1:5003', 'http://127.0.0.1:5003'],
+    ]
+
+    for (const [input, expected] of inputToExpected) {
+        const tempConfig = structuredClone(config)
+        tempConfig.bootstrap.idps[0].issuer = input
+
+        const tempDir = mkdtempSync(join(tmpdir(), 'wg-config-'))
+        const tempFile = join(tempDir, 'config.json')
+        writeFileSync(tempFile, JSON.stringify(tempConfig), 'utf-8')
+
+        const loaded = ConfigUtils.loadConfigFile(tempFile)
+        expect(loaded.bootstrap.idps[0].issuer).toBe(expected)
+    }
+})
+
+test('keeps non-url self-signed IDP issuer unchanged', async () => {
+    const config = JSON.parse(readFileSync('../test/config.json', 'utf-8'))
+    const expectedIssuer = 'unsafe-auth'
+
+    const tempConfig = structuredClone(config)
+    tempConfig.bootstrap.idps[2].issuer = expectedIssuer
+
+    const tempDir = mkdtempSync(join(tmpdir(), 'wg-config-'))
+    const tempFile = join(tempDir, 'config.json')
+    writeFileSync(tempFile, JSON.stringify(tempConfig), 'utf-8')
+
+    const loaded = ConfigUtils.loadConfigFile(tempFile)
+    expect(loaded.bootstrap.idps[2].issuer).toBe(expectedIssuer)
+})

--- a/wallet-gateway/remote/src/config/ConfigUtils.ts
+++ b/wallet-gateway/remote/src/config/ConfigUtils.ts
@@ -9,7 +9,7 @@ export class ConfigUtils {
     static loadConfigFile(filePath: string): Config {
         if (existsSync(filePath)) {
             const rawJson = JSON.parse(readFileSync(filePath, 'utf-8'))
-            const normalizedJson = normalizeLedgerApiBaseUrls(rawJson)
+            const normalizedJson = normalizeConfigUrls(rawJson)
 
             const rawConfig = rawConfigSchema.parse(normalizedJson)
 
@@ -63,28 +63,54 @@ export class ConfigUtils {
     }
 }
 
-function normalizeLedgerApiBaseUrls(input: unknown): unknown {
+function normalizeConfigUrls(input: unknown): unknown {
     if (!input || typeof input !== 'object') {
         return input
     }
 
     const candidate = input as {
-        bootstrap?: { networks?: Array<{ ledgerApi?: { baseUrl?: string } }> }
+        bootstrap?: {
+            idps?: Array<{ issuer?: string }>
+            networks?: Array<{ ledgerApi?: { baseUrl?: string } }>
+        }
+    }
+
+    const idps = candidate.bootstrap?.idps
+    if (Array.isArray(idps)) {
+        for (const idp of idps) {
+            const issuer = idp.issuer
+            if (typeof issuer === 'string' && shouldNormalizeAsUrl(issuer)) {
+                idp.issuer = normalizeBaseUrl(issuer)
+            }
+        }
     }
 
     const networks = candidate.bootstrap?.networks
-    if (!Array.isArray(networks)) {
-        return input
-    }
-
-    for (const network of networks) {
-        const baseUrl = network.ledgerApi?.baseUrl
-        if (typeof baseUrl === 'string') {
-            network.ledgerApi!.baseUrl = normalizeBaseUrl(baseUrl)
+    if (Array.isArray(networks)) {
+        for (const network of networks) {
+            const baseUrl = network.ledgerApi?.baseUrl
+            if (typeof baseUrl === 'string') {
+                network.ledgerApi!.baseUrl = normalizeBaseUrl(baseUrl)
+            }
         }
     }
 
     return input
+}
+
+function shouldNormalizeAsUrl(value: string): boolean {
+    const trimmed = value.trim()
+
+    // Preserve non-URL issuers for self-signed setups, e.g. "unsafe-auth".
+    if (
+        !trimmed.includes('://') &&
+        !trimmed.includes('.') &&
+        !trimmed.includes(':')
+    ) {
+        return trimmed.toLowerCase() === 'localhost'
+    }
+
+    return true
 }
 
 function normalizeBaseUrl(baseUrl: string): string {

--- a/wallet-gateway/remote/src/config/ConfigUtils.ts
+++ b/wallet-gateway/remote/src/config/ConfigUtils.ts
@@ -8,9 +8,10 @@ import { Env } from '../env.js'
 export class ConfigUtils {
     static loadConfigFile(filePath: string): Config {
         if (existsSync(filePath)) {
-            const rawConfig = rawConfigSchema.parse(
-                JSON.parse(readFileSync(filePath, 'utf-8'))
-            )
+            const rawJson = JSON.parse(readFileSync(filePath, 'utf-8'))
+            const normalizedJson = normalizeLedgerApiBaseUrls(rawJson)
+
+            const rawConfig = rawConfigSchema.parse(normalizedJson)
 
             const config = resolveRawConfig(rawConfig)
 
@@ -60,6 +61,77 @@ export class ConfigUtils {
             throw new Error("Supplied file path doesn't exist " + filePath)
         }
     }
+}
+
+function normalizeLedgerApiBaseUrls(input: unknown): unknown {
+    if (!input || typeof input !== 'object') {
+        return input
+    }
+
+    const candidate = input as {
+        bootstrap?: { networks?: Array<{ ledgerApi?: { baseUrl?: string } }> }
+    }
+
+    const networks = candidate.bootstrap?.networks
+    if (!Array.isArray(networks)) {
+        return input
+    }
+
+    for (const network of networks) {
+        const baseUrl = network.ledgerApi?.baseUrl
+        if (typeof baseUrl === 'string') {
+            network.ledgerApi!.baseUrl = normalizeBaseUrl(baseUrl)
+        }
+    }
+
+    return input
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+    const trimmed = baseUrl.trim()
+
+    if (trimmed.length === 0) {
+        return baseUrl
+    }
+
+    if (trimmed.includes('://')) {
+        return normalizeUrlWithProtocol(new URL(trimmed))
+    }
+
+    const withDefaultProtocol = new URL(`http://${trimmed}`)
+    const hasExplicitPort = hasPortInAuthority(trimmed)
+    if (!hasExplicitPort) {
+        withDefaultProtocol.port = '80'
+    }
+
+    return normalizeUrlWithProtocol(withDefaultProtocol)
+}
+
+function hasPortInAuthority(rawValue: string): boolean {
+    const authority = rawValue.split(/[/?#]/)[0]
+
+    // IPv6 literal with explicit port, e.g. [::1]:5003
+    if (authority.startsWith('[')) {
+        return authority.includes(']:')
+    }
+
+    return authority.includes(':')
+}
+
+function normalizeUrlWithProtocol(url: URL): string {
+    const defaultPort =
+        url.protocol === 'http:' ? '80' : url.protocol === 'https:' ? '443' : ''
+    const port = url.port || defaultPort
+    const hostname = url.hostname.includes(':')
+        ? `[${url.hostname}]`
+        : url.hostname
+    const authority = port ? `${hostname}:${port}` : hostname
+    const path =
+        url.pathname === '/' && !url.search && !url.hash
+            ? ''
+            : `${url.pathname}${url.search}${url.hash}`
+
+    return `${url.protocol}//${authority}${path}`
 }
 
 type RawNetworkAuth = NonNullable<


### PR DESCRIPTION
**Problem**
Some times people expect default behavior when inserting string urls in config, for instance they might insert localhost:8080 instead of http://localhost:8080 or they might insert my-domain.com instead of http://my-domain.com.

**Solution**
This pr addresses default behavior, defined as:
- if using http and no port, then use port 80
- if using https and no port, then use port 443
- if no transport is provided use http