### PR TITLE
feat: add runtime config.json to portfolio dApp

### DIFF
--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -41,6 +41,20 @@ yarn workspace @canton-network/example-portfolio dev
 
 The app will be available at [http://localhost:8081](http://localhost:8081).
 
+## Runtime configuration
+
+The app loads `config.json` at startup and validates it before rendering. The local/default config is in [`public/config.json`](public/config.json):
+
+```json
+{
+    "validatorUrl": "http://localhost:2000/api/validator",
+    "scanProxyUrl": "http://localhost:2000/api/validator",
+    "registries": [] // not currently used
+}
+```
+
+For static or Docker deployments, replace or mount `/config.json`.
+
 Alternatively, start all services (Wallet Gateway + example dApps) together from the repository root:
 
 ```bash

--- a/examples/portfolio/public/config.json
+++ b/examples/portfolio/public/config.json
@@ -1,0 +1,5 @@
+{
+    "validatorUrl": "http://localhost:2000/api/validator",
+    "scanProxyUrl": "http://localhost:2000/api/validator",
+    "registries": []
+}

--- a/examples/portfolio/src/components/tap-settings.tsx
+++ b/examples/portfolio/src/components/tap-settings.tsx
@@ -18,6 +18,7 @@ import { useForm } from '@tanstack/react-form'
 import { z } from 'zod'
 import { toast } from 'sonner'
 import { usePortfolio } from '../contexts/PortfolioContext'
+import { usePortfolioConfig } from '../contexts/PortfolioConfigContext'
 import { useConnection } from '../contexts/ConnectionContext'
 import { useRegistryUrls } from '@hooks/useRegistryUrls'
 import { usePrimaryAccount } from '@hooks/useAccounts'
@@ -36,6 +37,7 @@ export const TapSettings: React.FC = () => {
     const sessionToken = useConnection().status?.session?.accessToken
     const primaryParty = usePrimaryAccount()?.partyId
     const { tap } = usePortfolio()
+    const { scanProxyUrl } = usePortfolioConfig()
     const registryUrls = useRegistryUrls()
     const instruments = useInstruments()
 
@@ -68,6 +70,7 @@ export const TapSettings: React.FC = () => {
                     registryUrls,
                     party: primaryParty,
                     sessionToken,
+                    scanProxyUrl,
                     instrumentId: formData.instrumentId,
                     amount: Number(formData.amount),
                 })

--- a/examples/portfolio/src/config/portfolio-config.ts
+++ b/examples/portfolio/src/config/portfolio-config.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { z } from 'zod'
+
+const DEFAULT_CONFIG_URL = '/config.json'
+
+const httpUrlSchema = z
+    .url({
+        message: 'Must be a valid HTTP or HTTPS URL',
+        protocol: /^https?$/,
+    })
+    .transform((value) => new URL(value).toString())
+
+const optionalNonEmptyStringSchema = (fieldName: string) =>
+    z.string().trim().min(1, `${fieldName} must not be empty`).optional()
+
+export const registryConfigSchema = z
+    .object({
+        name: optionalNonEmptyStringSchema('Registry name'),
+        partyId: optionalNonEmptyStringSchema('Registry partyId'),
+        url: httpUrlSchema,
+    })
+    .strict()
+
+export const portfolioConfigSchema = z
+    .object({
+        validatorUrl: httpUrlSchema,
+        scanProxyUrl: httpUrlSchema,
+        registries: z.array(registryConfigSchema),
+    })
+    .strict()
+
+export type PortfolioRegistryConfig = z.infer<typeof registryConfigSchema>
+export type PortfolioConfig = z.infer<typeof portfolioConfigSchema>
+
+const formatConfigError = (error: z.ZodError): string =>
+    error.issues
+        .map((issue) => {
+            const path = issue.path.length > 0 ? issue.path.join('.') : '<root>'
+            return `${path}: ${issue.message}`
+        })
+        .join('; ')
+
+export const loadPortfolioConfig = async (
+    configUrl = DEFAULT_CONFIG_URL
+): Promise<PortfolioConfig> => {
+    const response = await fetch(configUrl, { cache: 'no-store' })
+
+    if (!response.ok) {
+        throw new Error(
+            `Failed to load portfolio config from ${configUrl}: ${response.status} ${response.statusText}`
+        )
+    }
+
+    let rawConfig: unknown
+    try {
+        rawConfig = await response.json()
+    } catch (error) {
+        throw new Error(
+            `Invalid JSON in portfolio config from ${configUrl}: ${String(error)}`,
+            { cause: error }
+        )
+    }
+
+    const result = portfolioConfigSchema.safeParse(rawConfig)
+    if (!result.success) {
+        throw new Error(
+            `Invalid portfolio config from ${configUrl}: ${formatConfigError(result.error)}`
+        )
+    }
+
+    return result.data
+}

--- a/examples/portfolio/src/contexts/PortfolioConfigContext.tsx
+++ b/examples/portfolio/src/contexts/PortfolioConfigContext.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createContext, useContext } from 'react'
+import { type PortfolioConfig } from '@config/portfolio-config'
+
+export const PortfolioConfigContext = createContext<
+    PortfolioConfig | undefined
+>(undefined)
+
+export const usePortfolioConfig = () => {
+    const ctx = useContext(PortfolioConfigContext)
+    if (!ctx) {
+        throw new Error(
+            'usePortfolioConfig must be used within PortfolioConfigProvider'
+        )
+    }
+    return ctx
+}

--- a/examples/portfolio/src/contexts/PortfolioConfigProvider.tsx
+++ b/examples/portfolio/src/contexts/PortfolioConfigProvider.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ReactNode } from 'react'
+import { type PortfolioConfig } from '@config/portfolio-config'
+import { PortfolioConfigContext } from '@contexts/PortfolioConfigContext'
+
+export const PortfolioConfigProvider = ({
+    children,
+    config,
+}: {
+    children: ReactNode
+    config: PortfolioConfig
+}) => {
+    return (
+        <PortfolioConfigContext.Provider value={config}>
+            {children}
+        </PortfolioConfigContext.Provider>
+    )
+}

--- a/examples/portfolio/src/hooks/query-options.ts
+++ b/examples/portfolio/src/hooks/query-options.ts
@@ -3,6 +3,7 @@
 
 import { queryOptions } from '@tanstack/react-query'
 import { usePortfolio } from '../contexts/PortfolioContext'
+import { usePortfolioConfig } from '../contexts/PortfolioConfigContext'
 import { queryKeys } from './query-keys'
 
 export const usePendingTransfersQueryOptions = (party: string | undefined) => {
@@ -37,10 +38,11 @@ export const useAllocationsQueryOptions = (party: string | undefined) => {
 
 export const useIsDevNetQueryOptions = (sessionToken: string | undefined) => {
     const { isDevNet } = usePortfolio()
+    const { scanProxyUrl } = usePortfolioConfig()
     return queryOptions({
         queryKey: queryKeys.isDevNet.all,
         queryFn: async () =>
-            sessionToken ? isDevNet({ sessionToken }) : false,
+            sessionToken ? isDevNet({ sessionToken, scanProxyUrl }) : false,
         enabled: !!sessionToken,
         staleTime: Infinity, // Network doesn't change, so cache forever
     })

--- a/examples/portfolio/src/main.tsx
+++ b/examples/portfolio/src/main.tsx
@@ -8,9 +8,11 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { routeTree } from './routeTree.gen'
 import ReactDOM from 'react-dom/client'
 
-import { ConnectionProvider } from './contexts/ConnectionProvider'
-import { PortfolioProvider } from './contexts/PortfolioProvider'
-import { AppThemeProvider } from './contexts/theme-provider'
+import { loadPortfolioConfig } from '@config/portfolio-config'
+import { ConnectionProvider } from '@contexts/ConnectionProvider'
+import { PortfolioProvider } from '@contexts/PortfolioProvider'
+import { PortfolioConfigProvider } from '@contexts/PortfolioConfigProvider'
+import { AppThemeProvider } from '@contexts/theme-provider'
 import { Toaster } from 'sonner'
 
 const queryClient = new QueryClient({
@@ -37,28 +39,49 @@ declare module '@tanstack/react-router' {
     }
 }
 
+const renderConfigError = (root: ReactDOM.Root, error: unknown) => {
+    root.render(
+        <div role="alert">
+            Failed to load portfolio configuration: <br /> {String(error)}
+        </div>
+    )
+}
+
+const renderApp = async (root: ReactDOM.Root) => {
+    root.render(<div role="status">Loading portfolio configuration…</div>)
+
+    const portfolioConfig = await loadPortfolioConfig()
+
+    root.render(
+        <StrictMode>
+            <AppThemeProvider>
+                <PortfolioConfigProvider config={portfolioConfig}>
+                    <LocalizationProvider dateAdapter={AdapterDateFns}>
+                        <QueryClientProvider client={queryClient}>
+                            <ConnectionProvider>
+                                <PortfolioProvider>
+                                    <RouterProvider
+                                        router={router}
+                                        context={{ queryClient }}
+                                    />
+                                    <Toaster richColors />
+                                </PortfolioProvider>
+                            </ConnectionProvider>
+                        </QueryClientProvider>
+                    </LocalizationProvider>
+                </PortfolioConfigProvider>
+            </AppThemeProvider>
+        </StrictMode>
+    )
+}
+
 // Render the app
 const rootElement = document.getElementById('app')
 
 if (rootElement && !rootElement.innerHTML) {
     const root = ReactDOM.createRoot(rootElement)
-    root.render(
-        <StrictMode>
-            <AppThemeProvider>
-                <LocalizationProvider dateAdapter={AdapterDateFns}>
-                    <QueryClientProvider client={queryClient}>
-                        <ConnectionProvider>
-                            <PortfolioProvider>
-                                <RouterProvider
-                                    router={router}
-                                    context={{ queryClient }}
-                                />
-                                <Toaster richColors />
-                            </PortfolioProvider>
-                        </ConnectionProvider>
-                    </QueryClientProvider>
-                </LocalizationProvider>
-            </AppThemeProvider>
-        </StrictMode>
-    )
+
+    renderApp(root).catch((error: unknown) => {
+        renderConfigError(root, error)
+    })
 }

--- a/examples/portfolio/src/services/portfolio-service-implementation.ts
+++ b/examples/portfolio/src/services/portfolio-service-implementation.ts
@@ -307,12 +307,14 @@ export const tap = async ({
     registryUrls,
     party,
     sessionToken,
+    scanProxyUrl,
     instrumentId,
     amount,
 }: {
     registryUrls: ReadonlyMap<PartyId, string>
     party: string
     sessionToken: string
+    scanProxyUrl: string
     instrumentId: { admin: string; id: string }
     amount: number
 }) => {
@@ -324,6 +326,7 @@ export const tap = async ({
 
     const amuletService = await resolveAmuletService({
         sessionToken,
+        scanProxyUrl,
     })
     const [tapCommand, disclosedContracts] = await amuletService.createTap(
         party,
@@ -350,9 +353,14 @@ export const tap = async ({
 
 export const isDevNet = async ({
     sessionToken,
+    scanProxyUrl,
 }: {
     sessionToken: string
+    scanProxyUrl: string
 }): Promise<boolean> => {
-    const amuletService = await resolveAmuletService({ sessionToken })
+    const amuletService = await resolveAmuletService({
+        sessionToken,
+        scanProxyUrl,
+    })
     return await amuletService.isDevNet()
 }

--- a/examples/portfolio/src/services/portfolio-service.ts
+++ b/examples/portfolio/src/services/portfolio-service.ts
@@ -76,13 +76,17 @@ export interface PortfolioService {
     }) => Promise<TransactionHistoryResponse>
 
     // Network info
-    isDevNet: (_: { sessionToken: string }) => Promise<boolean>
+    isDevNet: (_: {
+        sessionToken: string
+        scanProxyUrl: string
+    }) => Promise<boolean>
 
     // Tap
     tap: (_: {
         registryUrls: ReadonlyMap<PartyId, string>
         party: string
         sessionToken: string
+        scanProxyUrl: string
         instrumentId: { admin: string; id: string }
         amount: number
     }) => Promise<void>

--- a/examples/portfolio/src/services/resolve.ts
+++ b/examples/portfolio/src/services/resolve.ts
@@ -61,32 +61,30 @@ const createTokenStandardService = async ({
     return tokenStandardService
 }
 
-const DEFAULT_SCAN_PROXY_URL = 'http://localhost:2000/api/validator'
+const resolveScanProxyUrl = (scanProxyUrl: string): URL => {
+    const url = new URL(scanProxyUrl)
 
-const resolveScanProxyUrl = (): URL => {
-    const scanProxyUrl = new URL(
-        import.meta.env.VITE_SCAN_PROXY_URL ?? DEFAULT_SCAN_PROXY_URL
-    )
-
-    if (scanProxyUrl.protocol === 'http:') {
+    if (url.protocol === 'http:') {
         logger.warn(
-            { scanProxyUrl: scanProxyUrl.toString() },
-            'Using a non-TLS scan proxy endpoint. This is acceptable only in trusted environments. Set VITE_SCAN_PROXY_URL to an HTTPS endpoint if the scan proxy is reachable over an untrusted network.'
+            { scanProxyUrl: url.toString() },
+            'Using a non-TLS scan proxy endpoint. This is acceptable only in trusted environments. Set scanProxyUrl in portfolio config to an HTTPS endpoint if the scan proxy is reachable over an untrusted network.'
         )
     }
 
-    return scanProxyUrl
+    return url
 }
 
 const createAmuletService = async ({
     sessionToken,
+    scanProxyUrl,
     tokenStandardService,
 }: {
     sessionToken: string
+    scanProxyUrl: string
     tokenStandardService: TokenStandardService
 }): Promise<AmuletService> => {
     const scanProxyClient = new ScanProxyClient(
-        resolveScanProxyUrl(),
+        resolveScanProxyUrl(scanProxyUrl),
         logger,
         AuthTokenProvider.fromToken(sessionToken, logger)
     )
@@ -137,15 +135,18 @@ export const resolveTokenStandardService =
     }
 
 export const resolveAmuletService = async ({
-    sessionToken, // todo: scan URLs?
+    sessionToken,
+    scanProxyUrl,
 }: {
     sessionToken: string
+    scanProxyUrl: string
 }): Promise<AmuletService> => {
-    const key = 'current-session'
+    const key = `${scanProxyUrl}:current-session`
     if (amuletServices.has(key)) return amuletServices.get(key)!
     const tokenStandardService = await resolveTokenStandardService()
     const amuletService = await createAmuletService({
         sessionToken,
+        scanProxyUrl,
         tokenStandardService,
     })
     amuletServices.set(key, amuletService)

--- a/examples/portfolio/tsconfig.app.json
+++ b/examples/portfolio/tsconfig.app.json
@@ -1,14 +1,15 @@
 {
     "compilerOptions": {
         "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-        "target": "ES2020",
+        "target": "ES2022",
         "useDefineForClassFields": true,
-        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
         "module": "ESNext",
         "skipLibCheck": true,
         "baseUrl": ".",
         "paths": {
             "@components/*": ["src/components/*"],
+            "@config/*": ["src/config/*"],
             "@contexts/*": ["src/contexts/*"],
             "@hooks/*": ["src/hooks/*"],
             "@lib/*": ["src/lib/*"],


### PR DESCRIPTION
Fixes #1919 

Infra PR: https://github.com/digital-asset/wallet-gateway/pull/100


Some notes: 

- All changes to files in `services/` will be irrelevant and gone once we switch to using the wallet sdk in #1795 
- `registries` is in the config but not currently used. That will be sorted out in the new UI


Missing config shows
<img width="1178" height="318" alt="image" src="https://github.com/user-attachments/assets/3e5b7210-7132-4265-8ef0-963155f83c68" />


Config that fails validation shows 
<img width="1207" height="251" alt="image" src="https://github.com/user-attachments/assets/10f2350f-ba16-4d8b-af06-013faef34313" />


I tested with a local docker build and run :smile_cat: 