### PR TITLE
feat: filter out holdings by instrument

### DIFF
--- a/core/amulet-service/package.json
+++ b/core/amulet-service/package.json
@@ -44,6 +44,7 @@
         "@canton-network/core-wallet-auth": "workspace:^",
         "bignumber.js": "^10.0.2",
         "dayjs": "^1.11.19",
+        "decimal.js": "^10.6.0",
         "openapi-fetch": "^0.17.0",
         "pino": "^10.3.1"
     },

--- a/core/amulet-service/src/amulet-service.ts
+++ b/core/amulet-service/src/amulet-service.ts
@@ -8,7 +8,7 @@ import {
     DisclosedContract,
     TokenStandardService,
 } from '@canton-network/core-token-standard-service'
-
+import { Decimal } from 'decimal.js'
 // TODO: This appears in a couple of places, either move it somewhere more
 // central, or as part of the Service class hierarchy
 const REQUESTED_AT_SKEW_MS = 60_000
@@ -69,7 +69,7 @@ export class AmuletService {
         const inputHoldings = await this.tokenStandard.getInputHoldingsCids(
             provider,
             inputUtxos,
-            trafficAmount
+            new Decimal(trafficAmount)
         )
 
         if (!amuletRules) {

--- a/core/token-standard-service/package.json
+++ b/core/token-standard-service/package.json
@@ -44,7 +44,6 @@
         "@canton-network/core-tx-parser": "workspace:^",
         "@canton-network/core-types": "workspace:^",
         "@canton-network/core-wallet-auth": "workspace:^",
-        "bignumber.js": "^10.0.2",
         "dayjs": "^1.11.19",
         "decimal.js": "^10.6.0",
         "openapi-fetch": "^0.17.0",

--- a/core/token-standard-service/package.json
+++ b/core/token-standard-service/package.json
@@ -46,6 +46,7 @@
         "@canton-network/core-wallet-auth": "workspace:^",
         "bignumber.js": "^10.0.2",
         "dayjs": "^1.11.19",
+        "decimal.js": "^10.6.0",
         "openapi-fetch": "^0.17.0",
         "pino": "^10.3.1",
         "typescript-lru-cache": "^2.0.0"

--- a/core/token-standard-service/src/token-standard-service.test.ts
+++ b/core/token-standard-service/src/token-standard-service.test.ts
@@ -6,14 +6,19 @@ import { CoreService } from './token-standard-service.js'
 import { PrettyContract } from '@canton-network/core-tx-parser'
 import { HoldingView } from '@canton-network/core-token-standard'
 
-describe('getInputHoldingsCidsForAmount', () => {
-    const makeHolding = (id: string, amount: string) => ({
+describe('getInputHoldingsCidsForAmount', async () => {
+    const makeHolding = (
+        id: string,
+        amount: string,
+        admin: string,
+        instrumentId: string
+    ) => ({
         contractId: id,
         interfaceViewValue: {
             owner: 'dummy',
             instrumentId: {
-                admin: 'partyid',
-                id: 'amulet',
+                admin: admin,
+                id: instrumentId,
             },
             lock: null,
             meta: {
@@ -38,9 +43,9 @@ describe('getInputHoldingsCidsForAmount', () => {
 
     it('returns exact match', async () => {
         const holdings = [
-            makeHolding('a', '200'),
-            makeHolding('b', '20'),
-            makeHolding('c', '30'),
+            makeHolding('a', '200', 'partyId', 'amulet'),
+            makeHolding('b', '20', 'partyId', 'amulet'),
+            makeHolding('c', '30', 'partyId', 'amulet'),
         ]
 
         const result = await CoreService.getInputHoldingsCidsForAmount(
@@ -53,9 +58,9 @@ describe('getInputHoldingsCidsForAmount', () => {
 
     it('returns multiple holdings to meet target amount', async () => {
         const holdings = [
-            makeHolding('b', '20'),
-            makeHolding('a', '200'),
-            makeHolding('c', '30'),
+            makeHolding('b', '20', 'partyId', 'amulet'),
+            makeHolding('a', '200', 'partyId', 'amulet'),
+            makeHolding('c', '30', 'partyId', 'amulet'),
         ]
 
         const result = await CoreService.getInputHoldingsCidsForAmount(
@@ -68,9 +73,9 @@ describe('getInputHoldingsCidsForAmount', () => {
 
     it('returns all holdings to meet target amount even if it exceeds the target', async () => {
         const holdings = [
-            makeHolding('a', '2'),
-            makeHolding('b', '99'),
-            makeHolding('c', '3'),
+            makeHolding('a', '2', 'partyId', 'amulet'),
+            makeHolding('b', '99', 'partyId', 'amulet'),
+            makeHolding('c', '3', 'partyId', 'amulet'),
         ]
 
         const result = await CoreService.getInputHoldingsCidsForAmount(
@@ -79,6 +84,29 @@ describe('getInputHoldingsCidsForAmount', () => {
         )
 
         expect(result).toEqual(['b', 'a'])
+    })
+
+    it('a', async () => {
+        const holdings = [
+            makeHolding('a', '2', 'instrumentAdmin1', 'amulet'),
+            makeHolding('b', '99', 'instrumentAdmin1', 'amulet'),
+            makeHolding('c', '3', 'instrumentAdmin2', 'usdcx'),
+        ]
+
+        const usdcxHoldings = await CoreService.filterHoldingsByInstrument({
+            holdings,
+            instrumentAdmin: 'instrumentAdmin2',
+            instrumentId: 'usdcx',
+        })
+
+        const amuletHoldings = await CoreService.filterHoldingsByInstrument({
+            holdings,
+            instrumentAdmin: 'instrumentAdmin1',
+            instrumentId: 'amulet',
+        })
+
+        expect(usdcxHoldings.length).toBe(1)
+        expect(amuletHoldings.length).toBe(2)
     })
 
     it('throws an error if no unlocked holdings exist', async () => {
@@ -90,7 +118,10 @@ describe('getInputHoldingsCidsForAmount', () => {
     })
 
     it('throws an error if there are insufficient funds', async () => {
-        const holdings = [makeHolding('a', '5'), makeHolding('b', '10')]
+        const holdings = [
+            makeHolding('a', '5', 'partyId', 'amulet'),
+            makeHolding('b', '10', 'partyId', 'amulet'),
+        ]
 
         await expect(
             CoreService.getInputHoldingsCidsForAmount(20, holdings)
@@ -101,7 +132,7 @@ describe('getInputHoldingsCidsForAmount', () => {
 
     it('throws an error if it exceeds 100 utxos', async () => {
         const holdings = Array.from({ length: 101 }, (_, i) =>
-            makeHolding(`id${i}`, '1')
+            makeHolding(`id${i}`, '1', 'partyId', 'amulet')
         )
 
         await expect(

--- a/core/token-standard-service/src/token-standard-service.test.ts
+++ b/core/token-standard-service/src/token-standard-service.test.ts
@@ -86,7 +86,7 @@ describe('getInputHoldingsCidsForAmount', async () => {
         expect(result).toEqual(['b', 'a'])
     })
 
-    it('a', async () => {
+    it('should filter out holdings by instrument', async () => {
         const holdings = [
             makeHolding('a', '2', 'instrumentAdmin1', 'amulet'),
             makeHolding('b', '99', 'instrumentAdmin1', 'amulet'),

--- a/core/token-standard-service/src/token-standard-service.test.ts
+++ b/core/token-standard-service/src/token-standard-service.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest'
 import { CoreService } from './token-standard-service.js'
 import { PrettyContract } from '@canton-network/core-tx-parser'
 import { HoldingView } from '@canton-network/core-token-standard'
+import { Decimal } from 'decimal.js'
 
 describe('getInputHoldingsCidsForAmount', async () => {
     const makeHolding = (
@@ -49,7 +50,7 @@ describe('getInputHoldingsCidsForAmount', async () => {
         ]
 
         const result = await CoreService.getInputHoldingsCidsForAmount(
-            20,
+            new Decimal(20),
             holdings
         )
 
@@ -64,7 +65,7 @@ describe('getInputHoldingsCidsForAmount', async () => {
         ]
 
         const result = await CoreService.getInputHoldingsCidsForAmount(
-            220,
+            new Decimal(220),
             holdings
         )
 
@@ -79,7 +80,7 @@ describe('getInputHoldingsCidsForAmount', async () => {
         ]
 
         const result = await CoreService.getInputHoldingsCidsForAmount(
-            100,
+            new Decimal(100),
             holdings
         )
 
@@ -113,7 +114,10 @@ describe('getInputHoldingsCidsForAmount', async () => {
         const holdings: PrettyContract<HoldingView>[] = []
 
         await expect(
-            CoreService.getInputHoldingsCidsForAmount(220, holdings)
+            CoreService.getInputHoldingsCidsForAmount(
+                new Decimal(220),
+                holdings
+            )
         ).rejects.toThrow(`Sender doesn't have any unlocked holdings`)
     })
 
@@ -124,7 +128,7 @@ describe('getInputHoldingsCidsForAmount', async () => {
         ]
 
         await expect(
-            CoreService.getInputHoldingsCidsForAmount(20, holdings)
+            CoreService.getInputHoldingsCidsForAmount(new Decimal(20), holdings)
         ).rejects.toThrow(
             `Sender doesn't have sufficient funds for this transfer. Missing amount: 5`
         )
@@ -136,7 +140,10 @@ describe('getInputHoldingsCidsForAmount', async () => {
         )
 
         await expect(
-            CoreService.getInputHoldingsCidsForAmount(101, holdings)
+            CoreService.getInputHoldingsCidsForAmount(
+                new Decimal(101),
+                holdings
+            )
         ).rejects.toThrow(`Exceeded the maximum of 100 utxos in 1 transaction`)
     })
 })

--- a/core/token-standard-service/src/token-standard-service.ts
+++ b/core/token-standard-service/src/token-standard-service.ts
@@ -100,23 +100,25 @@ export class CoreService {
         )
     }
 
-    // TODO: probably needs a filter by instrument ID as well?
-    async getInputHoldingsCids(
-        sender: PartyId,
-        inputUtxos?: string[],
-        amount?: number,
+    async getInputHoldingsCids(options: {
+        sender: PartyId
+        instrumentAdmin?: string
+        instrumentId?: string
+        inputUtxos?: string[]
+        amount?: number
         continueUntilCompletion?: boolean
-    ) {
+    }) {
+        const { sender, instrumentAdmin, instrumentId } = options
         const now = new Date()
-        if (inputUtxos && inputUtxos.length > 0) {
-            return inputUtxos
+        if (options.inputUtxos && options.inputUtxos.length > 0) {
+            return options.inputUtxos
         }
         const senderHoldings = await this.listContractsByInterface<HoldingView>(
             HOLDING_INTERFACE_ID,
             sender,
             undefined,
             undefined,
-            continueUntilCompletion
+            options.continueUntilCompletion
         )
         if (senderHoldings.length === 0) {
             throw new Error(
@@ -140,14 +142,37 @@ export class CoreService {
             this.logger.warn(`Sender has more than 100 unlocked utxos.`)
         }
 
-        if (amount) {
+        const unlockedHoldingsForInstrument =
+            instrumentAdmin && instrumentId
+                ? await CoreService.filterHoldingsByInstrument({
+                      holdings: unlockedSenderHoldings,
+                      instrumentAdmin,
+                      instrumentId,
+                  })
+                : unlockedSenderHoldings
+
+        if (options.amount) {
             return CoreService.getInputHoldingsCidsForAmount(
-                amount,
-                unlockedSenderHoldings
+                options.amount,
+                unlockedHoldingsForInstrument
             )
         } else {
             return unlockedSenderHoldings.map((h) => h.contractId)
         }
+    }
+
+    static async filterHoldingsByInstrument(options: {
+        holdings: PrettyContract<HoldingView>[]
+        instrumentAdmin: string
+        instrumentId: string
+    }) {
+        const { holdings, instrumentAdmin, instrumentId } = options
+        return holdings.filter((utxo) => {
+            return (
+                utxo.interfaceViewValue.instrumentId.id === instrumentId &&
+                utxo.interfaceViewValue.instrumentId.admin === instrumentAdmin
+            )
+        })
     }
 
     static async getInputHoldingsCidsForAmount(
@@ -448,10 +473,11 @@ class AllocationService {
             },
         }
 
-        const inputHoldingCids = await this.core.getInputHoldingsCids(
-            allocationSpecificationNormalized.transferLeg.sender,
-            inputUtxos
-        )
+        //TODO: fix this instrumentID
+        const inputHoldingCids = await this.core.getInputHoldingsCids({
+            sender: allocationSpecificationNormalized.transferLeg.sender,
+            inputUtxos: inputUtxos ?? [],
+        })
 
         return {
             expectedAdmin,
@@ -798,10 +824,14 @@ class TransferService {
         continueUntilCompletion?: boolean
     ): Promise<CreateTransferChoiceArgs> {
         const inputHoldingCids: string[] = await this.core.getInputHoldingsCids(
-            sender,
-            inputUtxos,
-            parseFloat(amount),
-            continueUntilCompletion
+            {
+                sender,
+                instrumentAdmin,
+                instrumentId,
+                inputUtxos: inputUtxos ?? [],
+                amount: parseFloat(amount),
+                continueUntilCompletion: continueUntilCompletion ?? false,
+            }
         )
 
         return {
@@ -1562,7 +1592,18 @@ export class TokenStandardService {
         inputUtxos?: string[],
         amount?: number
     ) {
-        return this.core.getInputHoldingsCids(sender, inputUtxos, amount)
+        if (amount) {
+            return this.core.getInputHoldingsCids({
+                sender,
+                inputUtxos: inputUtxos ?? [],
+                amount,
+            })
+        } else {
+            return this.core.getInputHoldingsCids({
+                sender,
+                inputUtxos: inputUtxos ?? [],
+            })
+        }
     }
 
     async createDelegateProxyTranfser(

--- a/core/token-standard-service/src/token-standard-service.ts
+++ b/core/token-standard-service/src/token-standard-service.ts
@@ -476,6 +476,11 @@ class AllocationService {
         const inputHoldingCids = await this.core.getInputHoldingsCids({
             sender: allocationSpecificationNormalized.transferLeg.sender,
             inputUtxos: inputUtxos ?? [],
+            instrumentAdmin:
+                allocationSpecificationNormalized.transferLeg.instrumentId
+                    .admin,
+            instrumentId:
+                allocationSpecificationNormalized.transferLeg.instrumentId.id,
         })
 
         return {

--- a/core/token-standard-service/src/token-standard-service.ts
+++ b/core/token-standard-service/src/token-standard-service.ts
@@ -158,7 +158,7 @@ export class CoreService {
                 unlockedHoldingsForInstrument
             )
         } else {
-            return unlockedSenderHoldings.map((h) => h.contractId)
+            return unlockedHoldingsForInstrument.map((h) => h.contractId)
         }
     }
 

--- a/core/token-standard-service/src/token-standard-service.ts
+++ b/core/token-standard-service/src/token-standard-service.ts
@@ -45,6 +45,7 @@ import {
     AbstractLedgerProvider,
     Ops,
 } from '@canton-network/core-provider-ledger'
+import { Decimal } from 'decimal.js'
 
 const REQUESTED_AT_SKEW_MS = 60_000
 
@@ -105,7 +106,7 @@ export class CoreService {
         instrumentAdmin?: string
         instrumentId?: string
         inputUtxos?: string[]
-        amount?: number
+        amount?: Decimal
         continueUntilCompletion?: boolean
     }) {
         const { sender, instrumentAdmin, instrumentId } = options
@@ -176,13 +177,12 @@ export class CoreService {
     }
 
     static async getInputHoldingsCidsForAmount(
-        amount: number,
+        amount: Decimal,
         unlockedSenderHoldings: PrettyContract<HoldingView>[]
     ) {
         //find holding that is the exact amount if possible
-        const exactAmount = unlockedSenderHoldings.find(
-            (holding) =>
-                parseFloat(holding.interfaceViewValue.amount) === amount
+        const exactAmount = unlockedSenderHoldings.find((holding) =>
+            new Decimal(holding.interfaceViewValue.amount).equals(amount)
         )
 
         if (exactAmount) {
@@ -192,8 +192,9 @@ export class CoreService {
         //sort holdings from smallest to largest
         const sortedUnlockedSenderHoldings = unlockedSenderHoldings.toSorted(
             (a, b) =>
-                parseFloat(a.interfaceViewValue.amount) -
-                parseFloat(b.interfaceViewValue.amount)
+                new Decimal(a.interfaceViewValue.amount).comparedTo(
+                    new Decimal(b.interfaceViewValue.amount)
+                )
         )
 
         const largestHoldingAmount = sortedUnlockedSenderHoldings.pop()
@@ -202,25 +203,27 @@ export class CoreService {
             throw new Error(`Sender doesn't have any unlocked holdings`)
         }
 
-        let currentSum = parseFloat(
+        let currentSum = new Decimal(
             largestHoldingAmount.interfaceViewValue.amount
         )
         const cIds = [largestHoldingAmount.contractId]
 
         for (const h of sortedUnlockedSenderHoldings) {
-            if (currentSum >= amount) {
+            if (currentSum.greaterThanOrEqualTo(amount)) {
                 break
             }
 
-            const currentHoldingAmount = parseFloat(h.interfaceViewValue.amount)
+            const currentHoldingAmount = new Decimal(
+                h.interfaceViewValue.amount
+            )
 
-            currentSum += currentHoldingAmount
+            currentSum = currentSum.plus(currentHoldingAmount)
             cIds.push(h.contractId)
         }
 
-        if (currentSum < amount) {
+        if (currentSum.lessThan(amount)) {
             throw new Error(
-                `Sender doesn't have sufficient funds for this transfer. Missing amount: ${amount - currentSum}`
+                `Sender doesn't have sufficient funds for this transfer. Missing amount: ${amount.minus(currentSum)}`
             )
         }
 
@@ -833,7 +836,7 @@ class TransferService {
                 instrumentAdmin,
                 instrumentId,
                 inputUtxos: inputUtxos ?? [],
-                amount: parseFloat(amount),
+                amount: new Decimal(amount),
                 continueUntilCompletion: continueUntilCompletion ?? false,
             }
         )
@@ -1594,7 +1597,7 @@ export class TokenStandardService {
     async getInputHoldingsCids(
         sender: PartyId,
         inputUtxos?: string[],
-        amount?: number
+        amount?: Decimal
     ) {
         if (amount) {
             return this.core.getInputHoldingsCids({

--- a/core/token-standard-service/src/token-standard-service.ts
+++ b/core/token-standard-service/src/token-standard-service.ts
@@ -473,7 +473,6 @@ class AllocationService {
             },
         }
 
-        //TODO: fix this instrumentID
         const inputHoldingCids = await this.core.getInputHoldingsCids({
             sender: allocationSpecificationNormalized.transferLeg.sender,
             inputUtxos: inputUtxos ?? [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,6 +1895,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^4.1.2"
     bignumber.js: "npm:^10.0.2"
     dayjs: "npm:^1.11.19"
+    decimal.js: "npm:^10.6.0"
     openapi-fetch: "npm:^0.17.0"
     openapi-typescript: "npm:^7.13.0"
     pino: "npm:^10.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,6 +1503,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^4.1.2"
     bignumber.js: "npm:^10.0.2"
     dayjs: "npm:^1.11.19"
+    decimal.js: "npm:^10.6.0"
     openapi-fetch: "npm:^0.17.0"
     openapi-typescript: "npm:^7.13.0"
     pino: "npm:^10.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1894,7 +1894,6 @@ __metadata:
     "@types/node": "npm:^25.3.3"
     "@vitest/browser-playwright": "npm:^4.1.2"
     "@vitest/coverage-v8": "npm:^4.1.2"
-    bignumber.js: "npm:^10.0.2"
     dayjs: "npm:^1.11.19"
     decimal.js: "npm:^10.6.0"
     openapi-fetch: "npm:^0.17.0"


### PR DESCRIPTION
Fixes https://github.com/canton-network/wallet/issues/1925


Currently, when creating a transfer, all the unlocked utxos are selected (using the acs) for a senderParty. The original workaround was to listHoldings and filter by the instrument, then supply that list of utxos to createTransfer. We are adding this filtering logic to the getINputCids function if the instrumentId/instrumentAdmin are defined (these are passed in the createTransfer function)

Additionally, this removes parseFloat and replaces with Decimal