### PR TITLE
fix: fix updates request in asyncapi client 

### DIFF
--- a/core/asyncapi-client/src/websocket-client.ts
+++ b/core/asyncapi-client/src/websocket-client.ts
@@ -171,11 +171,10 @@ export class WebSocketClient {
             beginExclusive: options.beginExclusive,
             verbose: options.verbose ?? true,
             filter,
-            updateFormat: {},
             ...(options.endInclusive !== undefined
                 ? { endInclusive: options.endInclusive }
                 : {}),
-        }
+        } as GetUpdatesRequest
 
         return this.generate(wsUpdatesUrl, request)
     }

--- a/core/token-standard-service/src/token-standard-service.test.ts
+++ b/core/token-standard-service/src/token-standard-service.test.ts
@@ -1,47 +1,426 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from 'vitest'
-import { CoreService } from './token-standard-service.js'
+import { describe, it, expect, vi, MockedObject, beforeEach } from 'vitest'
+import { CoreService, TokenStandardService } from './token-standard-service.js'
 import { PrettyContract } from '@canton-network/core-tx-parser'
 import { HoldingView } from '@canton-network/core-token-standard'
 import { Decimal } from 'decimal.js'
+import { Logger } from '@canton-network/core-types'
 
-describe('getInputHoldingsCidsForAmount', async () => {
-    const makeHolding = (
-        id: string,
-        amount: string,
-        admin: string,
-        instrumentId: string
-    ) => ({
-        contractId: id,
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const {
+    mockAcsRead,
+    mockParseTransaction,
+    mockParseTransferObjects,
+    mockRenderTransaction,
+} = vi.hoisted(() => ({
+    mockAcsRead: vi.fn().mockResolvedValue([]),
+    mockParseTransaction: vi.fn().mockResolvedValue({ offset: 10, events: [] }),
+    mockParseTransferObjects: vi.fn().mockResolvedValue([]),
+    mockRenderTransaction: vi.fn((tx: unknown) => tx),
+}))
+
+vi.mock('@canton-network/core-acs-reader', () => ({
+    ACSReader: vi.fn().mockImplementation(() => ({
+        raw: { read: mockAcsRead },
+    })),
+}))
+
+const makeProvider = (overrides: Record<string, unknown> = {}) => ({
+    request: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn(),
+    off: vi.fn(),
+    ...overrides,
+})
+
+const accessTokenProvider = {
+    getAccessToken: vi.fn().mockResolvedValue('test-token'),
+    getAuthContext: vi.fn().mockResolvedValue(''),
+}
+const mockLogger: MockedObject<Logger> = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+} as MockedObject<Logger>
+
+const makeTokenClient = () => ({ get: vi.fn() })
+
+function makeService(isMasterUser = false) {
+    const provider = makeProvider()
+    const service = new TokenStandardService(
+        provider,
+        mockLogger,
+        accessTokenProvider,
+        isMasterUser
+    )
+
+    const tokenClient = makeTokenClient()
+    const getTokenStandardClient = vi
+        .spyOn(service.core, 'getTokenStandardClient')
+        .mockReturnValue(tokenClient as any)
+
+    return { service, getTokenStandardClient, provider, tokenClient }
+}
+
+const registryUrl = 'https://fake/registry'
+
+const makeHolding = (
+    id: string,
+    amount: string,
+    admin: string,
+    instrumentId: string,
+    lock?: { expiresAt?: string | null } | null
+) => ({
+    contractId: id,
+    interfaceViewValue: {
+        owner: 'dummy',
+        instrumentId: {
+            admin: admin,
+            id: instrumentId,
+        },
+        lock: lock ?? null,
+        meta: {
+            values: {},
+        },
+        amount,
+    },
+    activeContract: {
+        createdEvent: {
+            offset: 1,
+            nodeId: 1,
+            contractId: id,
+            templateId:
+                'a31be0483f3175647053f28965a4e6d97e3dbc433ea2338be303fae69bbcff6a:Splice.Amulet:Amulet',
+            contractKey: null,
+            contractKeyHash: '',
+            createdEventBlob: 'blob',
+            createdAt: 'time',
+            packageName: 'name',
+        },
+        synchronizerId: 'blah',
+        reassignmentCounter: 0,
+    },
+})
+
+const testActiveContract = {
+    workflowId: '',
+    contractEntry: {
+        JsActiveContract: {
+            createdEvent: {
+                offset: 340,
+                nodeId: 3,
+                contractId:
+                    '0018e06a02e11fe44ad91b40cdb438ed75a65a97e3a1d1a143da6bbf79596796d1ca1212207920f9a4d81fd9541abce95824864467f17a12c71fa55457bcfc4cf2672c00ed',
+                templateId:
+                    'a31be0483f3175647053f28965a4e6d97e3dbc433ea2338be303fae69bbcff6a:Splice.Amulet:Amulet',
+                contractKey: null,
+                contractKeyHash: '',
+                createArgument: {
+                    dso: 'DSO::1220c69732dd5f3b434c283f61cbc29d3bb492c50c56e306b436c3e1741cbc7be53e',
+                    owner: 'v1-01-alice::12208cc0a2bd8c703a03d76e4d1b551c88dda1154867119729bd15e9fca0d2d61a87',
+                    amount: {
+                        initialAmount: '10000.0000000000',
+                        createdAt: {
+                            number: '6',
+                        },
+                        ratePerRound: {
+                            rate: '0.0038051800',
+                        },
+                    },
+                },
+                createdEventBlob:
+                    'CgMyLjES8QQKRQAY4GoC4R/kStkbQM20OO11plqX46HRoUPaa795WWeW0coSEiB5IPmk2B/ZVBq86VgkhkRn8XoSxx+lVFe8/EzyZywA7RINc3BsaWNlLWFtdWxldBpaCkBhMzFiZTA0ODNmMzE3NTY0NzA1M2YyODk2NWE0ZTZkOTdlM2RiYzQzM2VhMjMzOGJlMzAzZmFlNjliYmNmZjZhEgZTcGxpY2USBkFtdWxldBoGQW11bGV0IukBauYBCk0KSzpJRFNPOjoxMjIwYzY5NzMyZGQ1ZjNiNDM0YzI4M2Y2MWNiYzI5ZDNiYjQ5MmM1MGM1NmUzMDZiNDM2YzNlMTc0MWNiYzdiZTUzZQpVClM6UXYxLTAxLWFsaWNlOjoxMjIwOGNjMGEyYmQ4YzcwM2EwM2Q3NmU0ZDFiNTUxYzg4ZGRhMTE1NDg2NzExOTcyOWJkMTVlOWZjYTBkMmQ2MWE4Nwo+CjxqOgoUChIyEDEwMDAwLjAwMDAwMDAwMDAKCgoIagYKBAoCGAwKFgoUahIKEAoOMgwwLjAwMzgwNTE4MDAqSURTTzo6MTIyMGM2OTczMmRkNWYzYjQzNGMyODNmNjFjYmMyOWQzYmI0OTJjNTBjNTZlMzA2YjQzNmMzZTE3NDFjYmM3YmU1M2UqUXYxLTAxLWFsaWNlOjoxMjIwOGNjMGEyYmQ4YzcwM2EwM2Q3NmU0ZDFiNTUxYzg4ZGRhMTE1NDg2NzExOTcyOWJkMTVlOWZjYTBkMmQ2MWE4Nzkxpy/GWlMGAEIqCiYKJAgBEiCkbJ4cmw6aj5y/K38+JpUf+LiO0hdbK2kAcIA/J+020RAe',
+                interfaceViews: [
+                    {
+                        interfaceId:
+                            '718a0f77e505a8de22f188bd4c87fe74101274e9d4cb1bfac7d09aec7158d35b:Splice.Api.Token.HoldingV1:Holding',
+                        viewStatus: {
+                            code: 0,
+                            message: '',
+                            details: [],
+                        },
+                        viewValue: {
+                            owner: 'v1-01-alice::12208cc0a2bd8c703a03d76e4d1b551c88dda1154867119729bd15e9fca0d2d61a87',
+                            instrumentId: {
+                                admin: 'DSO::1220c69732dd5f3b434c283f61cbc29d3bb492c50c56e306b436c3e1741cbc7be53e',
+                                id: 'Amulet',
+                            },
+                            amount: '10000.0000000000',
+                            lock: null,
+                            meta: {
+                                values: {
+                                    'amulet.splice.lfdecentralizedtrust.org/created-in-round':
+                                        '6',
+                                    'amulet.splice.lfdecentralizedtrust.org/rate-per-round':
+                                        '0.00380518',
+                                },
+                            },
+                        },
+                        implementationPackageId:
+                            'a31be0483f3175647053f28965a4e6d97e3dbc433ea2338be303fae69bbcff6a',
+                    },
+                ],
+                witnessParties: [
+                    'v1-01-alice::12208cc0a2bd8c703a03d76e4d1b551c88dda1154867119729bd15e9fca0d2d61a87',
+                ],
+                signatories: [
+                    'DSO::1220c69732dd5f3b434c283f61cbc29d3bb492c50c56e306b436c3e1741cbc7be53e',
+                    'v1-01-alice::12208cc0a2bd8c703a03d76e4d1b551c88dda1154867119729bd15e9fca0d2d61a87',
+                ],
+                observers: [],
+                createdAt: '2026-06-03T15:06:37.437745Z',
+                packageName: 'splice-amulet',
+                representativePackageId:
+                    'a31be0483f3175647053f28965a4e6d97e3dbc433ea2338be303fae69bbcff6a',
+                acsDelta: true,
+            },
+            synchronizerId:
+                'global-domain::1220c69732dd5f3b434c283f61cbc29d3bb492c50c56e306b436c3e1741cbc7be53e',
+            reassignmentCounter: 0,
+        },
+    },
+    streamContinuationToken: 'CgIIexIEpBtfAQ==',
+}
+
+function createHolding(
+    cId: string,
+    amount: string,
+    admin: string,
+    instrumentId: string,
+    lock?: { expiresAt?: string | null } | null
+) {
+    return {
+        contractId: cId,
+        activeContract: {
+            createdEvent: {
+                offset: 49,
+                nodeId: 3,
+                contractId: cId,
+                templateId:
+                    'a31be0483f3175647053f28965a4e6d97e3dbc433ea2338be303fae69bbcff6a:Splice.Amulet:Amulet',
+                contractKey: null,
+                contractKeyHash: '',
+                createArgument: {
+                    dso: 'DSO::1220c69732dd5f3b434c283f61cbc29d3bb492c50c56e306b436c3e1741cbc7be53e',
+                    owner: 'v1-01-alice::12206eee60f64d90be3f823007d1321dc6acc5f4f2c57d3dd6ac1f66148753bb65c5',
+                    amount: {
+                        initialAmount: amount,
+                        createdAt: {
+                            number: '1',
+                        },
+                        ratePerRound: {
+                            rate: '0.0038051800',
+                        },
+                    },
+                },
+                createdEventBlob:
+                    'CgMyLjES8QQKRQCU66JZw5C46HMQnw1hIk0dsgkuaPz00+MAPHn2zlBbFsoSEiDmApEy9AvI0VmgrNDLv8/GvvGuTC7G4rB+cZK+oPtoKhINc3BsaWNlLWFtdWxldBpaCkBhMzFiZTA0ODNmMzE3NTY0NzA1M2YyODk2NWE0ZTZkOTdlM2RiYzQzM2VhMjMzOGJlMzAzZmFlNjliYmNmZjZhEgZTcGxpY2USBkFtdWxldBoGQW11bGV0IukBauYBCk0KSzpJRFNPOjoxMjIwYzY5NzMyZGQ1ZjNiNDM0YzI4M2Y2MWNiYzI5ZDNiYjQ5MmM1MGM1NmUzMDZiNDM2YzNlMTc0MWNiYzdiZTUzZQpVClM6UXYxLTAxLWFsaWNlOjoxMjIwNmVlZTYwZjY0ZDkwYmUzZjgyMzAwN2QxMzIxZGM2YWNjNWY0ZjJjNTdkM2RkNmFjMWY2NjE0ODc1M2JiNjVjNQo+CjxqOgoUChIyEDEwMDAwLjAwMDAwMDAwMDAKCgoIagYKBAoCGAIKFgoUahIKEAoOMgwwLjAwMzgwNTE4MDAqSURTTzo6MTIyMGM2OTczMmRkNWYzYjQzNGMyODNmNjFjYmMyOWQzYmI0OTJjNTBjNTZlMzA2YjQzNmMzZTE3NDFjYmM3YmU1M2UqUXYxLTAxLWFsaWNlOjoxMjIwNmVlZTYwZjY0ZDkwYmUzZjgyMzAwN2QxMzIxZGM2YWNjNWY0ZjJjNTdkM2RkNmFjMWY2NjE0ODc1M2JiNjVjNTlmmBYOWlMGAEIqCiYKJAgBEiCzuweldZ8sz5U5S4gPJigbNNLmPal4Nl4KR8E7ifrx1RAe',
+                interfaceViews: [
+                    {
+                        interfaceId:
+                            '718a0f77e505a8de22f188bd4c87fe74101274e9d4cb1bfac7d09aec7158d35b:Splice.Api.Token.HoldingV1:Holding',
+                        viewStatus: {
+                            code: 0,
+                            message: '',
+                            details: [],
+                        },
+                        viewValue: {
+                            owner: 'v1-01-alice::12206eee60f64d90be3f823007d1321dc6acc5f4f2c57d3dd6ac1f66148753bb65c5',
+                            instrumentId: {
+                                admin: admin,
+                                id: instrumentId,
+                            },
+                            amount: '10000.0000000000',
+                            lock: lock,
+                            meta: {
+                                values: {
+                                    'amulet.splice.lfdecentralizedtrust.org/created-in-round':
+                                        '1',
+                                    'amulet.splice.lfdecentralizedtrust.org/rate-per-round':
+                                        '0.00380518',
+                                },
+                            },
+                        },
+                        implementationPackageId:
+                            'a31be0483f3175647053f28965a4e6d97e3dbc433ea2338be303fae69bbcff6a',
+                    },
+                ],
+                witnessParties: [
+                    'v1-01-alice::12206eee60f64d90be3f823007d1321dc6acc5f4f2c57d3dd6ac1f66148753bb65c5',
+                ],
+                signatories: [
+                    'DSO::1220c69732dd5f3b434c283f61cbc29d3bb492c50c56e306b436c3e1741cbc7be53e',
+                    'v1-01-alice::12206eee60f64d90be3f823007d1321dc6acc5f4f2c57d3dd6ac1f66148753bb65c5',
+                ],
+                observers: [],
+                createdAt: '2026-06-03T14:15:08.787814Z',
+                packageName: 'splice-amulet',
+                representativePackageId:
+                    'a31be0483f3175647053f28965a4e6d97e3dbc433ea2338be303fae69bbcff6a',
+                acsDelta: true,
+            },
+            synchronizerId:
+                'global-domain::1220c69732dd5f3b434c283f61cbc29d3bb492c50c56e306b436c3e1741cbc7be53e',
+            reassignmentCounter: 0,
+        },
         interfaceViewValue: {
-            owner: 'dummy',
+            owner: 'v1-01-alice::12206eee60f64d90be3f823007d1321dc6acc5f4f2c57d3dd6ac1f66148753bb65c5',
             instrumentId: {
                 admin: admin,
                 id: instrumentId,
             },
-            lock: null,
+            amount: amount,
+            lock: lock,
             meta: {
-                values: {},
+                values: {
+                    'amulet.splice.lfdecentralizedtrust.org/created-in-round':
+                        '1',
+                    'amulet.splice.lfdecentralizedtrust.org/rate-per-round':
+                        '0.00380518',
+                },
             },
-            amount,
         },
-        activeContract: {
-            createdEvent: {
-                offset: 1,
-                nodeId: 1,
-                contractId: id,
-                templateId: 'holding tempalte id',
-                createdEventBlob: 'blob',
-                createdAt: 'time',
-                packageName: 'name',
-            },
-            synchronizerId: 'blah',
-            reassignmentCounter: 0,
-        },
+        fetchedAtOffset: 51,
+    }
+}
+
+const senderParty =
+    'v1-01-alice::12206eee60f64d90be3f823007d1321dc6acc5f4f2c57d3dd6ac1f66148753bb65c5'
+describe('CoreService', () => {
+    it('should getInputHoldingsCids when input utxos are provided', async () => {
+        const { service } = makeService()
+        vi.spyOn(service.core, 'listContractsByInterface').mockResolvedValue([])
+        const result = await service.core.getInputHoldingsCids({
+            sender: 'blah',
+            inputUtxos: ['cid1', 'cid2'],
+        })
+
+        expect(result).toEqual(['cid1', 'cid2'])
     })
 
+    it('should throw an error when sender has no holdings', async () => {
+        const { service } = makeService()
+        vi.spyOn(service.core, 'listContractsByInterface').mockResolvedValue([])
+
+        await expect(
+            service.core.getInputHoldingsCids({
+                sender: 'blah',
+            })
+        ).rejects.toThrow(
+            `Sender has no holdings, so transfer can't be executed.`
+        )
+    })
+
+    it('should fetch only unlocked holdings', async () => {
+        const lockedHolding = createHolding('1', '20', 'admin:123', 'amulet', {
+            expiresAt: null,
+        })
+        const unlockedHolding = createHolding('2', '20', 'admin:123', 'amulet')
+        const { service } = makeService()
+        vi.spyOn(service.core, 'listContractsByInterface').mockResolvedValue([
+            lockedHolding,
+            unlockedHolding,
+        ])
+
+        const result = await service.core.getInputHoldingsCids({
+            sender: senderParty,
+        })
+        expect(result).toHaveLength(1)
+    })
+})
+
+describe('token standard service', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('should get instrument byId', async () => {
+        const { service, getTokenStandardClient, tokenClient } = makeService()
+
+        tokenClient.get.mockResolvedValue({ id: 'cc', name: 'amulet' })
+
+        const instrument = await service.getInstrumentById(registryUrl, 'cc')
+        expect(instrument.id).toBe('cc')
+        expect(instrument.name).toBe('amulet')
+        expect(getTokenStandardClient).toHaveBeenCalledWith(registryUrl)
+    })
+
+    it('should get instrumentAdmin', async () => {
+        const { service, tokenClient } = makeService()
+
+        tokenClient.get.mockResolvedValue({
+            id: 'cc',
+            name: 'amulet',
+            adminId: 'blah:123',
+        })
+
+        const admin = await service.getInstrumentAdmin(registryUrl)
+        expect(admin).toBe('blah:123')
+    })
+
+    it('convert the instruments to an asset type', async () => {
+        const { service, tokenClient } = makeService()
+
+        tokenClient.get
+            .mockResolvedValueOnce({
+                instruments: [
+                    {
+                        id: 'TestTokenExt',
+                        name: 'TestTokenExt',
+                        symbol: 'TestTokenExt',
+                        totalSupply: '201.0',
+                        totalSupplyAsOf: null,
+                        decimals: 10,
+                        supportedApis: {
+                            'splice-api-token-metadata-v1': 1,
+                            'splice-api-token-transfer-instruction-v1': 1,
+                            'splice-api-token-allocation-request-v1': 1,
+                            'splice-api-token-allocation-v1': 1,
+                            'splice-api-token-holding-v1': 1,
+                            'splice-api-token-allocation-instruction-v1': 1,
+                        },
+                    },
+                    {
+                        id: 'TestToken',
+                        name: 'TestToken',
+                        symbol: 'TestToken',
+                        totalSupply: '1300.0',
+                        totalSupplyAsOf: null,
+                        decimals: 10,
+                        supportedApis: {
+                            'splice-api-token-metadata-v1': 1,
+                            'splice-api-token-transfer-instruction-v1': 1,
+                            'splice-api-token-allocation-request-v1': 1,
+                            'splice-api-token-allocation-v1': 1,
+                            'splice-api-token-holding-v1': 1,
+                            'splice-api-token-allocation-instruction-v1': 1,
+                        },
+                    },
+                ],
+                nextPageToken: null,
+            })
+            .mockResolvedValue({
+                adminId:
+                    'auth0_007c6643538f2eadd3e573dd05b9::12205bcc106efa0eaa7f18dc491e5c6f5fb9b0cc68dc110ae66f4ed6467475d7c78e',
+                supportedApis: {
+                    'splice-api-token-metadata-v1': 1,
+                    'splice-api-token-transfer-instruction-v1': 1,
+                    'splice-api-token-allocation-request-v1': 1,
+                    'splice-api-token-allocation-v1': 1,
+                    'splice-api-token-holding-v1': 1,
+                    'splice-api-token-allocation-instruction-v1': 1,
+                },
+            })
+
+        const response = await service.instrumentsToAsset(registryUrl)
+        expect(response).toHaveLength(2)
+    })
+})
+
+describe('getInputHoldingsCidsForAmount', async () => {
     it('returns exact match', async () => {
         const holdings = [
             makeHolding('a', '200', 'partyId', 'amulet'),

--- a/docs/wallet-integration-guide/examples/scripts/12-subscribe-to-events.ts
+++ b/docs/wallet-integration-guide/examples/scripts/12-subscribe-to-events.ts
@@ -171,7 +171,10 @@ logger.info(
 
 logger.debug(commandsCompletionsEvents, 'commands completions events')
 
-if (commandsCompletionsEvents.length === 0) {
+if (
+    commandsCompletionsEvents.length === 0 &&
+    commandsCompletionsEvents.find((event) => event.update)
+) {
     logger.error(
         'No command completion events received, something went wrong with the subscription'
     )
@@ -181,7 +184,7 @@ if (commandsCompletionsEvents.length === 0) {
 
 logger.debug(updateEvents, 'Update events')
 
-if (updateEvents.length === 0) {
+if (updateEvents.length === 0 && updateEvents.find((event) => event.update)) {
     logger.error(
         'No command completion events received, something went wrong with the subscription'
     )


### PR DESCRIPTION
The `streamUpdates` function in the asyncapi client throws the following error against canton versions 3.5.x:

```
{"code":"INVALID_ARGUMENT","cause":"The submitted request has invalid arguments: Both update_format and filter are set. Please use either backwards compatible arguments (filter and verbose) or update_format, but not both.","correlationId":null,"traceId":"789fe90b612f00ece03bc3e64f0d53fc","context":{"participant":"app-user","definite_answer":"false","tid":"789fe90b612f00ece03bc3e64f0d53fc","category":"8"},"resources":[],"errorCategory":8,"grpcCodeValue":3,"retryInfo":null,"definiteAnswer":null}
```

The test was only testing the length of the updates but not the content of the response, so this was collecting errors as an event, this fixes the problem by changing the request format. 