### PR TITLE
fix: asyncapi streamupdates request body is invalid

### DIFF
--- a/core/asyncapi-client/src/websocket-client.ts
+++ b/core/asyncapi-client/src/websocket-client.ts
@@ -30,6 +30,8 @@ export type CompletionStreamRequest =
 export type GetUpdatesRequest = LedgerCommonSchemas['GetUpdatesRequest']
 
 export type JsGetUpdatesResponse = LedgerCommonSchemas['JsGetUpdatesResponse']
+export type CompletionsResponse =
+    LedgerCommonSchemas['CompletionStreamResponse']
 
 type UpdateSubscriptionOptions = {
     beginExclusive: number
@@ -90,11 +92,11 @@ export class WebSocketClient {
         )
     }
 
-    generate(
+    private generate<T extends JsGetUpdatesResponse | CompletionsResponse>(
         wsUrl: string,
         request: GetUpdatesRequest | CompletionStreamRequest
-    ): AsyncIterableIterator<JsGetUpdatesResponse> {
-        const messageQueue: JsGetUpdatesResponse[] = []
+    ): AsyncIterableIterator<T> {
+        const messageQueue: T[] = []
         let resolveNext: (() => void) | null = null
         let isClosed = false
         let streamError: Error | null = null
@@ -110,7 +112,7 @@ export class WebSocketClient {
                 ws.send(JSON.stringify(request))
             }
             ws.onmessage = (event) => {
-                messageQueue.push(JSON.parse(event.data as string))
+                messageQueue.push(JSON.parse(event.data as string) as T)
                 this.logger.debug(event.data, `Received event`)
                 resolveNext?.()
             }
@@ -176,12 +178,12 @@ export class WebSocketClient {
                 : {}),
         } as GetUpdatesRequest
 
-        return this.generate(wsUpdatesUrl, request)
+        return this.generate<JsGetUpdatesResponse>(wsUpdatesUrl, request)
     }
 
     streamCompletions(
         options: CommandsCompletionsOptions
-    ): AsyncIterableIterator<JsGetUpdatesResponse> {
+    ): AsyncIterableIterator<CompletionsResponse> {
         const wsCompletionsUrl = `${this.baseUrl}${this.channels.v2_commands_completions}`
 
         const request = {
@@ -190,6 +192,6 @@ export class WebSocketClient {
             parties: options.parties,
         }
 
-        return this.generate(wsCompletionsUrl, request)
+        return this.generate<CompletionsResponse>(wsCompletionsUrl, request)
     }
 }

--- a/core/asyncapi-client/src/websocket-client.ts
+++ b/core/asyncapi-client/src/websocket-client.ts
@@ -171,11 +171,10 @@ export class WebSocketClient {
             beginExclusive: options.beginExclusive,
             verbose: options.verbose ?? true,
             filter,
-            updateFormat: {},
             ...(options.endInclusive !== undefined
                 ? { endInclusive: options.endInclusive }
                 : {}),
-        }
+        } as GetUpdatesRequest
 
         return this.generate(wsUpdatesUrl, request)
     }

--- a/docs/wallet-integration-guide/examples/scripts/12-subscribe-to-events.ts
+++ b/docs/wallet-integration-guide/examples/scripts/12-subscribe-to-events.ts
@@ -172,8 +172,8 @@ logger.info(
 logger.debug(commandsCompletionsEvents, 'commands completions events')
 
 if (
-    commandsCompletionsEvents.length === 0 &&
-    commandsCompletionsEvents.find((event) => event.update)
+    commandsCompletionsEvents.length === 0 ||
+    commandsCompletionsEvents.find((event) => event.update) === undefined
 ) {
     logger.error(
         'No command completion events received, something went wrong with the subscription'
@@ -184,7 +184,10 @@ if (
 
 logger.debug(updateEvents, 'Update events')
 
-if (updateEvents.length === 0 && updateEvents.find((event) => event.update)) {
+if (
+    updateEvents.length === 0 ||
+    updateEvents.filter((event) => event.update) === undefined
+) {
     logger.error(
         'No command completion events received, something went wrong with the subscription'
     )

--- a/docs/wallet-integration-guide/examples/scripts/12-subscribe-to-events.ts
+++ b/docs/wallet-integration-guide/examples/scripts/12-subscribe-to-events.ts
@@ -171,7 +171,10 @@ logger.info(
 
 logger.debug(commandsCompletionsEvents, 'commands completions events')
 
-if (commandsCompletionsEvents.length === 0) {
+if (
+    commandsCompletionsEvents.length === 0 &&
+    commandsCompletionsEvents.find((event) => event.update)
+) {
     logger.error(
         'No command completion events received, something went wrong with the subscription'
     )
@@ -181,7 +184,7 @@ if (commandsCompletionsEvents.length === 0) {
 
 logger.debug(updateEvents, 'Update events')
 
-if (updateEvents.length === 0) {
+if (updateEvents.length === 0 && updateEvents.find((event) => event.update)) {
     logger.error(
         'No command completion events received, something went wrong with the subscription'
     )

--- a/docs/wallet-integration-guide/examples/scripts/12-subscribe-to-events.ts
+++ b/docs/wallet-integration-guide/examples/scripts/12-subscribe-to-events.ts
@@ -1,5 +1,10 @@
 import pino from 'pino'
-import { Event, localNetStaticConfig, SDK } from '@canton-network/wallet-sdk'
+import {
+    CompletionEvent,
+    UpdateEvent,
+    localNetStaticConfig,
+    SDK,
+} from '@canton-network/wallet-sdk'
 import { TOKEN_PROVIDER_CONFIG_DEFAULT } from './utils/index.js'
 
 const logger = pino({ name: 'v1-12-subscribe-to-events', level: 'info' })
@@ -65,7 +70,7 @@ const charlie = await sdk.party.external
 
 logger.info(charlie, 'Multi hosted party allocated successfully')
 
-const commandsCompletionsEvents: Event[] = []
+const commandsCompletionsEvents: CompletionEvent[] = []
 const commandsCompletionsController = new AbortController()
 logger.info('subscribing to command completions')
 const subscribeToCommandsMultiHostedParty = (async () => {
@@ -125,7 +130,7 @@ logger.info(
     'Multi hosted party with observing participant allocated successfully'
 )
 
-const updateEvents: Event[] = []
+const updateEvents: UpdateEvent[] = []
 const updatesController = new AbortController()
 
 const subscribeToPingUpdates = (async () => {
@@ -173,7 +178,8 @@ logger.debug(commandsCompletionsEvents, 'commands completions events')
 
 if (
     commandsCompletionsEvents.length === 0 ||
-    commandsCompletionsEvents.find((event) => event.update) === undefined
+    commandsCompletionsEvents.filter((event) => event.completionResponse) ===
+        undefined
 ) {
     logger.error(
         'No command completion events received, something went wrong with the subscription'

--- a/sdk/wallet-sdk/src/wallet/namespace/events/namespace.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/events/namespace.ts
@@ -7,9 +7,10 @@ import { SDKLogger } from '../../logger/logger.js'
 import {
     UpdatesOptions,
     CompletionOptions,
-    Event,
     InvalidSubscriptionOptionsError,
     EventsContext,
+    UpdateEvent,
+    CompletionEvent,
 } from './types.js'
 
 export class EventsNamespace {
@@ -28,7 +29,7 @@ export class EventsNamespace {
 
     async *completions(
         options: CompletionOptions
-    ): AsyncIterableIterator<Event> {
+    ): AsyncIterableIterator<CompletionEvent> {
         this.logger.info('Subscribing to command completions...')
 
         const request = {
@@ -46,7 +47,9 @@ export class EventsNamespace {
      * @throws InvalidSubscriptionOptionsError if the options is invalid
      * @throws WebSocketConnectionError if connection fails
      */
-    async *updates(options: UpdatesOptions): AsyncIterableIterator<Event> {
+    async *updates(
+        options: UpdatesOptions
+    ): AsyncIterableIterator<UpdateEvent> {
         try {
             this.validateUpdatesOptions(options)
             const normalizedOptions = this.normalizeUpdatesOptions(options)

--- a/sdk/wallet-sdk/src/wallet/namespace/events/types.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/events/types.ts
@@ -34,4 +34,7 @@ export type EventsContext = {
     websocketURL: ParsedURL
 }
 
-export type Event = LedgerCommonSchemas['JsGetUpdatesResponse']
+export type UpdateEvent = LedgerCommonSchemas['JsGetUpdatesResponse']
+export type CompletionEvent = LedgerCommonSchemas['CompletionStreamResponse']
+
+export type Event = UpdateEvent | CompletionEvent

--- a/sdk/wallet-sdk/src/wallet/sdk.ts
+++ b/sdk/wallet-sdk/src/wallet/sdk.ts
@@ -32,7 +32,11 @@ export type * from './namespace/token/index.js'
 export type * from './namespace/amulet/index.js'
 export { type TokenProviderConfig } from '@canton-network/core-wallet-auth'
 export { LedgerProvider } from '@canton-network/core-provider-ledger'
-export { type Event } from './namespace/events/index.js'
+export {
+    type Event,
+    type CompletionEvent,
+    type UpdateEvent,
+} from './namespace/events/index.js'
 export type * from './namespace/transactions/types.js'
 export {
     signTransactionHash,


### PR DESCRIPTION
Fixes https://github.com/canton-network/wallet/issues/1939

The `streamUpdates` function in the asyncapi client throws the following error against canton versions 3.5.x:

```
{"code":"INVALID_ARGUMENT","cause":"The submitted request has invalid arguments: Both update_format and filter are set. Please use either backwards compatible arguments (filter and verbose) or update_format, but not both.","correlationId":null,"traceId":"789fe90b612f00ece03bc3e64f0d53fc","context":{"participant":"app-user","definite_answer":"false","tid":"789fe90b612f00ece03bc3e64f0d53fc","category":"8"},"resources":[],"errorCategory":8,"grpcCodeValue":3,"retryInfo":null,"definiteAnswer":null}
```

The test was only testing the length of the updates but not the content of the response, so this was collecting errors as an event, this fixes the problem by changing the request format. 