### PR TITLE
chore(wallet-auth): add npm metadata links

### DIFF
--- a/core/wallet-auth/package.json
+++ b/core/wallet-auth/package.json
@@ -1,53 +1,57 @@
 {
-    "name": "@canton-network/core-wallet-auth",
-    "version": "1.4.0",
-    "type": "module",
-    "description": "Provides authentication middleware and user management for the Wallet Gateway",
-    "license": "Apache-2.0",
-    "author": "Marc Juchli <marc.juchli@digitalasset.com>",
-    "packageManager": "yarn@4.9.4",
-    "main": "./dist/index.cjs",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs",
-            "default": "./dist/index.js"
-        }
-    },
-    "scripts": {
-        "build": "tsup --onSuccess \"tsc\"",
-        "dev": "tsup --watch --onSuccess \"tsc\"",
-        "flatpack": "yarn pack --out \"$FLATPACK_OUTDIR\"",
-        "clean": "tsc -b --clean; rm -rf dist",
-        "test": "vitest run --project node --project browser",
-        "test:coverage": "vitest run --project node --project browser --coverage"
-    },
-    "devDependencies": {
-        "@vitest/browser-playwright": "^4.1.2",
-        "@vitest/coverage-v8": "^4.1.2",
-        "playwright": "^1.58.2",
-        "tsup": "^8.5.1",
-        "typescript": "^5.9.3",
-        "vitest": "^4.1.2"
-    },
-    "dependencies": {
-        "@canton-network/core-rpc-errors": "workspace:^",
-        "@canton-network/core-types": "workspace:^",
-        "jose": "^6.1.3",
-        "zod": "^4.3.6"
-    },
-    "files": [
-        "dist/**"
-    ],
-    "publishConfig": {
-        "access": "public"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/canton-network/wallet.git",
-        "directory": "core/wallet-auth"
+  "name": "@canton-network/core-wallet-auth",
+  "version": "1.4.0",
+  "type": "module",
+  "description": "Provides authentication middleware and user management for the Wallet Gateway",
+  "license": "Apache-2.0",
+  "author": "Marc Juchli <marc.juchli@digitalasset.com>",
+  "packageManager": "yarn@4.9.4",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
     }
+  },
+  "scripts": {
+    "build": "tsup --onSuccess \"tsc\"",
+    "dev": "tsup --watch --onSuccess \"tsc\"",
+    "flatpack": "yarn pack --out \"$FLATPACK_OUTDIR\"",
+    "clean": "tsc -b --clean; rm -rf dist",
+    "test": "vitest run --project node --project browser",
+    "test:coverage": "vitest run --project node --project browser --coverage"
+  },
+  "devDependencies": {
+    "@vitest/browser-playwright": "^4.1.2",
+    "@vitest/coverage-v8": "^4.1.2",
+    "playwright": "^1.58.2",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.2"
+  },
+  "dependencies": {
+    "@canton-network/core-rpc-errors": "workspace:^",
+    "@canton-network/core-types": "workspace:^",
+    "jose": "^6.1.3",
+    "zod": "^4.3.6"
+  },
+  "files": [
+    "dist/**"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/canton-network/wallet.git",
+    "directory": "core/wallet-auth"
+  },
+  "homepage": "https://github.com/canton-network/wallet/tree/main/core/wallet-auth#readme",
+  "bugs": {
+    "url": "https://github.com/canton-network/wallet/issues"
+  }
 }


### PR DESCRIPTION
## Summary
- add package `homepage` metadata for `@canton-network/core-wallet-auth`
- add npm-standard `bugs.url` metadata for the repository issue tracker

## Verification
- `npm view '@canton-network/core-wallet-auth@1.4.0' name version homepage repository bugs main files --json`
- parsed the edited package manifest with Node
- `npm pack --dry-run --json --ignore-scripts` against a scratch copy of the package manifest

This is metadata-only and does not change runtime code.