### PR TITLE
chore: add wallet SDK npm metadata

### DIFF
--- a/sdk/wallet-sdk/package.json
+++ b/sdk/wallet-sdk/package.json
@@ -69,5 +69,9 @@
         "type": "git",
         "url": "git+https://github.com/canton-network/wallet.git",
         "directory": "sdk/wallet-sdk"
+    },
+    "homepage": "https://github.com/canton-network/wallet/tree/main/sdk/wallet-sdk#readme",
+    "bugs": {
+        "url": "https://github.com/canton-network/wallet/issues"
     }
 }


### PR DESCRIPTION
## Summary

Adds missing npm metadata to `@canton-network/wallet-sdk`:

- `homepage`
- `bugs.url`

The package already points at this repository, and GitHub issues are enabled for `canton-network/wallet`.

## Verification

- Confirmed current npm metadata for `@canton-network/wallet-sdk@1.3.1` has no homepage or bugs field.
- Verified the updated package manifest points `homepage` to the package README and `bugs.url` to the repository issues page.
- Ran `git diff --check`.
- Ran `npm pack --dry-run --ignore-scripts --json` inside `sdk/wallet-sdk`.
