### PR TITLE
feat(example-portfolio): support configured token registries

### DIFF
--- a/core/types/src/index.ts
+++ b/core/types/src/index.ts
@@ -8,11 +8,24 @@ import { z } from 'zod'
  */
 export type Logger = Pick<Console, 'debug' | 'info' | 'warn' | 'error'>
 
+export const PARTY_ID_EXAMPLE = 'party-hint::fingerprint'
+export const PARTY_ID_ERROR_MESSAGE = `Must be in the form ${PARTY_ID_EXAMPLE}`
+export const PARTY_ID_PATTERN = /^[a-zA-Z0-9:_-]*::[a-z0-9]*/
+
 export const PartyId = z
     .string()
-    .regex(/^[a-zA-Z0-9:_-]*::[a-z0-9]*/, 'Invalid party ID format')
+    .regex(PARTY_ID_PATTERN, PARTY_ID_ERROR_MESSAGE)
 
 export type PartyId = z.infer<typeof PartyId>
+
+export const HttpUrl = z
+    .url({
+        message: 'Must be a valid HTTP or HTTPS URL',
+        protocol: /^https?$/,
+    })
+    .transform((value) => new URL(value).toString())
+
+export type HttpUrl = z.infer<typeof HttpUrl>
 
 /**
  *  Requests / responses

--- a/docs/dapp-building/examples/portfolio/index.md
+++ b/docs/dapp-building/examples/portfolio/index.md
@@ -2,7 +2,7 @@
 
 The Splice Portfolio is a dApp for managing token standard assets and allocations. The app is a static single-page application that can be hosted anywhere. It allows you to connect to your own Wallet Gateway, or any CIP-103 compatible wallet, to sign transactions.
 
-**NOTE:** You currently need to supply a `validatorUrl` for Canton Coin (Amulet) operations.
+**NOTE:** You currently need to supply `amulet.validatorUrl` for Canton Coin (Amulet) operations.
 
 There are two supported ways of running an instance the app UI:
 
@@ -18,20 +18,40 @@ It is also possible to host the UI directly on any webserver by downloading the 
 
 ## Configuration
 
-The app uses a simple configuration file, `config.json`. The only required option currently is `validatorUrl` which must point to a Validator API accessible to your browser using the same authentication setup as the Wallet Gateway user.
+The app uses a simple configuration file, `config.json`. `amulet.validatorUrl` must point to a Validator API accessible to your browser using the same authentication setup as the Wallet Gateway user.
 
 ```json
 {
-    "validatorUrl": "http://localhost:2000/api/validator",
-    "registries": [] // not currently used but still needed in the config.json file
+    "amulet": {
+        "validatorUrl": "http://localhost:2000/api/validator",
+        "registry": "http://scan.localhost:4000/registry/"
+    },
+    "token": {
+        "validatorUrl": "http://localhost:2000/api/validator",
+        "registries": [
+            {
+                "name": "DA Registry",
+                "partyId": "operator::1234567890",
+                "url": "https://apps.da.com/registrar/operator::1234567890/"
+            }
+        ]
+    }
 }
 ```
+
+- `amulet.registry` points to the Amulet/Scan registry endpoint.
+- `token.validatorUrl` points to the Validator API used for token-standard operations.
+- `token.registries` points to Token Standard registry APIs.
+    - Registry names are optional.
+    - Registry `partyId` values are optional.
+    - When a registry omits `partyId`, the app discovers the registry admin party from the registry metadata endpoint.
+- Configured registries from `amulet.registry` and `token.registries` are combined with registries saved in browser storage, with saved entries overriding matching configured parties.
 
 ## Deployment
 
 ### Docker
 
-To start the UI with Docker, create a `config.json` in your chosen directory and set your validatorUrl. Then, run the container:
+To start the UI with Docker, create a `config.json` in your chosen directory and set the Amulet and token configuration. Then, run the container:
 
 ```sh
 docker run --rm \
@@ -52,11 +72,15 @@ image:
     tag: ''
 
 config:
-    validatorUrl: 'http://localhost:2000/api/validator' # @schema required
-    registries:
-        - url: 'https://registry.example.com' # @schema required
-          name: '' # (optional)
-          partyId: '' # (optional)
+    amulet:
+        validatorUrl: 'http://localhost:2000/api/validator' # @schema required
+        registry: 'http://scan.localhost:4000/registry/' # @schema required
+    token:
+        validatorUrl: 'http://localhost:2000/api/validator' # @schema required
+        registries:
+            - url: 'https://registry.example.com' # @schema required
+              name: '' # (optional)
+              partyId: 'party-hint::fingerprint' # (optional)
 ```
 
 Then

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -47,10 +47,24 @@ The app loads `config.json` at startup and validates it before rendering. The lo
 
 ```json
 {
-    "validatorUrl": "http://localhost:2000/api/validator",
-    "registries": [] // not currently used
+    "amulet": {
+        "validatorUrl": "http://localhost:2000/api/validator",
+        "registry": "http://scan.localhost:4000/registry/"
+    },
+    "token": {
+        "validatorUrl": "http://localhost:2000/api/validator",
+        "registries": [
+            {
+                "name": "DA Registry",
+                "partyId": "operator::1234567890",
+                "url": "https://apps.da.com/registrar/operator::1234567890/"
+            }
+        ]
+    }
 }
 ```
+
+The `amulet` section configures Canton Coin (Amulet) operations. The `token` section configures token-standard operations and default registries. Registry `partyId` values are optional; when omitted, the app discovers the registry admin party from the registry metadata endpoint.
 
 For static or Docker deployments, replace or mount `/config.json`.
 

--- a/examples/portfolio/public/config.json
+++ b/examples/portfolio/public/config.json
@@ -1,4 +1,16 @@
 {
+  "amulet": {
     "validatorUrl": "http://localhost:2000/api/validator",
-    "registries": []
+    "registry": "http://scan.localhost:4000"
+  },
+  "token": {
+    "validatorUrl": "http://localhost:2000/api/validator",
+    "registries": [
+      {
+        "name": "Local Scan",
+        "partyId": "",
+        "url": "http://scan.localhost:4000"
+      }
+    ]
+  }
 }

--- a/examples/portfolio/public/config.json
+++ b/examples/portfolio/public/config.json
@@ -1,16 +1,16 @@
 {
-  "amulet": {
-    "validatorUrl": "http://localhost:2000/api/validator",
-    "registry": "http://scan.localhost:4000"
-  },
-  "token": {
-    "validatorUrl": "http://localhost:2000/api/validator",
-    "registries": [
-      {
-        "name": "Local Scan",
-        "partyId": "",
-        "url": "http://scan.localhost:4000"
-      }
-    ]
-  }
+    "amulet": {
+        "validatorUrl": "http://localhost:2000/api/validator",
+        "registry": "http://scan.localhost:4000"
+    },
+    "token": {
+        "validatorUrl": "http://localhost:2000/api/validator",
+        "registries": [
+            {
+                "name": "Local Scan",
+                "partyId": "",
+                "url": "http://scan.localhost:4000"
+            }
+        ]
+    }
 }

--- a/examples/portfolio/src/components/registry-settings.tsx
+++ b/examples/portfolio/src/components/registry-settings.tsx
@@ -19,12 +19,9 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import { CopyableIdentifier } from './copyable-identifier'
 import { useRegistryUrls, useRegistryMutations } from '@hooks/useRegistryUrls'
 import { useForm } from '@tanstack/react-form'
+import { HttpUrl } from '@canton-network/core-types'
 import { toast } from 'sonner'
-import {
-    httpUrlSchema,
-    registryFormSchema,
-    type RegistryFormData,
-} from '@lib/schemas'
+import { registryFormSchema, type RegistryFormData } from '@lib/schemas'
 
 interface Registry {
     partyId: string
@@ -33,7 +30,7 @@ interface Registry {
 
 const INSECURE_REGISTRY_URL_WARNING =
     'Registry responses can be spoofed by network attackers. Use HTTPS.'
-const registryUrlSchema = httpUrlSchema
+const registryUrlSchema = HttpUrl
 
 const isInsecureRegistryUrl = (value: string) => {
     const result = registryUrlSchema.safeParse(value)

--- a/examples/portfolio/src/components/registry-settings.tsx
+++ b/examples/portfolio/src/components/registry-settings.tsx
@@ -19,8 +19,12 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import { CopyableIdentifier } from './copyable-identifier'
 import { useRegistryUrls, useRegistryMutations } from '@hooks/useRegistryUrls'
 import { useForm } from '@tanstack/react-form'
-import { z } from 'zod'
 import { toast } from 'sonner'
+import {
+    httpUrlSchema,
+    registryFormSchema,
+    type RegistryFormData,
+} from '@lib/schemas'
 
 interface Registry {
     partyId: string
@@ -29,22 +33,12 @@ interface Registry {
 
 const INSECURE_REGISTRY_URL_WARNING =
     'Registry responses can be spoofed by network attackers. Use HTTPS.'
-const registryUrlSchema = z.url({
-    message: 'Must be a valid HTTP or HTTPS URL',
-    protocol: /^https?$/,
-})
+const registryUrlSchema = httpUrlSchema
 
 const isInsecureRegistryUrl = (value: string) => {
     const result = registryUrlSchema.safeParse(value)
     return result.success && new URL(result.data).protocol === 'http:'
 }
-
-const registryFormSchema = z.object({
-    partyId: z.string().min(1, 'Party ID is required'),
-    registryUrl: registryUrlSchema,
-})
-
-type RegistryFormData = z.infer<typeof registryFormSchema>
 
 export function RegistrySettings() {
     const { setRegistryUrl, deleteRegistryUrl } = useRegistryMutations()
@@ -128,6 +122,7 @@ export function RegistrySettings() {
                                 {(field) => (
                                     <TextField
                                         label="Party ID"
+                                        placeholder="party-hint::fingerprint"
                                         value={field.state.value}
                                         onChange={(e) =>
                                             field.handleChange(e.target.value)

--- a/examples/portfolio/src/components/tap-settings.tsx
+++ b/examples/portfolio/src/components/tap-settings.tsx
@@ -37,7 +37,9 @@ export const TapSettings: React.FC = () => {
     const sessionToken = useConnection().status?.session?.accessToken
     const primaryParty = usePrimaryAccount()?.partyId
     const { tap } = usePortfolio()
-    const { validatorUrl } = usePortfolioConfig()
+    const {
+        amulet: { validatorUrl },
+    } = usePortfolioConfig()
     const registryUrls = useRegistryUrls()
     const instruments = useInstruments()
 

--- a/examples/portfolio/src/config/portfolio-config.ts
+++ b/examples/portfolio/src/config/portfolio-config.ts
@@ -1,38 +1,15 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { z } from 'zod'
+import { type ZodError } from 'zod'
+import {
+    portfolioConfigSchema,
+    type PortfolioConfig,
+} from '@lib/schemas'
 
 const DEFAULT_CONFIG_URL = '/config.json'
 
-const httpUrlSchema = z
-    .url({
-        message: 'Must be a valid HTTP or HTTPS URL',
-        protocol: /^https?$/,
-    })
-    .transform((value) => new URL(value).toString())
-
-const optionalStringSchema = () => z.string().trim().optional()
-
-export const registryConfigSchema = z
-    .object({
-        name: optionalStringSchema(),
-        partyId: optionalStringSchema(),
-        url: httpUrlSchema,
-    })
-    .strict()
-
-export const portfolioConfigSchema = z
-    .object({
-        validatorUrl: httpUrlSchema,
-        registries: z.array(registryConfigSchema),
-    })
-    .strict()
-
-export type PortfolioRegistryConfig = z.infer<typeof registryConfigSchema>
-export type PortfolioConfig = z.infer<typeof portfolioConfigSchema>
-
-const formatConfigError = (error: z.ZodError): string =>
+const formatConfigError = (error: ZodError): string =>
     error.issues
         .map((issue) => {
             const path = issue.path.length > 0 ? issue.path.join('.') : '<root>'

--- a/examples/portfolio/src/config/portfolio-config.ts
+++ b/examples/portfolio/src/config/portfolio-config.ts
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { type ZodError } from 'zod'
-import {
-    portfolioConfigSchema,
-    type PortfolioConfig,
-} from '@lib/schemas'
+import { portfolioConfigSchema, type PortfolioConfig } from '@lib/schemas'
 
 const DEFAULT_CONFIG_URL = '/config.json'
 

--- a/examples/portfolio/src/contexts/PortfolioConfigContext.tsx
+++ b/examples/portfolio/src/contexts/PortfolioConfigContext.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createContext, useContext } from 'react'
-import { type PortfolioConfig } from '@config/portfolio-config'
+import { type PortfolioConfig } from '@lib/schemas'
 
 export const PortfolioConfigContext = createContext<
     PortfolioConfig | undefined

--- a/examples/portfolio/src/contexts/PortfolioConfigProvider.tsx
+++ b/examples/portfolio/src/contexts/PortfolioConfigProvider.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { type ReactNode } from 'react'
-import { type PortfolioConfig } from '@config/portfolio-config'
+import { type PortfolioConfig } from '@lib/schemas'
 import { PortfolioConfigContext } from '@contexts/PortfolioConfigContext'
 
 export const PortfolioConfigProvider = ({

--- a/examples/portfolio/src/hooks/query-options.ts
+++ b/examples/portfolio/src/hooks/query-options.ts
@@ -38,7 +38,9 @@ export const useAllocationsQueryOptions = (party: string | undefined) => {
 
 export const useIsDevNetQueryOptions = (sessionToken: string | undefined) => {
     const { isDevNet } = usePortfolio()
-    const { validatorUrl } = usePortfolioConfig()
+    const {
+        token: { validatorUrl },
+    } = usePortfolioConfig()
     return queryOptions({
         queryKey: queryKeys.isDevNet.all,
         queryFn: async () =>

--- a/examples/portfolio/src/hooks/useRegistryUrls.ts
+++ b/examples/portfolio/src/hooks/useRegistryUrls.ts
@@ -1,9 +1,11 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { type PartyId } from '@canton-network/core-types'
+import { type PortfolioRegistryConfig } from '@lib/schemas'
+import { usePortfolioConfig } from '@contexts/PortfolioConfigContext'
 import { resolveTokenStandardClient } from '@services/resolve'
 import { queryKeys } from '@hooks/query-keys'
 
@@ -23,16 +25,98 @@ const writeToStorage = (next: ReadonlyMap<PartyId, string>): void => {
     )
 }
 
+// Build the best synchronous view we can from config alone. Registries without
+// a partyId are skipped here because resolving their party requires a network call.
+const configuredRegistriesWithPartyIdsToMap = (
+    registries: PortfolioRegistryConfig[]
+): ReadonlyMap<PartyId, string> => {
+    return new Map(
+        registries.flatMap((registry) =>
+            registry.partyId ? [[registry.partyId, registry.url]] : []
+        )
+    )
+}
+
+const configuredRegistriesToMap = async (
+    registries: PortfolioRegistryConfig[]
+): Promise<ReadonlyMap<PartyId, string>> => {
+    const settled = await Promise.allSettled(
+        registries.map(async (registry): Promise<[PartyId, string]> => {
+            if (registry.partyId) {
+                return [registry.partyId, registry.url]
+            }
+
+            // Some config entries only know the registry URL. Ask the registry for
+            // its metadata so we can key the map by its admin partyId.
+            const client = await resolveTokenStandardClient({
+                registryUrl: registry.url,
+            })
+            const info = await client.get('/registry/metadata/v1/info')
+
+            return [info.adminId, registry.url]
+        })
+    )
+    const entries = settled.flatMap((result, index) => {
+        if (result.status === 'fulfilled') {
+            return [result.value]
+        }
+
+        // Keep the usable registries even if one configured registry is down or
+        // misconfigured; the UI can still operate with the remaining entries.
+        console.warn(
+            `Failed to resolve registry ${registries[index].url}:`,
+            result.reason
+        )
+        return []
+    })
+    return new Map(entries)
+}
+
+const mergeRegistryUrls = (
+    configured: ReadonlyMap<PartyId, string>,
+    stored: ReadonlyMap<PartyId, string>
+): ReadonlyMap<PartyId, string> => {
+    // User-provided overrides win over config values.
+    return new Map([...configured, ...stored])
+}
+
 const EMPTY: ReadonlyMap<PartyId, string> = new Map()
 
 export const useRegistryUrls = (): ReadonlyMap<PartyId, string> => {
+    const { amulet, token } = usePortfolioConfig()
+    const configuredRegistryConfigs = useMemo(
+        () => [{ url: amulet.registry }, ...token.registries],
+        [amulet.registry, token.registries]
+    )
+
+    const readMergedRegistries = useCallback(async () => {
+        const configuredRegistries = await configuredRegistriesToMap(
+            configuredRegistryConfigs
+        )
+        return mergeRegistryUrls(configuredRegistries, readFromStorage())
+    }, [configuredRegistryConfigs])
+
+    const readInitialRegistries = useCallback(
+        () =>
+            mergeRegistryUrls(
+                configuredRegistriesWithPartyIdsToMap(
+                    configuredRegistryConfigs
+                ),
+                readFromStorage()
+            ),
+        [configuredRegistryConfigs]
+    )
+
     const { data } = useQuery({
         queryKey: queryKeys.registries.all,
-        queryFn: readFromStorage,
-        initialData: readFromStorage,
+        queryFn: readMergedRegistries,
+        // Show immediately known registries while the async query resolves party
+        // party ids for config entries that only specify a URL.
+        placeholderData: readInitialRegistries,
         staleTime: Infinity,
         gcTime: Infinity,
     })
+
     return data ?? EMPTY
 }
 

--- a/examples/portfolio/src/lib/schemas.ts
+++ b/examples/portfolio/src/lib/schemas.ts
@@ -1,30 +1,20 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+    HttpUrl,
+    PartyId,
+    PARTY_ID_ERROR_MESSAGE,
+} from '@canton-network/core-types'
 import { z } from 'zod'
 
-export const httpUrlSchema = z
-    .url({
-        message: 'Must be a valid HTTP or HTTPS URL',
-        protocol: /^https?$/,
-    })
-    .transform((value) => new URL(value).toString())
-
 const optionalStringSchema = () => z.string().trim().optional()
-
-export const PARTY_ID_EXAMPLE = 'party-hint::fingerprint'
-export const PARTY_ID_ERROR_MESSAGE = `Must be in the form ${PARTY_ID_EXAMPLE}`
-export const PARTY_ID_PATTERN = /^[^:]+::[^:]+$/
-export const partyIdSchema = z
-    .string()
-    .trim()
-    .regex(PARTY_ID_PATTERN, PARTY_ID_ERROR_MESSAGE)
 
 export const optionalPartyIdSchema = z
     .string()
     .trim()
     .refine(
-        (value) => value === '' || PARTY_ID_PATTERN.test(value),
+        (value) => value === '' || PartyId.safeParse(value).success,
         PARTY_ID_ERROR_MESSAGE
     )
     .transform((value) => (value === '' ? undefined : value))
@@ -34,7 +24,7 @@ export const optionalPartyIdInputSchema = z
     .string()
     .trim()
     .refine(
-        (value) => value === '' || partyIdSchema.safeParse(value).success,
+        (value) => value === '' || PartyId.safeParse(value).success,
         PARTY_ID_ERROR_MESSAGE
     )
 
@@ -42,7 +32,7 @@ export const registryConfigSchema = z
     .object({
         name: optionalStringSchema(),
         partyId: optionalPartyIdSchema,
-        url: httpUrlSchema,
+        url: HttpUrl,
     })
     .strict()
 
@@ -50,13 +40,13 @@ export const portfolioConfigSchema = z
     .object({
         amulet: z
             .object({
-                validatorUrl: httpUrlSchema,
-                registry: httpUrlSchema,
+                validatorUrl: HttpUrl,
+                registry: HttpUrl,
             })
             .strict(),
         token: z
             .object({
-                validatorUrl: httpUrlSchema,
+                validatorUrl: HttpUrl,
                 registries: z.array(registryConfigSchema),
             })
             .strict(),
@@ -65,7 +55,7 @@ export const portfolioConfigSchema = z
 
 export const registryFormSchema = z.object({
     partyId: optionalPartyIdInputSchema,
-    registryUrl: httpUrlSchema,
+    registryUrl: HttpUrl,
 })
 
 export type PortfolioRegistryConfig = z.infer<typeof registryConfigSchema>

--- a/examples/portfolio/src/lib/schemas.ts
+++ b/examples/portfolio/src/lib/schemas.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { z } from 'zod'
+
+export const httpUrlSchema = z
+    .url({
+        message: 'Must be a valid HTTP or HTTPS URL',
+        protocol: /^https?$/,
+    })
+    .transform((value) => new URL(value).toString())
+
+const optionalStringSchema = () => z.string().trim().optional()
+
+export const PARTY_ID_EXAMPLE = 'party-hint::fingerprint'
+export const PARTY_ID_ERROR_MESSAGE = `Must be in the form ${PARTY_ID_EXAMPLE}`
+export const PARTY_ID_PATTERN = /^[^:]+::[^:]+$/
+export const partyIdSchema = z
+    .string()
+    .trim()
+    .regex(PARTY_ID_PATTERN, PARTY_ID_ERROR_MESSAGE)
+
+export const optionalPartyIdSchema = z
+    .string()
+    .trim()
+    .refine(
+        (value) => value === '' || PARTY_ID_PATTERN.test(value),
+        PARTY_ID_ERROR_MESSAGE
+    )
+    .transform((value) => (value === '' ? undefined : value))
+    .optional()
+
+export const optionalPartyIdInputSchema = z
+    .string()
+    .trim()
+    .refine(
+        (value) => value === '' || partyIdSchema.safeParse(value).success,
+        PARTY_ID_ERROR_MESSAGE
+    )
+
+export const registryConfigSchema = z
+    .object({
+        name: optionalStringSchema(),
+        partyId: optionalPartyIdSchema,
+        url: httpUrlSchema,
+    })
+    .strict()
+
+export const portfolioConfigSchema = z
+    .object({
+        amulet: z
+            .object({
+                validatorUrl: httpUrlSchema,
+                registry: httpUrlSchema,
+            })
+            .strict(),
+        token: z
+            .object({
+                validatorUrl: httpUrlSchema,
+                registries: z.array(registryConfigSchema),
+            })
+            .strict(),
+    })
+    .strict()
+
+export const registryFormSchema = z.object({
+    partyId: optionalPartyIdInputSchema,
+    registryUrl: httpUrlSchema,
+})
+
+export type PortfolioRegistryConfig = z.infer<typeof registryConfigSchema>
+export type PortfolioConfig = z.infer<typeof portfolioConfigSchema>
+export type RegistryFormData = z.infer<typeof registryFormSchema>


### PR DESCRIPTION
- separate CC/Amulet and token configuration 
- resolve default registries from config and allow user overrides(in settings page)

Related: https://github.com/digital-asset/wallet-gateway/pull/104