### PR TITLE
test: wallet sdk keys namespace test

### DIFF
--- a/sdk/wallet-sdk/src/wallet/namespace/keys/client.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/keys/client.ts
@@ -6,6 +6,7 @@ import {
     KeyPair,
     PublicKey,
 } from '@canton-network/core-signing-lib'
+import { base64ToBytes, bytesToHex } from '../utils/encoding'
 
 export class KeysNamespace {
     constructor() {}
@@ -18,16 +19,28 @@ export class KeysNamespace {
         return createKeyPair()
     }
 
+    /**
+     *
+     * @param publicKey base64 encoded public key
+     * @returns hex encoded fingerprint
+     */
     public async fingerprint(publicKey: PublicKey) {
         const hashPurpose = 12 // For `PublicKeyFingerprint`
-        const keyBytes = Buffer.from(publicKey, 'base64')
-        const hashInput = Buffer.alloc(4 + keyBytes.length)
-        hashInput.writeUInt32BE(hashPurpose, 0)
-        Buffer.from(keyBytes).copy(hashInput, 4)
+        const keyBytes = base64ToBytes(publicKey)
+        const hashInput = new Uint8Array(4 + keyBytes.length)
+        hashInput[0] = (hashPurpose >>> 24) & 0xff
+        hashInput[1] = (hashPurpose >>> 16) & 0xff
+        hashInput[2] = (hashPurpose >>> 8) & 0xff
+        hashInput[3] = hashPurpose & 0xff
+        hashInput.set(keyBytes, 4)
+
         const hash = new Uint8Array(
             await crypto.subtle.digest('SHA-256', hashInput)
         )
-        const multiprefix = Buffer.from([0x12, 0x20])
-        return Buffer.concat([multiprefix, hash]).toString('hex')
+        const multiprefix = new Uint8Array([0x12, 0x20])
+        const result = new Uint8Array(multiprefix.length + hash.length)
+        result.set(multiprefix, 0)
+        result.set(hash, multiprefix.length)
+        return bytesToHex(result)
     }
 }

--- a/sdk/wallet-sdk/src/wallet/namespace/keys/index.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/keys/index.ts
@@ -1,31 +1,4 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    createKeyPair,
-    KeyPair,
-    PublicKey,
-} from '@canton-network/core-signing-lib'
-
-export class KeysNamespace {
-    /**
-     *
-     * @returns A base64 encoded public/private key pair
-     */
-    public generate(): KeyPair {
-        return createKeyPair()
-    }
-
-    public async fingerprint(publicKey: PublicKey) {
-        const hashPurpose = 12 // For `PublicKeyFingerprint`
-        const keyBytes = Buffer.from(publicKey, 'base64')
-        const hashInput = Buffer.alloc(4 + keyBytes.length)
-        hashInput.writeUInt32BE(hashPurpose, 0)
-        Buffer.from(keyBytes).copy(hashInput, 4)
-        const hash = new Uint8Array(
-            await crypto.subtle.digest('SHA-256', hashInput)
-        )
-        const multiprefix = Buffer.from([0x12, 0x20])
-        return Buffer.concat([multiprefix, hash]).toString('hex')
-    }
-}
+export * from './client.js'

--- a/sdk/wallet-sdk/src/wallet/namespace/keys/keys.test.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/keys/keys.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest'
+import { KeysNamespace } from './index.js'
+import {
+    signTransactionHash,
+    verifySignedTxHash,
+} from '@canton-network/core-signing-lib'
+
+describe('Keys namespace', () => {
+    it('should generate a valid keypair to sign transactions with', () => {
+        const keys = new KeysNamespace()
+        const keyPair = keys.generate()
+
+        const messageToSign = 'EiAbC9+Qc4sRfwZLpRB7+ZtCgLHYiIhiENMoM6DsFhcFHQ=='
+
+        const signature = signTransactionHash(messageToSign, keyPair.privateKey)
+        const verify = verifySignedTxHash(
+            messageToSign,
+            keyPair.publicKey,
+            signature
+        )
+
+        expect(verify).toBe(true)
+    })
+
+    it('should calculate the fingerprint correctly from a known base64 encoded public key', async () => {
+        const keys = new KeysNamespace()
+        const keyPair = keys.generate()
+        const fingerprint = await keys.fingerprint(keyPair.publicKey)
+
+        console.log(fingerprint)
+    })
+})

--- a/sdk/wallet-sdk/src/wallet/namespace/keys/keys.test.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/keys/keys.test.ts
@@ -30,7 +30,7 @@ describe('Keys namespace', () => {
         const publicKeyWithKnownFingerprint =
             'PJCUPZmCN134OST9ofcs2BGLJ/4ju8BT/xiZjzSO6t4='
 
-        const fingerprint = await keys.fingerprint2(
+        const fingerprint = await keys.fingerprint(
             publicKeyWithKnownFingerprint
         )
 

--- a/sdk/wallet-sdk/src/wallet/namespace/keys/keys.test.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/keys/keys.test.ts
@@ -27,9 +27,15 @@ describe('Keys namespace', () => {
 
     it('should calculate the fingerprint correctly from a known base64 encoded public key', async () => {
         const keys = new KeysNamespace()
-        const keyPair = keys.generate()
-        const fingerprint = await keys.fingerprint(keyPair.publicKey)
+        const publicKeyWithKnownFingerprint =
+            'PJCUPZmCN134OST9ofcs2BGLJ/4ju8BT/xiZjzSO6t4='
 
-        console.log(fingerprint)
+        const fingerprint = await keys.fingerprint2(
+            publicKeyWithKnownFingerprint
+        )
+
+        expect(fingerprint).toEqual(
+            '1220def9be3ebfa2ff62e63e4ce8e05551f0487371447ac19178cfdb40da37b28059'
+        )
     })
 })

--- a/sdk/wallet-sdk/src/wallet/namespace/utils/encoding.ts
+++ b/sdk/wallet-sdk/src/wallet/namespace/utils/encoding.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export function base64ToBytes(base64: string): Uint8Array {
+    if (typeof atob === 'function') {
+        const binary = atob(base64)
+        const bytes = new Uint8Array(binary.length)
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i)
+        }
+        return bytes
+    }
+
+    return new Uint8Array(Buffer.from(base64, 'base64'))
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+    return Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('')
+}


### PR DESCRIPTION
Closes https://github.com/canton-network/wallet/issues/1970

<img width="690" height="53" alt="image" src="https://github.com/user-attachments/assets/8abd163b-d1d3-43dc-9269-080322551d61" />

Had to refactor the fingerprint calculation to remove the Buffer dependency (still has the Buffer.from fallback in base64ToBytes for older nodeenvironments that don't have atob) because the tests in the browser were failing with `ReferenceError: Buffer is not defined`. An alternative would be to add the polyfill plugin, but that seemed overkill for just the fingerprint calculation. 