### PR TITLE
feat: show insufficient funds alert for allocations

### DIFF
--- a/examples/portfolio/src/components/dashboard/allocation-action-dialog-content.tsx
+++ b/examples/portfolio/src/components/dashboard/allocation-action-dialog-content.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState, type ReactNode } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import {
     Alert,
     Box,
@@ -15,6 +15,7 @@ import {
 import CloseIcon from '@mui/icons-material/Close'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
+import Decimal from 'decimal.js'
 import { CopyableIdentifier } from '@components/copyable-identifier'
 import type {
     AllocationActionItem,
@@ -22,6 +23,11 @@ import type {
 } from '@components/types'
 import { PillButton } from '@components/ui/PillButton'
 import { isReceiverOfLeg, isSenderOfLeg } from '@components/utils'
+import { useAggregatedHoldings } from '@hooks/useAggregatedHoldings'
+import {
+    getInstrumentKey,
+    type AggregatedHolding,
+} from '@utils/aggregate-holdings'
 import { formatAmount } from '@utils/decimal'
 import {
     formatDistanceToNow,
@@ -54,6 +60,15 @@ export function AllocationActionDialogContent({
 }: AllocationActionDialogContentProps) {
     const [expandedLegIds, setExpandedLegIds] = useState(
         () => new Set(item.transferLegs.map((leg) => leg.transferLegId))
+    )
+    const { instruments: availableHoldings, isLoading: isHoldingsLoading } =
+        useAggregatedHoldings(item.currentPartyId)
+    const insufficientLegIds = useMemo(
+        () =>
+            isHoldingsLoading
+                ? new Set<string>()
+                : getInsufficientLegIds(item, availableHoldings),
+        [availableHoldings, isHoldingsLoading, item]
     )
     const allLegsExpanded = expandedLegIds.size === item.transferLegs.length
 
@@ -163,6 +178,9 @@ export function AllocationActionDialogContent({
                             isExpanded={expandedLegIds.has(leg.transferLegId)}
                             isLoading={isLoading}
                             isLegLoading={loadingLegId === leg.transferLegId}
+                            hasInsufficientFunds={insufficientLegIds.has(
+                                leg.transferLegId
+                            )}
                             error={
                                 failedLegId === leg.transferLegId
                                     ? allocationError
@@ -188,6 +206,7 @@ interface TransferLegCardProps {
     isExpanded: boolean
     isLoading: boolean
     isLegLoading: boolean
+    hasInsufficientFunds: boolean
     error: string | null
     onToggle: () => void
     onCreateAllocation: () => void
@@ -201,6 +220,7 @@ function TransferLegCard({
     isExpanded,
     isLoading,
     isLegLoading,
+    hasInsufficientFunds,
     error,
     onToggle,
     onCreateAllocation,
@@ -213,7 +233,12 @@ function TransferLegCard({
     const canCreateAllocation = isSender && !hasAllocation
     const canWithdrawAllocation =
         isSender && hasAllocation && allocationContractId
-    const actionDisabled = isLoading || Boolean(error)
+    const displayedError =
+        error ??
+        (hasInsufficientFunds
+            ? 'Cannot allocate due to insufficient funds.'
+            : null)
+    const actionDisabled = isLoading || Boolean(error) || hasInsufficientFunds
 
     return (
         <Box
@@ -224,7 +249,7 @@ function TransferLegCard({
                 overflow: 'hidden',
             }}
         >
-            {error ? (
+            {displayedError ? (
                 <Alert
                     severity="error"
                     icon={<InfoOutlinedIcon fontSize="inherit" />}
@@ -242,7 +267,7 @@ function TransferLegCard({
                         },
                     }}
                 >
-                    {error}
+                    {displayedError}
                 </Alert>
             ) : null}
 
@@ -512,6 +537,33 @@ function SubtleChip({ label }: { label: string }) {
                 '& .MuiChip-label': { px: 1 },
             }}
         />
+    )
+}
+
+function getInsufficientLegIds(
+    item: AllocationActionItem,
+    availableHoldings: AggregatedHolding[]
+) {
+    return new Set(
+        item.transferLegs
+            .filter((leg) => {
+                if (
+                    !isSenderOfLeg(item.currentPartyId, leg) ||
+                    leg.allocations.length
+                ) {
+                    return false
+                }
+
+                const availableAmount =
+                    availableHoldings.find(
+                        (holding) =>
+                            getInstrumentKey(holding.instrumentId) ===
+                            getInstrumentKey(leg.transferLeg.instrumentId)
+                    )?.availableAmount ?? '0'
+
+                return new Decimal(availableAmount).lt(leg.transferLeg.amount)
+            })
+            .map((leg) => leg.transferLegId)
     )
 }
 

--- a/examples/portfolio/src/hooks/useCreateAllocation.ts
+++ b/examples/portfolio/src/hooks/useCreateAllocation.ts
@@ -23,9 +23,14 @@ export const useCreateAllocation = () => {
                 ...args,
             }),
         onSuccess: async (_, args) => {
-            await queryClient.invalidateQueries({
-                queryKey: queryKeys.listAllocations.forParty(args.party),
-            })
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.listAllocations.forParty(args.party),
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.listHoldings.forParty(args.party),
+                }),
+            ])
         },
     })
 }

--- a/examples/portfolio/src/hooks/useWithdrawAllocation.ts
+++ b/examples/portfolio/src/hooks/useWithdrawAllocation.ts
@@ -23,9 +23,14 @@ export const useWithdrawAllocation = () => {
                 ...args,
             }),
         onSuccess: async (_, args) => {
-            await queryClient.invalidateQueries({
-                queryKey: queryKeys.listAllocations.forParty(args.party),
-            })
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.listAllocations.forParty(args.party),
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.listHoldings.forParty(args.party),
+                }),
+            ])
         },
     })
 }

--- a/examples/portfolio/src/utils/aggregate-holdings.ts
+++ b/examples/portfolio/src/utils/aggregate-holdings.ts
@@ -25,6 +25,10 @@ export interface AggregatedHolding {
     }
 }
 
+export function getInstrumentKey(instrumentId: { admin: string; id: string }) {
+    return `${instrumentId.admin}::${instrumentId.id}`
+}
+
 export function aggregateHoldings(
     holdings: Holding[],
     currentTime: Date = new Date()
@@ -32,7 +36,7 @@ export function aggregateHoldings(
     const aggregated = new Map<string, AggregatedHolding>()
 
     for (const holding of holdings) {
-        const key = `${holding.instrumentId.admin}::${holding.instrumentId.id}`
+        const key = getInstrumentKey(holding.instrumentId)
         const existing = aggregated.get(key)
         const isLocked = TokenStandardService.isHoldingLocked(
             holding,


### PR DESCRIPTION
Part of #1791 

When there are not enough funds for allocation:
- disable allocate button
- show error message 


<img width="1580" height="2122" alt="screenshot-2026-06-15_13-32-57" src="https://github.com/user-attachments/assets/cd6151b8-9f98-4bcd-b3cd-9b0d177e947e" />
