### PR TITLE
feat: refresh offers page in portfolio dApp

### DIFF
--- a/examples/portfolio/src/components/offers/offer-row.tsx
+++ b/examples/portfolio/src/components/offers/offer-row.tsx
@@ -3,6 +3,7 @@
 
 import { type KeyboardEvent } from 'react'
 import { Box, Chip, type SxProps, type Theme } from '@mui/material'
+import { CopyableIdentifier } from '@components/copyable-identifier'
 import type {
     AllocationActionItem,
     TransferActionItem,
@@ -102,12 +103,19 @@ function AllocationOfferRow({
     status: OfferStatus
 }) {
     return (
-        <OfferRowGrid columns={4}>
+        <OfferRowGrid columns={5}>
             <OfferDetailBlock label="Type" value="Allocation Request" />
             <OfferExpirationBlock
                 label="Allocate Before"
                 expiration={item.expiry}
             />
+            <Box sx={{ minWidth: 0 }}>
+                <OfferFieldLabel>Settlement Reference</OfferFieldLabel>
+                <CopyableIdentifier
+                    value={item.settlement.settlementRef.id}
+                    maxLength={14}
+                />
+            </Box>
             <OfferPartyBlock
                 label="Executor Party"
                 value={item.settlement.executor}

--- a/examples/portfolio/src/components/offers/offer-row.tsx
+++ b/examples/portfolio/src/components/offers/offer-row.tsx
@@ -15,7 +15,11 @@ import {
     OfferRowGrid,
     OfferRowShell,
 } from './offer-row-layout'
-import type { OfferItem, OfferStatus } from '@hooks/useOffers'
+import type {
+    OfferItem,
+    OfferStatus,
+    TransferOfferItem,
+} from '@hooks/useOffers'
 import { formatAmount } from '@utils/decimal'
 
 interface OfferRowProps {
@@ -42,7 +46,7 @@ export function OfferRow({ offer, onClick }: OfferRowProps) {
             onKeyDown={handleKeyDown}
             sx={interactiveOfferRowSx}
         >
-            {offer.source.kind === 'transfer' ? (
+            {isTransferOffer(offer) ? (
                 <TransferOfferRow offer={offer} item={offer.source} />
             ) : (
                 <AllocationOfferRow item={offer.source} status={offer.status} />
@@ -57,11 +61,15 @@ function getOfferRowLabel(offer: OfferItem) {
         : 'Allocation Request'
 }
 
+function isTransferOffer(offer: OfferItem): offer is TransferOfferItem {
+    return offer.source.kind === 'transfer'
+}
+
 function TransferOfferRow({
     offer,
     item,
 }: {
-    offer: OfferItem
+    offer: TransferOfferItem
     item: TransferActionItem
 }) {
     const counterparty =

--- a/examples/portfolio/src/components/offers/offer-tabs.tsx
+++ b/examples/portfolio/src/components/offers/offer-tabs.tsx
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Tab, Tabs } from '@mui/material'
-import type { OfferDirection } from '@hooks/useOffers'
+import type { OfferCategory } from '@hooks/useOffers'
 
 interface OfferTabsProps {
-    value: OfferDirection
-    onChange: (value: OfferDirection) => void
+    value: OfferCategory
+    onChange: (value: OfferCategory) => void
 }
 
 export function OfferTabs({ value, onChange }: OfferTabsProps) {
     return (
         <Tabs
             value={value}
-            onChange={(_, nextValue: OfferDirection) => onChange(nextValue)}
-            aria-label="Offer direction"
+            onChange={(_, nextValue: OfferCategory) => onChange(nextValue)}
+            aria-label="Offer category"
             textColor="inherit"
             slotProps={{
                 indicator: {
@@ -44,8 +44,8 @@ export function OfferTabs({ value, onChange }: OfferTabsProps) {
                 },
             }}
         >
-            <Tab disableRipple value="incoming" label="Incoming" />
-            <Tab disableRipple value="outgoing" label="Outgoing" />
+            <Tab disableRipple value="transfers" label="Transfers" />
+            <Tab disableRipple value="allocations" label="Allocations" />
         </Tabs>
     )
 }

--- a/examples/portfolio/src/components/offers/offer-toolbar.tsx
+++ b/examples/portfolio/src/components/offers/offer-toolbar.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Box, FormControlLabel, Switch } from '@mui/material'
+
+interface OfferToolbarProps {
+    showExpiredOffers: boolean
+    onShowExpiredOffersChange: (value: boolean) => void
+}
+
+export function OfferToolbar({
+    showExpiredOffers,
+    onShowExpiredOffersChange,
+}: OfferToolbarProps) {
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: { xs: 'space-between', sm: 'flex-end' },
+                gap: 3,
+                pb: { xs: 2, md: 1 },
+                flexWrap: 'wrap',
+            }}
+        >
+            <FormControlLabel
+                control={
+                    <Switch
+                        checked={showExpiredOffers}
+                        onChange={(event) =>
+                            onShowExpiredOffersChange(event.target.checked)
+                        }
+                        slotProps={{
+                            input: { 'aria-label': 'Show expired offers' },
+                        }}
+                        sx={{
+                            width: 34,
+                            height: 18,
+                            p: 0,
+                            '& .MuiSwitch-switchBase': {
+                                p: 0.25,
+                                '&.Mui-checked': {
+                                    transform: 'translateX(16px)',
+                                    color: 'text.primary',
+                                    '& + .MuiSwitch-track': {
+                                        bgcolor: 'secondary.main',
+                                        opacity: 1,
+                                    },
+                                },
+                                '&.Mui-focusVisible .MuiSwitch-thumb': {
+                                    outline: (theme) =>
+                                        `2px solid ${theme.palette.secondary.main}`,
+                                    outlineOffset: 2,
+                                },
+                            },
+                            '& .MuiSwitch-thumb': {
+                                width: 14,
+                                height: 14,
+                                bgcolor: 'text.primary',
+                                boxShadow: 'none',
+                            },
+                            '& .MuiSwitch-track': {
+                                borderRadius: 999,
+                                bgcolor: 'action.disabledBackground',
+                                opacity: 1,
+                            },
+                        }}
+                    />
+                }
+                label="Show expired offers"
+                sx={{
+                    m: 0,
+                    color: 'text.primary',
+                    gap: 0.75,
+                    '& .MuiFormControlLabel-label': {
+                        typography: 'body1',
+                    },
+                }}
+            />
+        </Box>
+    )
+}

--- a/examples/portfolio/src/components/offers/offers-content.tsx
+++ b/examples/portfolio/src/components/offers/offers-content.tsx
@@ -3,12 +3,17 @@
 
 import { Alert, Box, Skeleton } from '@mui/material'
 import { OfferRowGrid, OfferRowShell } from './offer-row-layout'
-import type { OfferDirection, OfferItem } from '@hooks/useOffers'
+import type { OfferCategory, OfferItem } from '@hooks/useOffers'
 import { OfferRow } from './offer-row'
+
+const OFFER_CATEGORY_LABELS = {
+    transfers: 'transfer offers',
+    allocations: 'allocation offers',
+} satisfies Record<OfferCategory, string>
 
 interface OffersContentProps {
     offers: OfferItem[]
-    direction: OfferDirection
+    category: OfferCategory
     isLoading: boolean
     isError: boolean
     error: Error | null
@@ -18,7 +23,7 @@ interface OffersContentProps {
 
 export function OffersContent({
     offers,
-    direction,
+    category,
     isLoading,
     isError,
     error,
@@ -48,7 +53,7 @@ export function OffersContent({
             <Alert severity="info">
                 {hasSearchQuery
                     ? 'No offers match your search.'
-                    : `There are currently no ${direction} offers.`}
+                    : `There are currently no ${OFFER_CATEGORY_LABELS[category]}.`}
             </Alert>
         )
     }

--- a/examples/portfolio/src/hooks/useOfferItems.ts
+++ b/examples/portfolio/src/hooks/useOfferItems.ts
@@ -41,6 +41,20 @@ function allocationKey(settlement: SettlementInfo, transferLegId: string) {
     ])
 }
 
+function compareOfferItemsByExpiry(left: ActionItem, right: ActionItem) {
+    const leftExpiry = getExpiryTime(left.expiry)
+    const rightExpiry = getExpiryTime(right.expiry)
+    const now = Date.now()
+    const leftExpired = leftExpiry < now
+    const rightExpired = rightExpiry < now
+
+    if (leftExpired !== rightExpired) {
+        return leftExpired ? 1 : -1
+    }
+
+    return leftExpiry - rightExpiry
+}
+
 export function useOfferItems(): OfferItemsResult {
     const primaryParty = usePrimaryAccount()?.partyId
 
@@ -150,11 +164,8 @@ export function useOfferItems(): OfferItemsResult {
             offerItems.push(allocationItem)
         }
 
-        // Show the items closest to expiry first.
-        return [...offerItems].sort(
-            (left, right) =>
-                getExpiryTime(left.expiry) - getExpiryTime(right.expiry)
-        )
+        // Show active items closest to expiry first, with expired items last.
+        return [...offerItems].sort(compareOfferItemsByExpiry)
     }, [
         pendingTransfers.data,
         allocationRequests.data,

--- a/examples/portfolio/src/hooks/useOffers.ts
+++ b/examples/portfolio/src/hooks/useOffers.ts
@@ -12,23 +12,32 @@ import { isExpired } from '@utils/date-format'
 import { useOfferItems, type OfferItemsResult } from './useOfferItems'
 
 export type OfferDirection = 'incoming' | 'outgoing'
+export type OfferCategory = 'transfers' | 'allocations'
 export type OfferStatus =
     | 'Pending'
     | 'Action Required'
     | 'Allocated'
     | 'Expired'
 
-export type OfferItem = {
+export type TransferOfferItem = {
     id: string
-    source: ActionItem
+    source: TransferActionItem
     direction: OfferDirection
     status: OfferStatus
 }
 
+export type AllocationOfferItem = {
+    id: string
+    source: AllocationActionItem
+    status: OfferStatus
+}
+
+export type OfferItem = TransferOfferItem | AllocationOfferItem
+
 export interface OffersResult extends Omit<OfferItemsResult, 'items'> {
     all: OfferItem[]
-    incoming: OfferItem[]
-    outgoing: OfferItem[]
+    transfers: OfferItem[]
+    allocations: OfferItem[]
 }
 
 export function useOffers(): OffersResult {
@@ -37,8 +46,10 @@ export function useOffers(): OffersResult {
         const all = deriveOffers(offerItems.items)
         return {
             all,
-            incoming: all.filter((offer) => offer.direction === 'incoming'),
-            outgoing: all.filter((offer) => offer.direction === 'outgoing'),
+            transfers: all.filter((offer) => offer.source.kind === 'transfer'),
+            allocations: all.filter(
+                (offer) => offer.source.kind === 'allocation'
+            ),
         }
     }, [offerItems.items])
 
@@ -51,16 +62,23 @@ export function useOffers(): OffersResult {
 }
 
 function deriveOffers(items: ActionItem[]): OfferItem[] {
-    return items.flatMap((item) => {
+    const offers: OfferItem[] = []
+
+    for (const item of items) {
         if (item.kind === 'transfer') {
             const offer = deriveTransferOffer(item)
-            return offer ? [offer] : []
+            if (offer) offers.push(offer)
+        } else {
+            offers.push(deriveAllocationOffer(item))
         }
-        return deriveAllocationOffers(item)
-    })
+    }
+
+    return offers
 }
 
-function deriveTransferOffer(item: TransferActionItem): OfferItem | null {
+function deriveTransferOffer(
+    item: TransferActionItem
+): TransferOfferItem | null {
     const status = isExpired(item.expiry) ? 'Expired' : 'Pending'
 
     if (item.receiver === item.currentPartyId) {
@@ -84,18 +102,9 @@ function deriveTransferOffer(item: TransferActionItem): OfferItem | null {
     return null
 }
 
-function deriveAllocationOffers(item: AllocationActionItem): OfferItem[] {
-    const directions = new Set<OfferDirection>()
-
-    for (const leg of item.transferLegs) {
-        if (isCurrentPartyReceiver(item.currentPartyId, leg)) {
-            directions.add('incoming')
-        }
-        if (isCurrentPartySender(item.currentPartyId, leg)) {
-            directions.add('outgoing')
-        }
-    }
-
+function deriveAllocationOffer(
+    item: AllocationActionItem
+): AllocationOfferItem {
     const isAllocated = areCurrentPartySenderLegsAllocated(item)
     const status = isAllocated
         ? 'Allocated'
@@ -103,12 +112,11 @@ function deriveAllocationOffers(item: AllocationActionItem): OfferItem[] {
           ? 'Expired'
           : 'Action Required'
 
-    return Array.from(directions).map((direction) => ({
-        id: `${item.contractId}-${direction}`,
+    return {
+        id: `${item.contractId}-allocation`,
         source: item,
-        direction,
         status,
-    }))
+    }
 }
 
 function areCurrentPartySenderLegsAllocated(item: AllocationActionItem) {
@@ -127,11 +135,4 @@ function isCurrentPartySender(
     leg: TransferLegWithAllocation
 ) {
     return leg.transferLeg.sender === currentPartyId
-}
-
-function isCurrentPartyReceiver(
-    currentPartyId: string,
-    leg: TransferLegWithAllocation
-) {
-    return leg.transferLeg.receiver === currentPartyId
 }

--- a/examples/portfolio/src/routes/next/dashboard/offers.tsx
+++ b/examples/portfolio/src/routes/next/dashboard/offers.tsx
@@ -4,7 +4,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import { ActionRequiredDialog } from '@components/dashboard/action-required-dialog'
 import { OffersContent } from '@components/offers/offers-content'
 import { OfferTabs } from '@components/offers/offer-tabs'
-import { useOffers, type OfferDirection } from '@hooks/useOffers'
+import { OfferToolbar } from '@components/offers/offer-toolbar'
+import { useOffers, type OfferCategory } from '@hooks/useOffers'
 
 export const Route = createFileRoute('/next/dashboard/offers')({
     component: RouteComponent,
@@ -12,12 +13,25 @@ export const Route = createFileRoute('/next/dashboard/offers')({
 
 function RouteComponent() {
     const offers = useOffers()
-    const [selectedDirection, setSelectedDirection] =
-        useState<OfferDirection>('incoming')
+    const [selectedCategory, setSelectedCategory] =
+        useState<OfferCategory>('transfers')
+    const [showExpiredOffers, setShowExpiredOffers] = useState(false)
     const [selectedOfferId, setSelectedOfferId] = useState<string | null>(null)
-    const selectedOffers =
-        selectedDirection === 'incoming' ? offers.incoming : offers.outgoing
-    const visibleOffers = useMemo(() => selectedOffers, [selectedOffers])
+    const visibleOffers = useMemo(() => {
+        const categoryOffers =
+            selectedCategory === 'transfers'
+                ? offers.transfers
+                : offers.allocations
+
+        return showExpiredOffers
+            ? categoryOffers
+            : categoryOffers.filter((offer) => offer.status !== 'Expired')
+    }, [
+        offers.allocations,
+        offers.transfers,
+        selectedCategory,
+        showExpiredOffers,
+    ])
     const selectedOffer = useMemo(
         () =>
             selectedOfferId
@@ -51,15 +65,19 @@ function RouteComponent() {
                 }}
             >
                 <OfferTabs
-                    value={selectedDirection}
-                    onChange={setSelectedDirection}
+                    value={selectedCategory}
+                    onChange={setSelectedCategory}
+                />
+                <OfferToolbar
+                    showExpiredOffers={showExpiredOffers}
+                    onShowExpiredOffersChange={setShowExpiredOffers}
                 />
             </Box>
 
-            <Box component="section" aria-label={`${selectedDirection} offers`}>
+            <Box component="section" aria-label={`${selectedCategory} offers`}>
                 <OffersContent
                     offers={visibleOffers}
-                    direction={selectedDirection}
+                    category={selectedCategory}
                     isLoading={offers.isLoading}
                     isError={offers.isError}
                     error={offers.error}


### PR DESCRIPTION
- switch from incoming/outgoing -> Transfers/Allocations
- Add toggle for expired items (off by default)
- Add settlement reference to the allocation request rows

https://github.com/user-attachments/assets/a50b0331-6b0a-43f7-9489-8dd192d420cd

