### PR TITLE
ci: pin action versions

### DIFF
--- a/.github/actions/save_cache_if_absent/action.yml
+++ b/.github/actions/save_cache_if_absent/action.yml
@@ -12,7 +12,7 @@ runs:
     steps:
         - name: Re-check cache before save
           id: cache-pre-save
-          uses: actions/cache/restore@v5
+          uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
           with:
               path: ${{ inputs.path }}
               key: ${{ inputs.key }}
@@ -20,7 +20,7 @@ runs:
 
         - name: Save cache
           if: ${{ steps.cache-pre-save.outputs.cache-hit != 'true' }}
-          uses: actions/cache/save@v5
+          uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
           with:
               path: ${{ inputs.path }}
               key: ${{ inputs.key }}

--- a/.github/actions/setup_canton/artifacts/action.yml
+++ b/.github/actions/setup_canton/artifacts/action.yml
@@ -11,7 +11,7 @@ runs:
     using: 'composite'
     steps:
         - name: Cache Canton binaries
-          uses: actions/cache/restore@v5
+          uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
           id: canton-cache
           with:
               path: .canton

--- a/.github/actions/setup_canton/initial/action.yml
+++ b/.github/actions/setup_canton/initial/action.yml
@@ -11,7 +11,7 @@ runs:
     using: 'composite'
     steps:
         - name: Cache Canton binaries
-          uses: actions/cache/restore@v5
+          uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
           id: canton-cache
           with:
               path: .canton

--- a/.github/actions/setup_localnet/artifacts/action.yml
+++ b/.github/actions/setup_localnet/artifacts/action.yml
@@ -11,7 +11,7 @@ runs:
     using: 'composite'
     steps:
         - name: Cache Localnet files
-          uses: actions/cache/restore@v5
+          uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
           id: localnet-cache
           with:
               path: |

--- a/.github/actions/setup_localnet/initial/action.yml
+++ b/.github/actions/setup_localnet/initial/action.yml
@@ -11,7 +11,7 @@ runs:
     using: 'composite'
     steps:
         - name: Cache Localnet files
-          uses: actions/cache/restore@v5
+          uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
           id: localnet-cache
           with:
               path: |

--- a/.github/actions/setup_playwright/action.yml
+++ b/.github/actions/setup_playwright/action.yml
@@ -26,7 +26,7 @@ runs:
         # says to do in the docs. There doesn't appear to be a command that prints
         # it out for us.
         - name: Load Playwright browser cache
-          uses: actions/cache@v5
+          uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
           id: playwright-cache
           with:
               path: '~/.cache/ms-playwright'

--- a/.github/actions/setup_yarn/artifacts/action.yml
+++ b/.github/actions/setup_yarn/artifacts/action.yml
@@ -12,13 +12,13 @@ runs:
           run: corepack enable
 
         - name: Setup Node.js
-          uses: actions/setup-node@v6
+          uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
           with:
               node-version-file: .nvmrc
               cache: yarn
 
         - name: Download build artifacts
-          uses: actions/download-artifact@v7
+          uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
           with:
               name: build-dist-${{ github.run_id }}
 

--- a/.github/actions/setup_yarn/artifacts/action.yml
+++ b/.github/actions/setup_yarn/artifacts/action.yml
@@ -14,8 +14,8 @@ runs:
         - name: Setup Node.js
           uses: actions/setup-node@v6
           with:
-              node-version: 'v24.9.0'
-              cache: 'yarn'
+              node-version-file: .nvmrc
+              cache: yarn
 
         - name: Download build artifacts
           uses: actions/download-artifact@v7

--- a/.github/actions/setup_yarn/initial/action.yml
+++ b/.github/actions/setup_yarn/initial/action.yml
@@ -18,8 +18,8 @@ runs:
         - name: Setup Node.js
           uses: actions/setup-node@v6
           with:
-              node-version: 'v24.9.0'
-              cache: 'yarn'
+              node-version-file: .nvmrc
+              cache: yarn
 
         - name: Restore DPM cache
           id: dpm_cache

--- a/.github/actions/setup_yarn/initial/action.yml
+++ b/.github/actions/setup_yarn/initial/action.yml
@@ -16,7 +16,7 @@ runs:
           run: corepack enable
 
         - name: Setup Node.js
-          uses: actions/setup-node@v6
+          uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
           with:
               node-version-file: .nvmrc
               cache: yarn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
             mainnet_splice_version: ${{ steps.version.outputs.mainnet_splice_version }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
 
             - name: Resolve version config outputs
               id: version
@@ -40,7 +40,7 @@ jobs:
         needs: version-config
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
 
             - uses: ./.github/actions/setup_yarn/initial
               with:
@@ -51,7 +51,7 @@ jobs:
               run: yarn build:all
 
             - name: Upload build artifacts
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: build-dist-${{ github.run_id }}
                   path: |
@@ -80,7 +80,7 @@ jobs:
                 instance: [canton, localnet]
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
 
             - uses: ./.github/actions/setup_yarn/artifacts
               with:
@@ -126,23 +126,23 @@ jobs:
         needs: build
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
 
             - name: Setup Python
               id: setup-python
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version-file: .python-version
 
             - name: Install and configure Poetry
-              uses: snok/install-poetry@v1
+              uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
               with:
                   version: 2.1.3
 
             # load cached venv if cache exists
             - name: Load cached venv
               id: cached-poetry-dependencies
-              uses: actions/cache/restore@v5
+              uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   path: docs/wallet-integration-guide/.venv
                   key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('docs/wallet-integration-guide/poetry.lock') }}
@@ -168,7 +168,7 @@ jobs:
         needs: [version-config, build]
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
 
             - uses: ./.github/actions/setup_yarn/artifacts
               with:
@@ -202,7 +202,7 @@ jobs:
         needs: [version-config, build]
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
               with:
                   fetch-depth: 0
 
@@ -231,7 +231,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
               with:
                   fetch-depth: 0
 
@@ -251,7 +251,7 @@ jobs:
         needs: build
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
               with:
                   fetch-depth: 0
 
@@ -275,7 +275,7 @@ jobs:
                 db: [sqlite, postgres]
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
 
             - uses: ./.github/actions/setup_yarn/artifacts
               with:
@@ -343,14 +343,14 @@ jobs:
               if: ${{ !cancelled() }}
               run: yarn pm2 logs remote --raw --nostream --lines 10000 > "wallet-gateway-remote.log" 2>&1 || true
 
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               if: ${{ !cancelled() }}
               with:
                   name: example-ping-playwright-report-${{ matrix.network }}-${{ matrix.db }}
                   path: examples/ping/playwright-report/
                   retention-days: 5
 
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               if: ${{ !cancelled() }}
               with:
                   name: ping-wallet-gateway-remote-log-${{ matrix.network }}-${{ matrix.db }}
@@ -384,7 +384,8 @@ jobs:
                 network: [devnet, mainnet]
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
+
             - uses: ./.github/actions/setup_yarn/artifacts
               with:
                   daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}
@@ -406,14 +407,14 @@ jobs:
               if: ${{ !cancelled() }}
               run: yarn pm2 logs remote --raw --nostream --lines 10000 > "wallet-gateway-remote.log" 2>&1 || true
 
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               if: ${{ !cancelled() }}
               with:
                   name: example-portfolio-playwright-report-${{ matrix.network }}
                   path: examples/portfolio/playwright-report/
                   retention-days: 5
 
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               if: ${{ !cancelled() }}
               with:
                   name: portfolio-wallet-gateway-remote-log-${{ matrix.network }}
@@ -444,7 +445,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
 
             - uses: ./.github/actions/setup_yarn/artifacts
               with:
@@ -478,7 +479,7 @@ jobs:
 
             - name: Upload logs as artifacts
               if: failure()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: docker-logs-snippets-${{ matrix.network }}
                   path: logs/
@@ -494,7 +495,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
 
             - uses: ./.github/actions/setup_yarn/artifacts
               with:
@@ -530,7 +531,7 @@ jobs:
 
             - name: Upload logs as artifacts
               if: failure()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: docker-logs-scripts-${{ matrix.network }}
                   path: logs/
@@ -562,7 +563,8 @@ jobs:
         needs: [version-config, build]
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
+
             - uses: ./.github/actions/setup_yarn/artifacts
               with:
                   daml_release_version: ${{ needs.version-config.outputs.daml_release_version }}

--- a/.github/workflows/examples-under-stress.yml
+++ b/.github/workflows/examples-under-stress.yml
@@ -40,7 +40,7 @@ jobs:
             mainnet_splice_version: ${{ steps.version.outputs.mainnet_splice_version }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
               with:
                   ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -62,7 +62,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
               with:
                   ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -104,7 +104,7 @@ jobs:
 
             - name: Upload logs as artifacts
               if: failure()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: docker-logs-${{ github.event.inputs.network || 'devnet' }}
                   path: logs/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
             (github.event_name == 'push' && contains(github.event.head_commit.message, 'chore(release):'))
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
               with:
                   fetch-depth: 0
                   fetch-tags: true
@@ -32,7 +32,7 @@ jobs:
               run: corepack enable
 
             - name: Setup Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version-file: .nvmrc
                   cache: yarn
@@ -64,7 +64,7 @@ jobs:
                   yarn workspaces foreach --no-private -t -A --include 'core/*' --include 'sdk/*' --include 'wallet-gateway/*' --include 'examples/*' npm publish --tolerate-republish --tag $npmTag
 
             - name: Trigger Release announce
-              uses: actions/github-script@v7
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               env:
                   PUBLISH_RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
                   REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,8 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 'v22.16.0'
-                  cache: 'yarn'
+                  node-version-file: .nvmrc
+                  cache: yarn
 
             - name: Install dependencies
               run: yarn install --immutable

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -24,7 +24,7 @@ jobs:
             mainnet_splice_version: ${{ steps.version.outputs.mainnet_splice_version }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
               with:
                   ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -46,7 +46,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
               with:
                   ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -81,7 +81,7 @@ jobs:
 
             - name: Upload logs as artifacts
               if: failure()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: docker-logs-${{ github.event.inputs.network || 'devnet' }}
                   path: logs/

--- a/.github/workflows/update-docs-snippets.yml
+++ b/.github/workflows/update-docs-snippets.yml
@@ -15,14 +15,14 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7.0.0
 
             - name: Extract Snippet data
               run: node docs/scripts/generateOutputDocs.js
 
             - name: Store Artifact output
               id: store-artifact
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: splice-wallet-kernel-snippets
                   path: docs-output/


### PR DESCRIPTION
According to the GitHub guide on using third-party actions, it's good practice to pin GitHub Actions using their full-length commit SHA: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

I also updated the versions and removed some duplicate node-version specification - but this does update the Node.js runtime from `v22.16.0` to `v24.9.0` for the publish task.