### PR TITLE
fix(wallet-sdk): export custom log adapter types

### DIFF
--- a/scripts/sdk-package-test.txt
+++ b/scripts/sdk-package-test.txt
@@ -1,8 +1,7 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-
-import { SDK, SDKInterface } from '@canton-network/wallet-sdk'
+import { CustomLogAdapter, SDK, SDKInterface } from '@canton-network/wallet-sdk'
 console.log('SDK imported successfully')
 
 if (typeof SDK.create !== 'function') {
@@ -19,6 +18,7 @@ if (!sdkType.create) {
 console.log('SDK structure is correct')
 
 import type {
+    LogAdapter,
     CommonCtx,
     PrepareOptions,
     ExecuteOptions,
@@ -26,3 +26,10 @@ import type {
 } from '@canton-network/wallet-sdk'
 
 console.log('Type exports are available')
+
+const logAdapter = new CustomLogAdapter((() => {}) as LogAdapter['log'])
+if (typeof logAdapter.log !== 'function') {
+    throw new Error('CustomLogAdapter does not expose log method')
+}
+
+console.log('Custom log adapter exports are available')

--- a/sdk/wallet-sdk/src/wallet/index.ts
+++ b/sdk/wallet-sdk/src/wallet/index.ts
@@ -2,3 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from './sdk.js'
+export { default as CustomLogAdapter } from './logger/adapter/custom.js'
+export type {
+    AllowedLogAdapters,
+    DefaultLogAdapters,
+    LogAdapter,
+    LogContext,
+    LogLevel,
+} from './logger/types.js'

--- a/sdk/wallet-sdk/src/wallet/logger/adapter/custom.ts
+++ b/sdk/wallet-sdk/src/wallet/logger/adapter/custom.ts
@@ -7,7 +7,7 @@ import { SDKLogger } from '../logger' // eslint-disable-line @typescript-eslint/
 /**
  * CustomLogAdapter allows users to provide their own logging implementation.
  *
- * This adapter can be passed to {@link SDKLogger.create} to enable custom log handling logic,
+ * This adapter can be passed to {@link SDKLogger} to enable custom log handling logic,
  * such as integrating with third-party logging services or frameworks.
  *
  * @example
@@ -15,7 +15,7 @@ import { SDKLogger } from '../logger' // eslint-disable-line @typescript-eslint/
  * const customAdapter = new CustomLogAdapter((level, ctx, message) => {
  *   // Custom log logic here
  * });
- * const logger = new SdkLogger(customAdapter);
+ * const logger = new SDKLogger(customAdapter);
  * logger.info({}, 'Custom log message');
  */
 export default class CustomLogAdapter implements LogAdapter {


### PR DESCRIPTION
## Summary

The Wallet SDK already accepts a custom `logAdapter` when creating SDK instances, but the types needed to construct and type a custom logger are not exposed from the package root.

This PR exports `CustomLogAdapter` and the logger adapter types from `@canton-network/wallet-sdk`, so SDK users can provide their own logging implementation without importing from internal paths.

## Changes

- Export `CustomLogAdapter` from the wallet SDK package root.
- Export logger adapter types used by custom `logAdapter` implementations.
- Extend the package validation script to verify these exports from the packed package.