### PR TITLE
feat: add service account auth UI, fix existing issues in networks

### DIFF
--- a/core/wallet-ui-components/src/components/auth-editor.test.ts
+++ b/core/wallet-ui-components/src/components/auth-editor.test.ts
@@ -1,0 +1,174 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { elementUpdated, fixture } from '@open-wc/testing-helpers'
+import { html } from 'lit'
+import { describe, expect, it, vi } from 'vitest'
+import './auth-editor.js'
+import { AuthEditor, AuthEditorChangeEvent } from './auth-editor.js'
+
+const byTestId = <T extends Element>(el: Element, id: string): T | null =>
+    el.querySelector<T>(`[data-test-id="${id}"]`)
+
+describe('auth-editor', () => {
+    it('renders auth inputs directly when optional is false', async () => {
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor .optional=${false}></auth-editor>`
+        )
+
+        expect(byTestId(el, 'auth-editor-edit-state')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-method-select')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-client-id-input')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-add-button')).toBeNull()
+    })
+
+    it('renders Add state when optional is true and auth missing', async () => {
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor .optional=${true}></auth-editor>`
+        )
+
+        expect(byTestId(el, 'auth-editor-empty-state')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-empty-text')?.textContent).toContain(
+            'No auth configured.'
+        )
+        expect(byTestId(el, 'auth-editor-add-button')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-method-select')).toBeNull()
+    })
+
+    it('renders summary with edit and remove when optional and configured', async () => {
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor
+                .optional=${true}
+                .auth=${{
+                    method: 'client_credentials',
+                    clientId: 'client-id',
+                    audience: 'aud',
+                    scope: 'scope',
+                    clientSecret: 'secret',
+                }}
+            ></auth-editor>`
+        )
+
+        expect(byTestId(el, 'auth-editor-view-state')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-summary-list')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-edit-button')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-remove-button')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-empty-state')).toBeNull()
+    })
+
+    it('switches auth methods and renders method specific inputs', async () => {
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor .optional=${false}></auth-editor>`
+        )
+        // The editor emits updates and expects the parent to pass the new auth back.
+        el.addEventListener('auth-change', (event: Event) => {
+            el.auth = (event as AuthEditorChangeEvent).auth
+        })
+
+        const methodSelect = byTestId<HTMLSelectElement>(
+            el,
+            'auth-editor-method-select'
+        )
+        expect(methodSelect).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-client-secret-input')).toBeNull()
+        expect(byTestId(el, 'auth-editor-issuer-input')).toBeNull()
+
+        methodSelect!.value = 'client_credentials'
+        methodSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+        await elementUpdated(el)
+        expect(byTestId(el, 'auth-editor-client-secret-input')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-issuer-input')).toBeNull()
+
+        methodSelect!.value = 'self_signed'
+        methodSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+        await elementUpdated(el)
+        expect(byTestId(el, 'auth-editor-client-secret-input')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-issuer-input')).not.toBeNull()
+    })
+
+    it('hides current secret in input and emits replacement secret', async () => {
+        const existingAuth = {
+            method: 'client_credentials' as const,
+            clientId: 'client-id',
+            audience: 'aud',
+            scope: 'scope',
+            clientSecret: 'existing-secret',
+        }
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor
+                .optional=${false}
+                .auth=${existingAuth}
+            ></auth-editor>`
+        )
+
+        const secretInput = byTestId<HTMLInputElement>(
+            el,
+            'auth-editor-client-secret-input'
+        )
+        expect(secretInput).toBeDefined()
+        expect(secretInput?.value).toBe('')
+        expect(byTestId(el, 'auth-editor-secret-help')?.textContent).toContain(
+            'Current secret is hidden. Enter a new value to replace it.'
+        )
+
+        const listener = vi.fn()
+        el.addEventListener('auth-change', listener)
+
+        secretInput!.value = 'new-secret'
+        secretInput!.dispatchEvent(new Event('change', { bubbles: true }))
+
+        const lastEvent = listener.mock.calls.at(
+            -1
+        )?.[0] as AuthEditorChangeEvent
+        expect(lastEvent.auth).toMatchObject({
+            method: 'client_credentials',
+            clientSecret: 'new-secret',
+        })
+    })
+
+    it('emits undefined on remove and restores previous auth on cancel', async () => {
+        const existingAuth = {
+            method: 'client_credentials' as const,
+            clientId: 'client-id',
+            audience: 'aud',
+            scope: 'scope',
+            clientSecret: 'existing-secret',
+        }
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor
+                .optional=${true}
+                .auth=${existingAuth}
+            ></auth-editor>`
+        )
+
+        const listener = vi.fn()
+        el.addEventListener('auth-change', listener)
+
+        const removeBtn = byTestId<HTMLButtonElement>(
+            el,
+            'auth-editor-remove-button'
+        )
+        removeBtn?.click()
+        await elementUpdated(el)
+
+        const removeEvent = listener.mock.calls.at(
+            -1
+        )?.[0] as AuthEditorChangeEvent
+        expect(removeEvent.auth).toBeUndefined()
+        expect(
+            byTestId(el, 'auth-editor-pending-remove-text')?.textContent
+        ).toContain('Auth will be removed after submitting')
+
+        const cancelBtn = byTestId<HTMLButtonElement>(
+            el,
+            'auth-editor-cancel-remove-button'
+        )
+        cancelBtn?.click()
+        await elementUpdated(el)
+
+        const restoreEvent = listener.mock.calls.at(
+            -1
+        )?.[0] as AuthEditorChangeEvent
+        expect(restoreEvent.auth).toMatchObject(existingAuth)
+    })
+})

--- a/core/wallet-ui-components/src/components/auth-editor.test.ts
+++ b/core/wallet-ui-components/src/components/auth-editor.test.ts
@@ -206,6 +206,65 @@ describe('auth-editor', () => {
         })
     })
 
+    it('does not treat cleared add mode secret as hidden existing secret', async () => {
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor
+                .optional=${true}
+                .allowedMethods=${['client_credentials']}
+            ></auth-editor>`
+        )
+        const listener = vi.fn()
+        el.addEventListener('auth-change', listener)
+        // Keep test behavior aligned with parent component being source of state for auth-editor
+        el.addEventListener('auth-change', (event: Event) => {
+            el.auth = (event as AuthEditorChangeEvent).auth
+        })
+
+        byTestId<HTMLButtonElement>(el, 'auth-editor-add-button')?.click()
+        await elementUpdated(el)
+
+        const secretInput = byTestId<HTMLInputElement>(
+            el,
+            'auth-editor-client-secret-input'
+        )
+        secretInput!.value = 'new-secret'
+        secretInput!.dispatchEvent(new Event('change', { bubbles: true }))
+        await elementUpdated(el)
+        secretInput!.value = ''
+        secretInput!.dispatchEvent(new Event('change', { bubbles: true }))
+        await elementUpdated(el)
+
+        expect(secretInput?.placeholder).toBe('')
+        expect(byTestId(el, 'auth-editor-secret-help')).toBeNull()
+
+        const lastEvent = listener.mock.calls.at(
+            -1
+        )?.[0] as AuthEditorChangeEvent
+        expect(lastEvent.auth).toMatchObject({
+            method: 'client_credentials',
+            clientSecret: '',
+        })
+    })
+
+    it('keeps method select visible and shows warning for unsupported method', async () => {
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor
+                .optional=${false}
+                .auth=${{
+                    method: 'unexpected_method',
+                    clientId: 'client-id',
+                    audience: 'aud',
+                    scope: 'scope',
+                }}
+            ></auth-editor>`
+        )
+
+        expect(byTestId(el, 'auth-editor-method-select')).not.toBeNull()
+        expect(
+            byTestId(el, 'auth-editor-unsupported-method-warning')?.textContent
+        ).toContain('Unsupported auth method')
+    })
+
     it('renders auth inputs directly when optional is false', async () => {
         const el = await fixture<AuthEditor>(
             html`<auth-editor .optional=${false}></auth-editor>`

--- a/core/wallet-ui-components/src/components/auth-editor.test.ts
+++ b/core/wallet-ui-components/src/components/auth-editor.test.ts
@@ -11,6 +11,201 @@ const byTestId = <T extends Element>(el: Element, id: string): T | null =>
     el.querySelector<T>(`[data-test-id="${id}"]`)
 
 describe('auth-editor', () => {
+    it('starts add mode and uses first allowed method as default auth', async () => {
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor
+                .optional=${true}
+                .allowedMethods=${['client_credentials']}
+            ></auth-editor>`
+        )
+
+        expect(byTestId(el, 'auth-editor-empty-state')).not.toBeNull()
+
+        byTestId<HTMLButtonElement>(el, 'auth-editor-add-button')?.click()
+        await elementUpdated(el)
+
+        const methodSelect = byTestId<HTMLSelectElement>(
+            el,
+            'auth-editor-method-select'
+        )
+        expect(byTestId(el, 'auth-editor-edit-state')).not.toBeNull()
+        expect(methodSelect?.value).toBe('client_credentials')
+        expect(byTestId(el, 'auth-editor-client-secret-input')).not.toBeNull()
+    })
+
+    it('starts edit mode with values from auth when edit is clicked', async () => {
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor
+                .optional=${true}
+                .auth=${{
+                    method: 'authorization_code',
+                    clientId: 'client-id',
+                    audience: 'aud',
+                    scope: 'scope',
+                }}
+            ></auth-editor>`
+        )
+
+        expect(byTestId(el, 'auth-editor-view-state')).not.toBeNull()
+
+        byTestId<HTMLButtonElement>(el, 'auth-editor-edit-button')?.click()
+        await elementUpdated(el)
+
+        expect(byTestId(el, 'auth-editor-view-state')).toBeNull()
+        expect(byTestId(el, 'auth-editor-edit-state')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-cancel-edit-button')).not.toBeNull()
+        expect(byTestId(el, 'auth-editor-method-select')).not.toBeNull()
+    })
+
+    it('cancels add mode to empty state and emits undefined auth', async () => {
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor .optional=${true}></auth-editor>`
+        )
+        const listener = vi.fn()
+        el.addEventListener('auth-change', listener)
+
+        byTestId<HTMLButtonElement>(el, 'auth-editor-add-button')?.click()
+        await elementUpdated(el)
+        byTestId<HTMLButtonElement>(
+            el,
+            'auth-editor-cancel-edit-button'
+        )?.click()
+        await elementUpdated(el)
+
+        expect(byTestId(el, 'auth-editor-empty-state')).not.toBeNull()
+        const lastEvent = listener.mock.calls.at(
+            -1
+        )?.[0] as AuthEditorChangeEvent
+        expect(lastEvent.auth).toBeUndefined()
+    })
+
+    it('cancels edit and restores backup auth values', async () => {
+        const existingAuth = {
+            method: 'authorization_code',
+            clientId: 'client-id',
+            audience: 'aud',
+            scope: 'scope',
+        }
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor
+                .optional=${true}
+                .auth=${existingAuth}
+            ></auth-editor>`
+        )
+        const listener = vi.fn()
+        el.addEventListener('auth-change', listener)
+        // Keep test behavior aligned with parent component being source of state for auth-editor
+        el.addEventListener('auth-change', (event: Event) => {
+            el.auth = (event as AuthEditorChangeEvent).auth
+        })
+
+        byTestId<HTMLButtonElement>(el, 'auth-editor-edit-button')?.click()
+        await elementUpdated(el)
+
+        const clientIdInput = byTestId<HTMLInputElement>(
+            el,
+            'auth-editor-client-id-input'
+        )
+        clientIdInput!.value = 'changed-client-id'
+        clientIdInput!.dispatchEvent(new Event('change', { bubbles: true }))
+        await elementUpdated(el)
+
+        byTestId<HTMLButtonElement>(
+            el,
+            'auth-editor-cancel-edit-button'
+        )?.click()
+        await elementUpdated(el)
+
+        const lastEvent = listener.mock.calls.at(
+            -1
+        )?.[0] as AuthEditorChangeEvent
+        expect(lastEvent.auth).toMatchObject(existingAuth)
+        expect(byTestId(el, 'auth-editor-view-state')).not.toBeNull()
+    })
+
+    it('resolves secret from backup when replacement input stays empty', async () => {
+        const existingAuth = {
+            method: 'client_credentials' as const,
+            clientId: 'client-id',
+            audience: 'aud',
+            scope: 'scope',
+            clientSecret: 'existing-secret',
+        }
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor
+                .optional=${true}
+                .auth=${existingAuth}
+            ></auth-editor>`
+        )
+        const listener = vi.fn()
+        el.addEventListener('auth-change', listener)
+        // Keep test behavior aligned with parent component being source of state for auth-editor
+        el.addEventListener('auth-change', (event: Event) => {
+            el.auth = (event as AuthEditorChangeEvent).auth
+        })
+
+        byTestId<HTMLButtonElement>(el, 'auth-editor-edit-button')?.click()
+        await elementUpdated(el)
+
+        const secretInput = byTestId<HTMLInputElement>(
+            el,
+            'auth-editor-client-secret-input'
+        )
+        secretInput!.value = 'new-secret'
+        secretInput!.dispatchEvent(new Event('change', { bubbles: true }))
+
+        secretInput!.value = ''
+        secretInput!.dispatchEvent(new Event('change', { bubbles: true }))
+
+        const lastEvent = listener.mock.calls.at(
+            -1
+        )?.[0] as AuthEditorChangeEvent
+        expect(lastEvent.auth).toMatchObject({
+            method: 'client_credentials',
+            clientSecret: 'existing-secret',
+        })
+    })
+
+    it('emits new secret when replacement input has value', async () => {
+        const existingAuth = {
+            method: 'client_credentials' as const,
+            clientId: 'client-id',
+            audience: 'aud',
+            scope: 'scope',
+            clientSecret: 'existing-secret',
+        }
+        const el = await fixture<AuthEditor>(
+            html`<auth-editor
+                .optional=${true}
+                .auth=${existingAuth}
+            ></auth-editor>`
+        )
+        const listener = vi.fn()
+        el.addEventListener('auth-change', listener)
+        // Keep test behavior aligned with parent component being source of state for auth-editor
+        el.addEventListener('auth-change', (event: Event) => {
+            el.auth = (event as AuthEditorChangeEvent).auth
+        })
+
+        byTestId<HTMLButtonElement>(el, 'auth-editor-edit-button')?.click()
+        await elementUpdated(el)
+
+        const secretInput = byTestId<HTMLInputElement>(
+            el,
+            'auth-editor-client-secret-input'
+        )
+        secretInput!.value = 'new-secret'
+        secretInput!.dispatchEvent(new Event('change', { bubbles: true }))
+
+        const lastEvent = listener.mock.calls.at(
+            -1
+        )?.[0] as AuthEditorChangeEvent
+        expect(lastEvent.auth).toMatchObject({
+            method: 'client_credentials',
+            clientSecret: 'new-secret',
+        })
+    })
+
     it('renders auth inputs directly when optional is false', async () => {
         const el = await fixture<AuthEditor>(
             html`<auth-editor .optional=${false}></auth-editor>`

--- a/core/wallet-ui-components/src/components/auth-editor.ts
+++ b/core/wallet-ui-components/src/components/auth-editor.ts
@@ -114,25 +114,25 @@ export class AuthEditor extends BaseElement {
                 margin: 0;
             }
 
-            .kv-list {
+            .auth-summary-list {
                 display: flex;
                 flex-direction: column;
                 gap: var(--wg-space-3);
             }
 
-            .kv-item {
+            .auth-summary-item {
                 display: flex;
                 flex-direction: column;
                 gap: var(--wg-space-1);
             }
 
-            .kv-label {
+            .auth-summary-label {
                 font-size: var(--wg-font-size-xs);
                 color: var(--wg-text-secondary);
                 font-weight: var(--wg-font-weight-semibold);
             }
 
-            .kv-value {
+            .auth-summary-value {
                 font-size: var(--wg-font-size-sm);
                 color: var(--wg-text);
                 overflow: hidden;
@@ -592,18 +592,25 @@ export class AuthEditor extends BaseElement {
 
         if (this._mode === 'view' && this._hasConfiguredAuth(this.auth)) {
             const rows = this._getSummary(this.auth)
-            // TODO let's make it separate method
             return html`
                 <div class="config-panel" data-test-id="auth-editor-view-state">
-                    <dl class="kv-list" data-test-id="auth-editor-summary-list">
+                    <dl
+                        class="auth-summary-list"
+                        data-test-id="auth-editor-summary-list"
+                    >
                         ${rows.map(
                             (row) => html`
                                 <div
-                                    class="kv-item"
+                                    class="auth-summary-item"
                                     data-test-id="auth-editor-summary-row"
                                 >
-                                    <dt class="kv-label">${row.key}</dt>
-                                    <dd class="kv-value" title=${row.value}>
+                                    <dt class="auth-summary-label">
+                                        ${row.key}
+                                    </dt>
+                                    <dd
+                                        class="auth-summary-value"
+                                        title=${row.value}
+                                    >
                                         ${row.value}
                                     </dd>
                                 </div>

--- a/core/wallet-ui-components/src/components/auth-editor.ts
+++ b/core/wallet-ui-components/src/components/auth-editor.ts
@@ -1,0 +1,582 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { css, html, nothing } from 'lit'
+import { customElement, property, state } from 'lit/decorators.js'
+import { BaseElement } from '../internal/base-element'
+import { chevronDownIcon } from '../icons/index.js'
+import type {
+    Auth,
+    AuthorizationCodeAuth,
+    ClientCredentialsAuth,
+    SelfSignedAuth,
+} from '@canton-network/core-wallet-auth'
+
+export type AuthMethod =
+    | 'authorization_code'
+    | 'client_credentials'
+    | 'self_signed'
+
+type EditorMode = 'none' | 'view' | 'edit' | 'pending-remove'
+
+export class AuthEditorChangeEvent extends Event {
+    auth: Auth | undefined
+
+    constructor(auth?: Auth) {
+        super('auth-change', { bubbles: true, composed: true })
+        this.auth = auth
+    }
+}
+
+@customElement('auth-editor')
+export class AuthEditor extends BaseElement {
+    @property({ type: Object }) accessor auth: Auth | undefined
+    @property({ type: Array })
+    accessor allowedMethods: AuthMethod[] = [
+        'authorization_code',
+        'client_credentials',
+        'self_signed',
+    ]
+    @property({ type: Boolean }) accessor optional = false
+    @property({ type: Boolean }) accessor startInEdit = false
+    @property({ type: Boolean }) accessor showCancelInEdit = true
+    @property({ type: Boolean }) accessor showActions = true
+    @property({ type: String }) accessor emptyText = 'No auth configured.'
+    @property({ type: String }) accessor pendingRemoveText =
+        'Auth will be removed after submitting this form.'
+
+    @state() private _mode: EditorMode = 'none'
+    @state() private _backup?: Auth
+
+    static styles = [
+        BaseElement.styles,
+        css`
+            :host {
+                display: block;
+            }
+
+            .field-group {
+                gap: var(--wg-space-2);
+                margin-bottom: var(--wg-space-3);
+            }
+
+            .field-label {
+                font-size: var(--wg-font-size-sm);
+                font-weight: var(--wg-font-weight-medium);
+                color: var(--wg-text-secondary);
+                line-height: var(--wg-line-height-tight);
+            }
+
+            .required {
+                color: var(--wg-label-required-color);
+            }
+
+            .field-control {
+                width: 100%;
+                border: 1px solid var(--wg-input-border);
+                border-radius: 4px;
+                background: var(--wg-input-bg);
+                color: var(--wg-input-text);
+                padding: 12px 14px;
+            }
+
+            .select-wrap {
+                position: relative;
+            }
+
+            .select-wrap .field-control {
+                padding-right: 40px;
+                appearance: none;
+                -webkit-appearance: none;
+            }
+
+            .select-chevron {
+                position: absolute;
+                top: 50%;
+                right: 12px;
+                transform: translateY(-50%);
+                color: var(--wg-text-secondary);
+                pointer-events: none;
+                display: inline-flex;
+            }
+
+            .config-panel {
+                border: 1px solid var(--wg-border);
+                border-radius: 8px;
+                padding: var(--wg-space-3);
+                background: var(--wg-input-bg);
+                display: flex;
+                flex-direction: column;
+                gap: var(--wg-space-3);
+            }
+
+            .field-help {
+                font-size: var(--wg-font-size-xs);
+                color: var(--wg-text-secondary);
+                margin: 0;
+            }
+
+            .kv-list {
+                display: flex;
+                flex-direction: column;
+                gap: var(--wg-space-3);
+            }
+
+            .kv-item {
+                display: flex;
+                flex-direction: column;
+                gap: var(--wg-space-1);
+            }
+
+            .kv-label {
+                font-size: var(--wg-font-size-xs);
+                color: var(--wg-text-secondary);
+                font-weight: var(--wg-font-weight-semibold);
+            }
+
+            .kv-value {
+                font-size: var(--wg-font-size-sm);
+                color: var(--wg-text);
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                margin: 0;
+            }
+
+            .inline-actions {
+                display: flex;
+                gap: var(--wg-space-2);
+            }
+
+            .btn-inline {
+                border: 1px solid var(--wg-border);
+                border-radius: var(--wg-radius-full);
+                background: var(--wg-input-bg);
+                color: var(--wg-text);
+                font-size: var(--wg-font-size-sm);
+                font-weight: var(--wg-font-weight-semibold);
+                padding: 0.35rem 0.9rem;
+                cursor: pointer;
+            }
+
+            .btn-inline.danger {
+                border-color: var(--wg-error);
+                color: var(--wg-error);
+            }
+
+            .warning-banner {
+                border: 1px solid var(--wg-error);
+                border-radius: 8px;
+                background: rgba(var(--wg-error-rgb), 0.08);
+                color: var(--wg-error);
+                padding: var(--wg-space-3);
+                font-size: var(--wg-font-size-sm);
+            }
+        `,
+    ]
+
+    connectedCallback(): void {
+        super.connectedCallback()
+        this._mode = this.startInEdit
+            ? 'edit'
+            : this.auth
+              ? 'view'
+              : this.optional
+                ? 'none'
+                : 'edit'
+    }
+
+    private _emit(auth?: Auth) {
+        this.dispatchEvent(new AuthEditorChangeEvent(structuredClone(auth)))
+    }
+
+    private _defaultAuth(method: AuthMethod): Auth {
+        if (method === 'authorization_code') {
+            return {
+                method,
+                clientId: '',
+                audience: '',
+                scope: '',
+            } satisfies AuthorizationCodeAuth
+        }
+
+        if (method === 'client_credentials') {
+            return {
+                method,
+                clientId: '',
+                audience: '',
+                scope: '',
+                clientSecret: '',
+            } satisfies ClientCredentialsAuth
+        }
+
+        return {
+            method: 'self_signed',
+            clientId: '',
+            audience: '',
+            scope: '',
+            issuer: '',
+            clientSecret: '',
+        } satisfies SelfSignedAuth
+    }
+
+    private _maskSecret(secret?: string): string {
+        return secret ? '********' : '(not set)'
+    }
+
+    private _getSummary(auth: Auth): Array<{ key: string; value: string }> {
+        const rows: Array<{ key: string; value: string }> = [
+            { key: 'Method', value: auth.method },
+            { key: 'Client Id', value: auth.clientId ?? '' },
+            { key: 'Audience', value: auth.audience ?? '' },
+            { key: 'Scope', value: auth.scope ?? '' },
+        ]
+
+        if ('issuer' in auth) {
+            rows.push({ key: 'Issuer', value: auth.issuer ?? '' })
+        }
+        if ('clientSecret' in auth) {
+            rows.push({
+                key: 'Client Secret',
+                value: this._maskSecret(auth.clientSecret),
+            })
+        }
+        return rows
+    }
+
+    private _startAdd() {
+        this._mode = 'edit'
+    }
+
+    private _startEdit() {
+        if (this.auth) {
+            this._backup = structuredClone(this.auth)
+        }
+        this._mode = 'edit'
+    }
+
+    private _markForRemove() {
+        if (this.auth) {
+            this._backup = structuredClone(this.auth)
+        }
+        this._emit(undefined)
+        this._mode = 'pending-remove'
+    }
+
+    private _cancelRemove() {
+        if (this._backup) {
+            const formState: Auth = structuredClone(this._backup)
+            this._emit(formState)
+            this._mode = 'view'
+        } else {
+            this._mode = this.optional ? 'none' : 'edit'
+        }
+    }
+
+    private _cancelEdit() {
+        if (this._backup) {
+            const formState: Auth = structuredClone(this._backup)
+            this._emit(formState)
+            this._mode = 'view'
+        } else {
+            this._emit(undefined)
+            this._mode = this.optional ? 'none' : 'edit'
+        }
+    }
+
+    private _onAuthMethodChange(e: Event) {
+        const value = (e.target as HTMLSelectElement).value
+
+        switch (value) {
+            case 'authorization_code':
+                this._emit({
+                    method: 'authorization_code',
+                    clientId: this.auth?.clientId ?? '',
+                    audience: this.auth?.audience ?? '',
+                    scope: this.auth?.scope ?? '',
+                } satisfies AuthorizationCodeAuth)
+                break
+
+            case 'self_signed':
+                this._emit({
+                    method: 'self_signed',
+                    clientId: this.auth?.clientId ?? '',
+                    audience: this.auth?.audience ?? '',
+                    scope: this.auth?.scope ?? '',
+                    issuer: (this.auth as SelfSignedAuth)?.issuer ?? '',
+                    clientSecret:
+                        (this.auth as SelfSignedAuth)?.clientSecret ?? '',
+                } satisfies SelfSignedAuth)
+                break
+
+            case 'client_credentials':
+                this._emit({
+                    method: 'client_credentials',
+                    clientId: this.auth?.clientId ?? '',
+                    audience: this.auth?.audience ?? '',
+                    scope: this.auth?.scope ?? '',
+                    clientSecret:
+                        (this.auth as ClientCredentialsAuth)?.clientSecret ??
+                        '',
+                } satisfies ClientCredentialsAuth)
+                break
+            default:
+                throw new Error(`Unsupported auth method: ${value}`)
+        }
+    }
+
+    private _renderAuthForm(authObj: Auth) {
+        const commonFields = html`
+            <div class="field-group d-flex flex-column">
+                <label class="form-label field-label mb-0">
+                    Method <span class="required">*</span>
+                </label>
+                <div class="select-wrap">
+                    <select
+                        class="form-select field-control"
+                        .value=${authObj.method}
+                        @change=${(e: Event) => {
+                            this._onAuthMethodChange(e)
+                        }}
+                    >
+                        ${this.allowedMethods.includes('authorization_code')
+                            ? html`<option
+                                  ?value="authorization_code"
+                                  ?selected=${authObj.method ===
+                                  'authorization_code'}
+                              >
+                                  authorization_code
+                              </option>`
+                            : nothing}
+                        ${this.allowedMethods.includes('client_credentials')
+                            ? html`<option
+                                  value="client_credentials"
+                                  ?selected=${authObj.method ===
+                                  'client_credentials'}
+                              >
+                                  client_credentials
+                              </option>`
+                            : nothing}
+                        ${this.allowedMethods.includes('self_signed')
+                            ? html`<option
+                                  value="self_signed"
+                                  ?selected=${authObj.method === 'self_signed'}
+                              >
+                                  self_signed
+                              </option>`
+                            : nothing}
+                    </select>
+                    <span class="select-chevron">${chevronDownIcon}</span>
+                </div>
+            </div>
+
+            <div class="field-group d-flex flex-column">
+                <label class="form-label field-label mb-0">
+                    Client Id <span class="required">*</span>
+                </label>
+                <input
+                    class="form-control field-control"
+                    type="text"
+                    required
+                    .value=${authObj.clientId}
+                    @change=${(e: Event) => {
+                        authObj.clientId = (e.target as HTMLInputElement).value
+                        this._emit(authObj)
+                    }}
+                />
+            </div>
+
+            <div class="field-group d-flex flex-column">
+                <label class="form-label field-label mb-0">
+                    Audience <span class="required">*</span>
+                </label>
+                <input
+                    class="form-control field-control"
+                    type="text"
+                    required
+                    .value=${authObj.audience}
+                    @change=${(e: Event) => {
+                        authObj.audience = (e.target as HTMLInputElement).value
+                        this._emit(authObj)
+                    }}
+                />
+            </div>
+
+            <div class="field-group d-flex flex-column">
+                <label class="form-label field-label mb-0">
+                    Scope <span class="required">*</span>
+                </label>
+                <input
+                    class="form-control field-control"
+                    type="text"
+                    required
+                    .value=${authObj.scope}
+                    @change=${(e: Event) => {
+                        authObj.scope = (e.target as HTMLInputElement).value
+                        this._emit(authObj)
+                    }}
+                />
+            </div>
+        `
+
+        if (authObj.method === 'authorization_code') {
+            return commonFields
+        }
+
+        if (authObj.method === 'client_credentials') {
+            return html`${commonFields}
+                <div class="field-group d-flex flex-column">
+                    <label class="form-label field-label mb-0">
+                        Client Secret <span class="required">*</span>
+                    </label>
+                    <input
+                        class="form-control field-control"
+                        type="text"
+                        required
+                        .value=${(authObj as ClientCredentialsAuth)
+                            .clientSecret}
+                        @change=${(e: Event) => {
+                            ;(authObj as ClientCredentialsAuth).clientSecret = (
+                                e.target as HTMLInputElement
+                            ).value
+                            this._emit(authObj)
+                        }}
+                    />
+                </div>`
+        }
+
+        return html`${commonFields}
+            <div class="field-group d-flex flex-column">
+                <label class="form-label field-label mb-0">
+                    Issuer <span class="required">*</span>
+                </label>
+                <input
+                    class="form-control field-control"
+                    type="text"
+                    required
+                    .value=${(authObj as SelfSignedAuth).issuer}
+                    @change=${(e: Event) => {
+                        ;(authObj as SelfSignedAuth).issuer = (
+                            e.target as HTMLInputElement
+                        ).value
+                        this._emit(authObj)
+                    }}
+                />
+            </div>
+            <div class="field-group d-flex flex-column">
+                <label class="form-label field-label mb-0">
+                    Client Secret <span class="required">*</span>
+                </label>
+                <input
+                    class="form-control field-control"
+                    type="text"
+                    required
+                    .value=${(authObj as SelfSignedAuth).clientSecret}
+                    @change=${(e: Event) => {
+                        ;(authObj as SelfSignedAuth).clientSecret = (
+                            e.target as HTMLInputElement
+                        ).value
+                        this._emit(authObj)
+                    }}
+                />
+            </div>`
+    }
+
+    protected render() {
+        if (this._mode === 'none') {
+            return html`
+                <div class="config-panel">
+                    <p class="field-help">${this.emptyText}</p>
+                    ${this.showActions
+                        ? html`<div class="inline-actions">
+                              <button
+                                  type="button"
+                                  class="btn-inline"
+                                  @click=${this._startAdd}
+                              >
+                                  Add
+                              </button>
+                          </div>`
+                        : nothing}
+                </div>
+            `
+        }
+
+        if (this._mode === 'pending-remove') {
+            return html`
+                <div class="config-panel">
+                    <div class="warning-banner">${this.pendingRemoveText}</div>
+                    <div class="inline-actions">
+                        <button
+                            type="button"
+                            class="btn-inline"
+                            @click=${this._cancelRemove}
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            `
+        }
+
+        if (this._mode === 'view' && this.auth) {
+            const rows = this._getSummary(this.auth)
+            // TODO let's make it separate method
+            return html`
+                <div class="config-panel">
+                    <dl class="kv-list">
+                        ${rows.map(
+                            (row) => html`
+                                <div class="kv-item">
+                                    <dt class="kv-label">${row.key}</dt>
+                                    <dd class="kv-value" title=${row.value}>
+                                        ${row.value}
+                                    </dd>
+                                </div>
+                            `
+                        )}
+                    </dl>
+                    ${this.showActions
+                        ? html`<div class="inline-actions">
+                              <button
+                                  type="button"
+                                  class="btn-inline"
+                                  @click=${this._startEdit}
+                              >
+                                  Edit
+                              </button>
+                              ${this.optional
+                                  ? html`<button
+                                        type="button"
+                                        class="btn-inline danger"
+                                        @click=${this._markForRemove}
+                                    >
+                                        Remove
+                                    </button>`
+                                  : nothing}
+                          </div>`
+                        : nothing}
+                </div>
+            `
+        }
+
+        const auth = this.auth
+            ? structuredClone(this.auth)
+            : this._defaultAuth(this.allowedMethods[0])
+
+        return html`
+            <div>${this._renderAuthForm(auth)}</div>
+            ${this.showCancelInEdit && this.showActions
+                ? html`<div class="inline-actions">
+                      <button
+                          type="button"
+                          class="btn-inline"
+                          @click=${this._cancelEdit}
+                      >
+                          Cancel
+                      </button>
+                  </div>`
+                : nothing}
+        `
+    }
+}

--- a/core/wallet-ui-components/src/components/auth-editor.ts
+++ b/core/wallet-ui-components/src/components/auth-editor.ts
@@ -38,9 +38,6 @@ export class AuthEditor extends BaseElement {
         'self_signed',
     ]
     @property({ type: Boolean }) accessor optional = false
-    @property({ type: Boolean }) accessor startInEdit = false
-    @property({ type: Boolean }) accessor showCancelInEdit = true
-    @property({ type: Boolean }) accessor showActions = true
     @property({ type: String }) accessor emptyText = 'No auth configured.'
     @property({ type: String }) accessor pendingRemoveText =
         'Auth will be removed after submitting this form.'
@@ -182,13 +179,21 @@ export class AuthEditor extends BaseElement {
 
     connectedCallback(): void {
         super.connectedCallback()
-        this._mode = this.startInEdit
-            ? 'edit'
-            : this.auth
-              ? 'view'
-              : this.optional
-                ? 'none'
-                : 'edit'
+        this._mode = this._initialMode()
+    }
+
+    private _hasConfiguredAuth(auth: Auth | undefined): auth is Auth {
+        return typeof auth?.method === 'string'
+    }
+
+    private _initialMode(): EditorMode {
+        if (!this.optional) {
+            return 'edit'
+        }
+        if (this._hasConfiguredAuth(this.auth)) {
+            return 'view'
+        }
+        return 'none'
     }
 
     private _emit(auth?: Auth) {
@@ -531,17 +536,15 @@ export class AuthEditor extends BaseElement {
             return html`
                 <div class="config-panel">
                     <p class="field-help">${this.emptyText}</p>
-                    ${this.showActions
-                        ? html`<div class="inline-actions">
-                              <button
-                                  type="button"
-                                  class="btn-inline"
-                                  @click=${this._startAdd}
-                              >
-                                  Add
-                              </button>
-                          </div>`
-                        : nothing}
+                    <div class="inline-actions">
+                        <button
+                            type="button"
+                            class="btn-inline"
+                            @click=${this._startAdd}
+                        >
+                            Add
+                        </button>
+                    </div>
                 </div>
             `
         }
@@ -563,7 +566,7 @@ export class AuthEditor extends BaseElement {
             `
         }
 
-        if (this._mode === 'view' && this.auth) {
+        if (this._mode === 'view' && this._hasConfiguredAuth(this.auth)) {
             const rows = this._getSummary(this.auth)
             // TODO let's make it separate method
             return html`
@@ -580,37 +583,34 @@ export class AuthEditor extends BaseElement {
                             `
                         )}
                     </dl>
-                    ${this.showActions
-                        ? html`<div class="inline-actions">
-                              <button
-                                  type="button"
-                                  class="btn-inline"
-                                  @click=${this._startEdit}
-                              >
-                                  Edit
-                              </button>
-                              ${this.optional
-                                  ? html`<button
-                                        type="button"
-                                        class="btn-inline danger"
-                                        @click=${this._markForRemove}
-                                    >
-                                        Remove
-                                    </button>`
-                                  : nothing}
-                          </div>`
-                        : nothing}
+                    <div class="inline-actions">
+                        <button
+                            type="button"
+                            class="btn-inline"
+                            @click=${this._startEdit}
+                        >
+                            Edit
+                        </button>
+                        <button
+                            type="button"
+                            class="btn-inline danger"
+                            @click=${this._markForRemove}
+                        >
+                            Remove
+                        </button>
+                    </div>
                 </div>
             `
         }
 
-        const auth = this.auth
-            ? structuredClone(this.auth)
-            : this._defaultAuth(this.allowedMethods[0])
+        const auth =
+            this.auth && this._hasConfiguredAuth(this.auth)
+                ? structuredClone(this.auth)
+                : this._defaultAuth(this.allowedMethods[0])
 
         return html`
             <div>${this._renderAuthForm(auth)}</div>
-            ${this.showCancelInEdit && this.showActions
+            ${this.optional
                 ? html`<div class="inline-actions">
                       <button
                           type="button"

--- a/core/wallet-ui-components/src/components/auth-editor.ts
+++ b/core/wallet-ui-components/src/components/auth-editor.ts
@@ -47,6 +47,7 @@ export class AuthEditor extends BaseElement {
 
     @state() private _mode: EditorMode = 'none'
     @state() private _backup?: Auth
+    @state() private _secretReplacement = ''
 
     static styles = [
         BaseElement.styles,
@@ -249,6 +250,7 @@ export class AuthEditor extends BaseElement {
     }
 
     private _startAdd() {
+        this._secretReplacement = ''
         this._mode = 'edit'
     }
 
@@ -256,6 +258,7 @@ export class AuthEditor extends BaseElement {
         if (this.auth) {
             this._backup = structuredClone(this.auth)
         }
+        this._secretReplacement = ''
         this._mode = 'edit'
     }
 
@@ -286,6 +289,42 @@ export class AuthEditor extends BaseElement {
             this._emit(undefined)
             this._mode = this.optional ? 'none' : 'edit'
         }
+        this._secretReplacement = ''
+    }
+
+    private _resolveClientSecret(
+        authObj: ClientCredentialsAuth | SelfSignedAuth
+    ): string {
+        if (this._secretReplacement.trim() !== '') {
+            return this._secretReplacement
+        }
+
+        const backupSecret =
+            this._backup && 'clientSecret' in this._backup
+                ? this._backup.clientSecret
+                : undefined
+        if (typeof backupSecret === 'string') {
+            return backupSecret
+        }
+
+        return authObj.clientSecret ?? ''
+    }
+
+    private _hasExistingSecret(
+        authObj: ClientCredentialsAuth | SelfSignedAuth
+    ): boolean {
+        if (
+            typeof authObj.clientSecret === 'string' &&
+            authObj.clientSecret !== ''
+        ) {
+            return true
+        }
+
+        const backupSecret =
+            this._backup && 'clientSecret' in this._backup
+                ? this._backup.clientSecret
+                : undefined
+        return typeof backupSecret === 'string' && backupSecret.length > 0
     }
 
     private _onAuthMethodChange(e: Event) {
@@ -327,6 +366,53 @@ export class AuthEditor extends BaseElement {
             default:
                 throw new Error(`Unsupported auth method: ${value}`)
         }
+    }
+
+    _renderIssuerInput(authObj: SelfSignedAuth) {
+        return html` <div class="field-group d-flex flex-column">
+            <label class="form-label field-label mb-0">
+                Issuer <span class="required">*</span>
+            </label>
+            <input
+                class="form-control field-control"
+                type="text"
+                required
+                .value=${(authObj as SelfSignedAuth).issuer}
+                @change=${(e: Event) => {
+                    authObj.issuer = (e.target as HTMLInputElement).value
+                    this._emit(authObj)
+                }}
+            />
+        </div>`
+    }
+
+    _renderClientSecretInput(authObj: ClientCredentialsAuth | SelfSignedAuth) {
+        return html` <div class="field-group d-flex flex-column">
+            <label class="form-label field-label mb-0">
+                Client Secret <span class="required">*</span>
+            </label>
+            <input
+                class="form-control field-control"
+                type="text"
+                ?required=${!this._hasExistingSecret(authObj)}
+                .value=${this._secretReplacement}
+                placeholder=${this._hasExistingSecret(authObj)
+                    ? '********'
+                    : ''}
+                @change=${(e: Event) => {
+                    this._secretReplacement = (
+                        e.target as HTMLInputElement
+                    ).value
+                    authObj.clientSecret = this._resolveClientSecret(authObj)
+                    this._emit(authObj)
+                }}
+            />
+            ${this._hasExistingSecret(authObj)
+                ? html`<p class="field-help mb-0">
+                      Current secret is hidden. Enter a new value to replace it.
+                  </p>`
+                : nothing}
+        </div>`
     }
 
     private _renderAuthForm(authObj: Auth) {
@@ -428,62 +514,16 @@ export class AuthEditor extends BaseElement {
         }
 
         if (authObj.method === 'client_credentials') {
-            return html`${commonFields}
-                <div class="field-group d-flex flex-column">
-                    <label class="form-label field-label mb-0">
-                        Client Secret <span class="required">*</span>
-                    </label>
-                    <input
-                        class="form-control field-control"
-                        type="text"
-                        required
-                        .value=${(authObj as ClientCredentialsAuth)
-                            .clientSecret}
-                        @change=${(e: Event) => {
-                            ;(authObj as ClientCredentialsAuth).clientSecret = (
-                                e.target as HTMLInputElement
-                            ).value
-                            this._emit(authObj)
-                        }}
-                    />
-                </div>`
+            return html` ${commonFields}
+            ${this._renderClientSecretInput(authObj)}`
         }
 
-        return html`${commonFields}
-            <div class="field-group d-flex flex-column">
-                <label class="form-label field-label mb-0">
-                    Issuer <span class="required">*</span>
-                </label>
-                <input
-                    class="form-control field-control"
-                    type="text"
-                    required
-                    .value=${(authObj as SelfSignedAuth).issuer}
-                    @change=${(e: Event) => {
-                        ;(authObj as SelfSignedAuth).issuer = (
-                            e.target as HTMLInputElement
-                        ).value
-                        this._emit(authObj)
-                    }}
-                />
-            </div>
-            <div class="field-group d-flex flex-column">
-                <label class="form-label field-label mb-0">
-                    Client Secret <span class="required">*</span>
-                </label>
-                <input
-                    class="form-control field-control"
-                    type="text"
-                    required
-                    .value=${(authObj as SelfSignedAuth).clientSecret}
-                    @change=${(e: Event) => {
-                        ;(authObj as SelfSignedAuth).clientSecret = (
-                            e.target as HTMLInputElement
-                        ).value
-                        this._emit(authObj)
-                    }}
-                />
-            </div>`
+        if (authObj.method === 'self_signed') {
+            return html` ${commonFields} ${this._renderIssuerInput(authObj)}
+            ${this._renderClientSecretInput(authObj)}`
+        }
+
+        return nothing // TODO show some error maybe?
     }
 
     protected render() {

--- a/core/wallet-ui-components/src/components/auth-editor.ts
+++ b/core/wallet-ui-components/src/components/auth-editor.ts
@@ -175,6 +175,10 @@ export class AuthEditor extends BaseElement {
         `,
     ]
 
+    protected createRenderRoot(): HTMLElement {
+        return this
+    }
+
     connectedCallback(): void {
         super.connectedCallback()
         this._mode = this.startInEdit

--- a/core/wallet-ui-components/src/components/auth-editor.ts
+++ b/core/wallet-ui-components/src/components/auth-editor.ts
@@ -17,7 +17,7 @@ export type AuthMethod =
     | 'client_credentials'
     | 'self_signed'
 
-type EditorMode = 'none' | 'view' | 'edit' | 'pending-remove'
+type EditorMode = 'none' | 'view' | 'edit' | 'add' | 'pending-remove'
 
 export class AuthEditorChangeEvent extends Event {
     auth: Auth | undefined
@@ -256,7 +256,7 @@ export class AuthEditor extends BaseElement {
 
     private _startAdd() {
         this._secretReplacement = ''
-        this._mode = 'edit'
+        this._mode = 'add'
     }
 
     private _startEdit() {
@@ -304,6 +304,10 @@ export class AuthEditor extends BaseElement {
             return this._secretReplacement
         }
 
+        if (this._mode === 'add') {
+            return ''
+        }
+
         const backupSecret =
             this._backup && 'clientSecret' in this._backup
                 ? this._backup.clientSecret
@@ -318,6 +322,14 @@ export class AuthEditor extends BaseElement {
     private _hasExistingSecret(
         authObj: ClientCredentialsAuth | SelfSignedAuth
     ): boolean {
+        if (this._secretReplacement.trim() !== '') {
+            return false
+        }
+
+        if (this._mode === 'add') {
+            return false
+        }
+
         if (
             typeof authObj.clientSecret === 'string' &&
             authObj.clientSecret !== ''
@@ -330,6 +342,16 @@ export class AuthEditor extends BaseElement {
                 ? this._backup.clientSecret
                 : undefined
         return typeof backupSecret === 'string' && backupSecret.length > 0
+    }
+
+    private _renderUnsupportedMethodWarning(method: string) {
+        return html`<div
+            class="warning-banner"
+            data-test-id="auth-editor-unsupported-method-warning"
+        >
+            Unsupported auth method "${method}". Select a supported method to
+            continue.
+        </div>`
     }
 
     private _onAuthMethodChange(e: Event) {
@@ -426,6 +448,7 @@ export class AuthEditor extends BaseElement {
     }
 
     private _renderAuthForm(authObj: Auth) {
+        const method = authObj.method
         const commonFields = html`
             <div class="field-group d-flex flex-column">
                 <label class="form-label field-label mb-0">
@@ -435,7 +458,7 @@ export class AuthEditor extends BaseElement {
                     <select
                         class="form-select field-control"
                         data-test-id="auth-editor-method-select"
-                        .value=${authObj.method}
+                        .value=${method}
                         @change=${(e: Event) => {
                             this._onAuthMethodChange(e)
                         }}
@@ -443,8 +466,7 @@ export class AuthEditor extends BaseElement {
                         ${this.allowedMethods.includes('authorization_code')
                             ? html`<option
                                   ?value="authorization_code"
-                                  ?selected=${authObj.method ===
-                                  'authorization_code'}
+                                  ?selected=${method === 'authorization_code'}
                               >
                                   authorization_code
                               </option>`
@@ -452,8 +474,7 @@ export class AuthEditor extends BaseElement {
                         ${this.allowedMethods.includes('client_credentials')
                             ? html`<option
                                   value="client_credentials"
-                                  ?selected=${authObj.method ===
-                                  'client_credentials'}
+                                  ?selected=${method === 'client_credentials'}
                               >
                                   client_credentials
                               </option>`
@@ -461,7 +482,7 @@ export class AuthEditor extends BaseElement {
                         ${this.allowedMethods.includes('self_signed')
                             ? html`<option
                                   value="self_signed"
-                                  ?selected=${authObj.method === 'self_signed'}
+                                  ?selected=${method === 'self_signed'}
                               >
                                   self_signed
                               </option>`
@@ -523,21 +544,23 @@ export class AuthEditor extends BaseElement {
             </div>
         `
 
-        if (authObj.method === 'authorization_code') {
+        if (method === 'authorization_code') {
             return commonFields
         }
 
-        if (authObj.method === 'client_credentials') {
+        if (method === 'client_credentials') {
             return html` ${commonFields}
             ${this._renderClientSecretInput(authObj)}`
         }
 
-        if (authObj.method === 'self_signed') {
+        if (method === 'self_signed') {
             return html` ${commonFields} ${this._renderIssuerInput(authObj)}
             ${this._renderClientSecretInput(authObj)}`
         }
 
-        return nothing // TODO show some error maybe?
+        // shouldn't happen, unless parent passes wrong method value. just in case make it recoverable
+        return html` ${commonFields}
+        ${this._renderUnsupportedMethodWarning(method)}`
     }
 
     protected render() {

--- a/core/wallet-ui-components/src/components/auth-editor.ts
+++ b/core/wallet-ui-components/src/components/auth-editor.ts
@@ -380,6 +380,7 @@ export class AuthEditor extends BaseElement {
             </label>
             <input
                 class="form-control field-control"
+                data-test-id="auth-editor-issuer-input"
                 type="text"
                 required
                 .value=${(authObj as SelfSignedAuth).issuer}
@@ -398,6 +399,7 @@ export class AuthEditor extends BaseElement {
             </label>
             <input
                 class="form-control field-control"
+                data-test-id="auth-editor-client-secret-input"
                 type="text"
                 ?required=${!this._hasExistingSecret(authObj)}
                 .value=${this._secretReplacement}
@@ -413,7 +415,10 @@ export class AuthEditor extends BaseElement {
                 }}
             />
             ${this._hasExistingSecret(authObj)
-                ? html`<p class="field-help mb-0">
+                ? html`<p
+                      class="field-help mb-0"
+                      data-test-id="auth-editor-secret-help"
+                  >
                       Current secret is hidden. Enter a new value to replace it.
                   </p>`
                 : nothing}
@@ -429,6 +434,7 @@ export class AuthEditor extends BaseElement {
                 <div class="select-wrap">
                     <select
                         class="form-select field-control"
+                        data-test-id="auth-editor-method-select"
                         .value=${authObj.method}
                         @change=${(e: Event) => {
                             this._onAuthMethodChange(e)
@@ -471,6 +477,7 @@ export class AuthEditor extends BaseElement {
                 </label>
                 <input
                     class="form-control field-control"
+                    data-test-id="auth-editor-client-id-input"
                     type="text"
                     required
                     .value=${authObj.clientId}
@@ -487,6 +494,7 @@ export class AuthEditor extends BaseElement {
                 </label>
                 <input
                     class="form-control field-control"
+                    data-test-id="auth-editor-audience-input"
                     type="text"
                     required
                     .value=${authObj.audience}
@@ -503,6 +511,7 @@ export class AuthEditor extends BaseElement {
                 </label>
                 <input
                     class="form-control field-control"
+                    data-test-id="auth-editor-scope-input"
                     type="text"
                     required
                     .value=${authObj.scope}
@@ -534,12 +543,18 @@ export class AuthEditor extends BaseElement {
     protected render() {
         if (this._mode === 'none') {
             return html`
-                <div class="config-panel">
-                    <p class="field-help">${this.emptyText}</p>
+                <div
+                    class="config-panel"
+                    data-test-id="auth-editor-empty-state"
+                >
+                    <p class="field-help" data-test-id="auth-editor-empty-text">
+                        ${this.emptyText}
+                    </p>
                     <div class="inline-actions">
                         <button
                             type="button"
                             class="btn-inline"
+                            data-test-id="auth-editor-add-button"
                             @click=${this._startAdd}
                         >
                             Add
@@ -551,12 +566,21 @@ export class AuthEditor extends BaseElement {
 
         if (this._mode === 'pending-remove') {
             return html`
-                <div class="config-panel">
-                    <div class="warning-banner">${this.pendingRemoveText}</div>
+                <div
+                    class="config-panel"
+                    data-test-id="auth-editor-pending-remove-state"
+                >
+                    <div
+                        class="warning-banner"
+                        data-test-id="auth-editor-pending-remove-text"
+                    >
+                        ${this.pendingRemoveText}
+                    </div>
                     <div class="inline-actions">
                         <button
                             type="button"
                             class="btn-inline"
+                            data-test-id="auth-editor-cancel-remove-button"
                             @click=${this._cancelRemove}
                         >
                             Cancel
@@ -570,11 +594,14 @@ export class AuthEditor extends BaseElement {
             const rows = this._getSummary(this.auth)
             // TODO let's make it separate method
             return html`
-                <div class="config-panel">
-                    <dl class="kv-list">
+                <div class="config-panel" data-test-id="auth-editor-view-state">
+                    <dl class="kv-list" data-test-id="auth-editor-summary-list">
                         ${rows.map(
                             (row) => html`
-                                <div class="kv-item">
+                                <div
+                                    class="kv-item"
+                                    data-test-id="auth-editor-summary-row"
+                                >
                                     <dt class="kv-label">${row.key}</dt>
                                     <dd class="kv-value" title=${row.value}>
                                         ${row.value}
@@ -587,6 +614,7 @@ export class AuthEditor extends BaseElement {
                         <button
                             type="button"
                             class="btn-inline"
+                            data-test-id="auth-editor-edit-button"
                             @click=${this._startEdit}
                         >
                             Edit
@@ -594,6 +622,7 @@ export class AuthEditor extends BaseElement {
                         <button
                             type="button"
                             class="btn-inline danger"
+                            data-test-id="auth-editor-remove-button"
                             @click=${this._markForRemove}
                         >
                             Remove
@@ -609,12 +638,15 @@ export class AuthEditor extends BaseElement {
                 : this._defaultAuth(this.allowedMethods[0])
 
         return html`
-            <div>${this._renderAuthForm(auth)}</div>
+            <div data-test-id="auth-editor-edit-state">
+                ${this._renderAuthForm(auth)}
+            </div>
             ${this.optional
                 ? html`<div class="inline-actions">
                       <button
                           type="button"
                           class="btn-inline"
+                          data-test-id="auth-editor-cancel-edit-button"
                           @click=${this._cancelEdit}
                       >
                           Cancel

--- a/core/wallet-ui-components/src/components/fixtures.ts
+++ b/core/wallet-ui-components/src/components/fixtures.ts
@@ -49,7 +49,7 @@ export function makeNetwork(overrides: Partial<Network> = {}): Network {
         name: 'Test Network',
         description: 'Test network description',
         identityProviderId: 'idp-1',
-        ledgerApi: { baseUrl: 'http://localhost:6865' },
+        ledgerApi: 'http://localhost:6865',
         auth: {
             method: 'authorization_code',
             audience: 'audience',

--- a/core/wallet-ui-components/src/components/fixtures.ts
+++ b/core/wallet-ui-components/src/components/fixtures.ts
@@ -1,14 +1,11 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    PartyLevelRight,
-    type Network,
-    type Wallet,
-} from '@canton-network/core-wallet-store'
+import { PartyLevelRight, type Wallet } from '@canton-network/core-wallet-store'
 import type { WalletPickerEntry } from '@canton-network/core-types'
 import type {
     Idp,
+    Network,
     PublicNetwork,
 } from '@canton-network/core-wallet-user-rpc-client'
 

--- a/core/wallet-ui-components/src/components/network-form.test.ts
+++ b/core/wallet-ui-components/src/components/network-form.test.ts
@@ -9,6 +9,7 @@ import {
     NetworkDeleteEvent,
     NetworkEditCancelEvent,
     NetworkEditSaveEvent,
+    // NetworkFormData,
     NetworkForm,
 } from './network-form.js'
 import { makeNetwork } from './fixtures.js'
@@ -30,6 +31,18 @@ function getFormInputs(el: NetworkForm) {
         )
     )
 }
+
+// function makeFormNetwork(overrides: Partial<NetworkFormData> = {}): NetworkFormData {
+//     const base = makeNetwork() as unknown as Omit<NetworkFormData, 'ledgerApi'> & {
+//         ledgerApi: { baseUrl: string }
+//     }
+//
+//     return {
+//         ...base,
+//         ledgerApi: base.ledgerApi.baseUrl,
+//         ...overrides,
+//     } as NetworkFormData
+// }
 
 function fillFormInputs(
     el: NetworkForm,
@@ -125,7 +138,7 @@ describe('network-form', () => {
             name: 'New Network',
             description: 'A new network',
             identityProviderId: 'idp-1',
-            ledgerApi: { baseUrl: 'http://localhost:6865' },
+            ledgerApi: 'http://localhost:6865',
         })
         const el = await fixture<NetworkForm>(
             html`<network-form mode="add" .network=${network}></network-form>`
@@ -244,5 +257,41 @@ describe('network-form', () => {
         methodSelect.dispatchEvent(new Event('change', { bubbles: true }))
         await elementUpdated(el)
         expect(el.shadowRoot?.textContent).toContain('Client Secret')
+    })
+
+    it('uses api-shaped ledgerApi string while validating with store zod', async () => {
+        const apiShapedNetwork = makeNetwork({
+            id: 'api-shaped-net',
+            name: 'API Shaped',
+            description: 'Network loaded from API',
+            identityProviderId: 'idp-api',
+            ledgerApi: 'http://localhost:9999',
+            auth: {
+                method: 'client_credentials',
+                audience: 'audience',
+                scope: 'scope',
+                clientId: 'client-id',
+                clientSecret: 'client-secret',
+            },
+        })
+        const el = await fixture<NetworkForm>(
+            html`<network-form
+                mode="review"
+                .network=${apiShapedNetwork}
+            ></network-form>`
+        )
+
+        const [, , , , , ledgerApiInput] = getFormInputs(el)
+        expect(ledgerApiInput?.value).toBe('http://localhost:9999')
+
+        const listener = vi.fn()
+        el.addEventListener('network-edit-save', listener)
+        submitForm(el)
+
+        expect(listener).toHaveBeenCalledOnce()
+        expect(
+            (listener.mock.calls[0][0] as NetworkEditSaveEvent).network
+                .ledgerApi
+        ).toBe('http://localhost:9999')
     })
 })

--- a/core/wallet-ui-components/src/components/network-form.test.ts
+++ b/core/wallet-ui-components/src/components/network-form.test.ts
@@ -9,7 +9,6 @@ import {
     NetworkDeleteEvent,
     NetworkEditCancelEvent,
     NetworkEditSaveEvent,
-    // NetworkFormData,
     NetworkForm,
 } from './network-form.js'
 import { makeNetwork } from './fixtures.js'
@@ -31,18 +30,6 @@ function getFormInputs(el: NetworkForm) {
         )
     )
 }
-
-// function makeFormNetwork(overrides: Partial<NetworkFormData> = {}): NetworkFormData {
-//     const base = makeNetwork() as unknown as Omit<NetworkFormData, 'ledgerApi'> & {
-//         ledgerApi: { baseUrl: string }
-//     }
-//
-//     return {
-//         ...base,
-//         ledgerApi: base.ledgerApi.baseUrl,
-//         ...overrides,
-//     } as NetworkFormData
-// }
 
 function fillFormInputs(
     el: NetworkForm,

--- a/core/wallet-ui-components/src/components/network-form.ts
+++ b/core/wallet-ui-components/src/components/network-form.ts
@@ -70,6 +70,7 @@ export class NetworkForm extends BaseElement {
     accessor network: NetworkFormData = {
         ledgerApi: '',
         auth: {},
+        serviceAccountAuth: {},
     } as NetworkFormData
 
     @state() private _error = ''
@@ -306,6 +307,7 @@ export class NetworkForm extends BaseElement {
                                         (authObj as SelfSignedAuth)
                                             .clientSecret ?? '',
                                 } satisfies SelfSignedAuth)
+                                // TODO should I enforce client credientials for network.serviceAccountAuth?
                             } else if (select.value === 'client_credentials') {
                                 Object.assign(authObj, {
                                     method: 'client_credentials',
@@ -557,12 +559,17 @@ export class NetworkForm extends BaseElement {
                         />
                     </div>
 
-                    ${isReview /*|| true*/
-                        ? html`
-                              <h3 class="section-title">Configure user auth</h3>
-                              ${this.renderAuthForm(this.network.auth)}
-                          `
-                        : nothing}
+                    <h3 class="section-title">Configure user auth</h3>
+                    ${this.renderAuthForm(this.network.auth)}
+
+                    <h3 class="section-title">
+                        Configure service account auth
+                    </h3>
+                    ${
+                        this.renderAuthForm(
+                            this.network.serviceAccountAuth
+                        ) /* TODO what if network doesn't have serviceAccountAuth yet? */
+                    }
                 </div>
 
                 ${this._error

--- a/core/wallet-ui-components/src/components/network-form.ts
+++ b/core/wallet-ui-components/src/components/network-form.ts
@@ -244,7 +244,6 @@ export class NetworkForm extends BaseElement {
             this.toStoreNetworkForValidation(this.network)
         )
 
-        // TODO This doesn't really work anymore, because it allows empty string values. Previosuly required on inputs forced non empty strings, but now that auth-editor is separate shadowRoot, HTML validation doesn't capture it anymore
         if (!parsedData.success) {
             this._error =
                 'Invalid network data, please ensure all fields are set correctly'
@@ -388,6 +387,23 @@ export class NetworkForm extends BaseElement {
                                     ...this.network,
                                     auth: e.auth,
                                 }
+                            }
+                        }}
+                    ></auth-editor>
+
+                    <h3 class="section-title">Configure admin auth</h3>
+                    <auth-editor
+                        .auth=${this.network.serviceAccountAuth}
+                        .optional=${true}
+                        .startInEdit=${false}
+                        .showActions=${true}
+                        .showCancelInEdit=${true}
+                        .emptyText=${'No admin auth configured.'}
+                        .pendingRemoveText=${'Admin auth will be removed after submitting this form.'}
+                        @auth-change=${(e: AuthEditorChangeEvent) => {
+                            this.network = {
+                                ...this.network,
+                                adminAuth: e.auth,
                             }
                         }}
                     ></auth-editor>

--- a/core/wallet-ui-components/src/components/network-form.ts
+++ b/core/wallet-ui-components/src/components/network-form.ts
@@ -11,6 +11,7 @@ import { BaseElement } from '../internal/base-element'
 import { chevronDownIcon } from '../icons/index.js'
 import {
     AuthorizationCodeAuth,
+    Auth,
     ClientCredentialsAuth,
     SelfSignedAuth,
 } from '@canton-network/core-wallet-auth'
@@ -18,6 +19,9 @@ import {
 export type NetworkFormData = Omit<StoreNetwork, 'ledgerApi'> & {
     ledgerApi: string
 }
+
+type ServiceAccountAuthMode = 'none' | 'view' | 'edit' | 'pending-remove'
+type AuthMethod = 'authorization_code' | 'client_credentials' | 'self_signed'
 
 /**
  * Emitted when the user clicks the Cancel button on the form
@@ -70,10 +74,12 @@ export class NetworkForm extends BaseElement {
     accessor network: NetworkFormData = {
         ledgerApi: '',
         auth: {},
-        serviceAccountAuth: {},
+        serviceAccountAuth: undefined,
     } as NetworkFormData
 
     @state() private _error = ''
+    @state() private _serviceAccountMode: ServiceAccountAuthMode = 'none'
+    @state() private _serviceAccountBackup?: Auth
 
     static styles = [
         BaseElement.styles,
@@ -150,6 +156,71 @@ export class NetworkForm extends BaseElement {
                 font-size: var(--wg-font-size-base);
                 font-weight: var(--wg-font-weight-bold);
                 color: var(--wg-text);
+            }
+
+            .config-panel {
+                border: 1px solid var(--wg-border);
+                border-radius: 8px;
+                padding: var(--wg-space-3);
+                background: var(--wg-input-bg);
+                display: flex;
+                flex-direction: column;
+                gap: var(--wg-space-3);
+            }
+
+            .kv-list {
+                display: grid;
+                gap: var(--wg-space-3);
+            }
+
+            .kv-item {
+                display: flex;
+                flex-direction: column;
+                gap: var(--wg-space-1);
+            }
+
+            .kv-label {
+                font-size: var(--wg-font-size-xs);
+                color: var(--wg-text-secondary);
+                font-weight: var(--wg-font-weight-semibold);
+            }
+
+            .kv-value {
+                font-size: var(--wg-font-size-sm);
+                color: var(--wg-text);
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .inline-actions {
+                display: flex;
+                gap: var(--wg-space-2);
+            }
+
+            .btn-inline {
+                border: 1px solid var(--wg-border);
+                border-radius: var(--wg-radius-full);
+                background: var(--wg-input-bg);
+                color: var(--wg-text);
+                font-size: var(--wg-font-size-sm);
+                font-weight: var(--wg-font-weight-semibold);
+                padding: 0.35rem 0.9rem;
+                cursor: pointer;
+            }
+
+            .btn-inline.danger {
+                border-color: var(--wg-error);
+                color: var(--wg-error);
+            }
+
+            .warning-banner {
+                border: 1px solid var(--wg-error);
+                border-radius: 8px;
+                background: rgba(var(--wg-error-rgb), 0.08);
+                color: var(--wg-error);
+                padding: var(--wg-space-3);
+                font-size: var(--wg-font-size-sm);
             }
 
             .delete-section {
@@ -238,6 +309,211 @@ export class NetworkForm extends BaseElement {
         `,
     ]
 
+    override willUpdate(changedProperties: Map<PropertyKey, unknown>) {
+        if (changedProperties.has('network')) {
+            this._serviceAccountBackup = this.network.serviceAccountAuth
+                ? structuredClone(this.network.serviceAccountAuth)
+                : undefined
+            this._serviceAccountMode = this.network.serviceAccountAuth
+                ? 'view'
+                : 'none'
+        }
+    }
+
+    private _maskSecret(secret?: string): string {
+        return secret ? '********' : '(not set)'
+    }
+
+    private _serviceAccountSummary(
+        auth: Auth
+    ): Array<{ key: string; value: string }> {
+        const values: Array<{ key: string; value: string }> = [
+            { key: 'Method', value: auth.method },
+            { key: 'Client Id', value: auth.clientId ?? '' },
+            { key: 'Audience', value: auth.audience ?? '' },
+            { key: 'Scope', value: auth.scope ?? '' },
+        ]
+
+        if ('issuer' in auth) {
+            values.push({
+                key: 'Issuer',
+                value: (auth as SelfSignedAuth).issuer ?? '',
+            })
+        }
+
+        if ('clientSecret' in auth) {
+            values.push({
+                key: 'Client Secret',
+                value: this._maskSecret(
+                    (auth as ClientCredentialsAuth | SelfSignedAuth)
+                        .clientSecret
+                ),
+            })
+        }
+
+        return values
+    }
+
+    private _startEditingServiceAccountAuth() {
+        this._serviceAccountBackup = this.network.serviceAccountAuth
+            ? structuredClone(this.network.serviceAccountAuth)
+            : undefined
+
+        if (!this.network.serviceAccountAuth) {
+            this.network.serviceAccountAuth = {
+                method: 'client_credentials',
+                audience: '',
+                scope: '',
+                clientId: '',
+                clientSecret: '',
+            }
+        }
+
+        this._serviceAccountMode = 'edit'
+        this.requestUpdate()
+    }
+
+    private _markServiceAccountForRemoval() {
+        if (!this.network.serviceAccountAuth) {
+            return
+        }
+
+        this._serviceAccountBackup = structuredClone(
+            this.network.serviceAccountAuth
+        )
+        this.network.serviceAccountAuth = undefined
+        this._serviceAccountMode = 'pending-remove'
+        this.requestUpdate()
+    }
+
+    private _cancelServiceAccountRemoval() {
+        if (this._serviceAccountBackup) {
+            this.network.serviceAccountAuth = structuredClone(
+                this._serviceAccountBackup
+            )
+            this._serviceAccountMode = 'view'
+        } else {
+            this._serviceAccountMode = 'none'
+        }
+        this.requestUpdate()
+    }
+
+    private _cancelServiceAccountEditing() {
+        if (this._serviceAccountBackup) {
+            this.network.serviceAccountAuth = structuredClone(
+                this._serviceAccountBackup
+            )
+            this._serviceAccountMode = 'view'
+        } else {
+            this.network.serviceAccountAuth = undefined
+            this._serviceAccountMode = 'none'
+        }
+        this.requestUpdate()
+    }
+
+    private renderServiceAccountAuthSection() {
+        if (this._serviceAccountMode === 'none') {
+            return html`
+                <h3 class="section-title">Configure service account auth</h3>
+                <div class="config-panel">
+                    <p class="field-help mb-0">
+                        No service account auth configured.
+                    </p>
+                    <div class="inline-actions">
+                        <button
+                            type="button"
+                            class="btn-inline"
+                            @click=${this._startEditingServiceAccountAuth}
+                        >
+                            Add
+                        </button>
+                    </div>
+                </div>
+            `
+        }
+
+        if (this._serviceAccountMode === 'pending-remove') {
+            return html`
+                <h3 class="section-title">Configure service account auth</h3>
+                <div class="config-panel">
+                    <div class="warning-banner">
+                        Service account auth will be removed after submitting
+                        this form.
+                    </div>
+                    <div class="inline-actions">
+                        <button
+                            type="button"
+                            class="btn-inline"
+                            @click=${this._cancelServiceAccountRemoval}
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            `
+        }
+
+        if (
+            this._serviceAccountMode === 'view' &&
+            this.network.serviceAccountAuth
+        ) {
+            const summary = this._serviceAccountSummary(
+                this.network.serviceAccountAuth
+            )
+            return html`
+                <h3 class="section-title">Configure service account auth</h3>
+                <div class="config-panel">
+                    <div class="kv-list">
+                        ${summary.map(
+                            (item) => html`
+                                <div class="kv-item">
+                                    <span class="kv-label">${item.key}</span>
+                                    <span class="kv-value" title=${item.value}
+                                        >${item.value}</span
+                                    >
+                                </div>
+                            `
+                        )}
+                    </div>
+                    <div class="inline-actions">
+                        <button
+                            type="button"
+                            class="btn-inline"
+                            @click=${this._startEditingServiceAccountAuth}
+                        >
+                            Edit
+                        </button>
+                        <button
+                            type="button"
+                            class="btn-inline danger"
+                            @click=${this._markServiceAccountForRemoval}
+                        >
+                            Remove
+                        </button>
+                    </div>
+                </div>
+            `
+        }
+
+        return html`
+            <h3 class="section-title">Configure service account auth</h3>
+            ${this.network.serviceAccountAuth
+                ? this.renderAuthForm(this.network.serviceAccountAuth, {
+                      allowedMethods: ['client_credentials'],
+                  })
+                : nothing}
+            <div class="inline-actions">
+                <button
+                    type="button"
+                    class="btn-inline"
+                    @click=${this._cancelServiceAccountEditing}
+                >
+                    Cancel
+                </button>
+            </div>
+        `
+    }
+
     handleSubmit(e: Event) {
         e.preventDefault()
 
@@ -265,14 +541,23 @@ export class NetworkForm extends BaseElement {
         } as StoreNetwork
     }
 
-    renderAuthForm(authObj: NetworkFormData['auth']) {
+    renderAuthForm(
+        authObj: NetworkFormData['auth'],
+        options?: { allowedMethods?: AuthMethod[]; defaultMethod?: AuthMethod }
+    ) {
+        const allowedMethods = options?.allowedMethods ?? [
+            'authorization_code',
+            'client_credentials',
+            'self_signed',
+        ]
+
         if (typeof authObj.method === 'undefined') {
             Object.assign(authObj, {
-                method: 'authorization_code',
+                method: options?.defaultMethod ?? 'authorization_code',
                 clientId: '',
                 audience: '',
                 scope: '',
-            } satisfies AuthorizationCodeAuth)
+            })
         }
 
         const commonFields = html`
@@ -307,7 +592,6 @@ export class NetworkForm extends BaseElement {
                                         (authObj as SelfSignedAuth)
                                             .clientSecret ?? '',
                                 } satisfies SelfSignedAuth)
-                                // TODO should I enforce client credientials for network.serviceAccountAuth?
                             } else if (select.value === 'client_credentials') {
                                 Object.assign(authObj, {
                                     method: 'client_credentials',
@@ -327,13 +611,21 @@ export class NetworkForm extends BaseElement {
                         }}
                         .value=${authObj.method}
                     >
-                        <option value="authorization_code">
-                            authorization_code
-                        </option>
-                        <option value="client_credentials">
-                            client_credentials
-                        </option>
-                        <option value="self_signed">self_signed</option>
+                        ${allowedMethods.includes('authorization_code')
+                            ? html`<option value="authorization_code">
+                                  authorization_code
+                              </option>`
+                            : nothing}
+                        ${allowedMethods.includes('client_credentials')
+                            ? html`<option value="client_credentials">
+                                  client_credentials
+                              </option>`
+                            : nothing}
+                        ${allowedMethods.includes('self_signed')
+                            ? html`<option value="self_signed">
+                                  self_signed
+                              </option>`
+                            : nothing}
                     </select>
                     <span class="select-chevron">${chevronDownIcon}</span>
                 </div>
@@ -561,15 +853,7 @@ export class NetworkForm extends BaseElement {
 
                     <h3 class="section-title">Configure user auth</h3>
                     ${this.renderAuthForm(this.network.auth)}
-
-                    <h3 class="section-title">
-                        Configure service account auth
-                    </h3>
-                    ${
-                        this.renderAuthForm(
-                            this.network.serviceAccountAuth
-                        ) /* TODO what if network doesn't have serviceAccountAuth yet? */
-                    }
+                    ${this.renderServiceAccountAuthSection()}
                 </div>
 
                 ${this._error

--- a/core/wallet-ui-components/src/components/network-form.ts
+++ b/core/wallet-ui-components/src/components/network-form.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { Network as ApiNetwork } from '@canton-network/core-wallet-user-rpc-client'
 import {
     Network as StoreNetwork,
     networkSchema,
@@ -10,10 +11,6 @@ import { customElement, property, state } from 'lit/decorators.js'
 import { BaseElement } from '../internal/base-element'
 import { AuthEditor, AuthEditorChangeEvent } from './auth-editor.js'
 import './auth-editor.js'
-
-export type NetworkFormData = Omit<StoreNetwork, 'ledgerApi'> & {
-    ledgerApi: string
-}
 
 /**
  * Emitted when the user clicks the Cancel button on the form
@@ -28,9 +25,9 @@ export class NetworkEditCancelEvent extends Event {
  * Emitted when the user clicks the Save/Add/Update button on the form
  */
 export class NetworkEditSaveEvent extends Event {
-    network: NetworkFormData
+    network: ApiNetwork
 
-    constructor(network: NetworkFormData) {
+    constructor(network: ApiNetwork) {
         super('network-edit-save', { bubbles: true, composed: true })
         this.network = network
     }
@@ -40,9 +37,9 @@ export class NetworkEditSaveEvent extends Event {
  * Emitted when the user clicks the Delete button
  */
 export class NetworkDeleteEvent extends Event {
-    network: NetworkFormData
+    network: ApiNetwork
 
-    constructor(network: NetworkFormData) {
+    constructor(network: ApiNetwork) {
         super('network-delete', { bubbles: true, composed: true })
         this.network = network
     }
@@ -64,11 +61,19 @@ export class NetworkForm extends BaseElement {
     accessor mode: 'add' | 'review' = 'add'
 
     @property({ type: Object })
-    accessor network: NetworkFormData = {
+    accessor network: ApiNetwork = {
+        id: '',
+        name: '',
+        description: '',
+        identityProviderId: '',
         ledgerApi: '',
-        auth: {},
-        serviceAccountAuth: undefined,
-    } as NetworkFormData
+        auth: {
+            method: 'authorization_code',
+            audience: '',
+            scope: '',
+            clientId: '',
+        },
+    }
 
     @state() private _error = ''
 
@@ -240,7 +245,6 @@ export class NetworkForm extends BaseElement {
         e.preventDefault()
 
         const parsedData = networkSchema.safeParse(
-            // TODO #1902 use validation that doesn't rely on store shapes that differ from API
             this.toStoreNetworkForValidation(this.network)
         )
 
@@ -254,9 +258,7 @@ export class NetworkForm extends BaseElement {
         }
     }
 
-    private toStoreNetworkForValidation(
-        network: NetworkFormData
-    ): StoreNetwork {
+    private toStoreNetworkForValidation(network: ApiNetwork): StoreNetwork {
         return {
             ...network,
             ledgerApi: { baseUrl: network.ledgerApi },
@@ -333,8 +335,14 @@ export class NetworkForm extends BaseElement {
                             .value=${this.network.synchronizerId ?? ''}
                             @change=${(e: Event) => {
                                 const val = (e.target as HTMLInputElement).value
-                                this.network.synchronizerId =
-                                    val === '' ? undefined : val
+
+                                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                                const { synchronizerId, ...network } =
+                                    this.network
+                                this.network = {
+                                    ...network,
+                                    ...(val && { synchronizerId: val }),
+                                }
                             }}
                         />
                     </div>
@@ -395,9 +403,11 @@ export class NetworkForm extends BaseElement {
                         .emptyText=${'No admin auth configured.'}
                         .pendingRemoveText=${'Admin auth will be removed after submitting this form.'}
                         @auth-change=${(e: AuthEditorChangeEvent) => {
+                            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                            const { adminAuth, ...network } = this.network
                             this.network = {
-                                ...this.network,
-                                adminAuth: e.auth,
+                                ...network,
+                                ...(e.auth && { adminAuth: e.auth }),
                             }
                         }}
                     ></auth-editor>
@@ -412,9 +422,12 @@ export class NetworkForm extends BaseElement {
                         .emptyText=${'No service account auth configured.'}
                         .pendingRemoveText=${'Service account auth will be removed after submitting this form.'}
                         @auth-change=${(e: AuthEditorChangeEvent) => {
+                            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                            const { serviceAccountAuth, ...network } =
+                                this.network
                             this.network = {
-                                ...this.network,
-                                serviceAccountAuth: e.auth,
+                                ...network,
+                                ...(e.auth && { serviceAccountAuth: e.auth }),
                             }
                         }}
                     ></auth-editor>

--- a/core/wallet-ui-components/src/components/network-form.ts
+++ b/core/wallet-ui-components/src/components/network-form.ts
@@ -1,7 +1,10 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Network, networkSchema } from '@canton-network/core-wallet-store'
+import {
+    Network as StoreNetwork,
+    networkSchema,
+} from '@canton-network/core-wallet-store'
 import { css, html, nothing } from 'lit'
 import { customElement, property, state } from 'lit/decorators.js'
 import { BaseElement } from '../internal/base-element'
@@ -11,6 +14,10 @@ import {
     ClientCredentialsAuth,
     SelfSignedAuth,
 } from '@canton-network/core-wallet-auth'
+
+export type NetworkFormData = Omit<StoreNetwork, 'ledgerApi'> & {
+    ledgerApi: string
+}
 
 /**
  * Emitted when the user clicks the Cancel button on the form
@@ -25,9 +32,9 @@ export class NetworkEditCancelEvent extends Event {
  * Emitted when the user clicks the Save/Add/Update button on the form
  */
 export class NetworkEditSaveEvent extends Event {
-    network: Network
+    network: NetworkFormData
 
-    constructor(network: Network) {
+    constructor(network: NetworkFormData) {
         super('network-edit-save', { bubbles: true, composed: true })
         this.network = network
     }
@@ -37,9 +44,9 @@ export class NetworkEditSaveEvent extends Event {
  * Emitted when the user clicks the Delete button
  */
 export class NetworkDeleteEvent extends Event {
-    network: Network
+    network: NetworkFormData
 
-    constructor(network: Network) {
+    constructor(network: NetworkFormData) {
         super('network-delete', { bubbles: true, composed: true })
         this.network = network
     }
@@ -60,10 +67,10 @@ export class NetworkForm extends BaseElement {
     accessor mode: 'add' | 'review' = 'add'
 
     @property({ type: Object })
-    accessor network: Network = {
-        ledgerApi: {},
+    accessor network: NetworkFormData = {
+        ledgerApi: '',
         auth: {},
-    } as Network
+    } as NetworkFormData
 
     @state() private _error = ''
 
@@ -233,7 +240,10 @@ export class NetworkForm extends BaseElement {
     handleSubmit(e: Event) {
         e.preventDefault()
 
-        const parsedData = networkSchema.safeParse(this.network)
+        const parsedData = networkSchema.safeParse(
+            // TODO #1902 use validation that doesn't rely on store shapes that differ from API
+            this.toStoreNetworkForValidation(this.network)
+        )
 
         if (!parsedData.success) {
             this._error =
@@ -245,7 +255,16 @@ export class NetworkForm extends BaseElement {
         }
     }
 
-    renderAuthForm(authObj: Network['auth']) {
+    private toStoreNetworkForValidation(
+        network: NetworkFormData
+    ): StoreNetwork {
+        return {
+            ...network,
+            ledgerApi: { baseUrl: network.ledgerApi },
+        } as StoreNetwork
+    }
+
+    renderAuthForm(authObj: NetworkFormData['auth']) {
         if (typeof authObj.method === 'undefined') {
             Object.assign(authObj, {
                 method: 'authorization_code',
@@ -529,16 +548,16 @@ export class NetworkForm extends BaseElement {
                             class="form-control field-control"
                             type="text"
                             required
-                            .value=${this.network.ledgerApi.baseUrl ?? ''}
+                            .value=${this.network.ledgerApi ?? ''}
                             @change=${(e: Event) => {
-                                this.network.ledgerApi.baseUrl = (
+                                this.network.ledgerApi = (
                                     e.target as HTMLInputElement
                                 ).value
                             }}
                         />
                     </div>
 
-                    ${isReview
+                    ${isReview /*|| true*/
                         ? html`
                               <h3 class="section-title">Configure user auth</h3>
                               ${this.renderAuthForm(this.network.auth)}

--- a/core/wallet-ui-components/src/components/network-form.ts
+++ b/core/wallet-ui-components/src/components/network-form.ts
@@ -8,20 +8,12 @@ import {
 import { css, html, nothing } from 'lit'
 import { customElement, property, state } from 'lit/decorators.js'
 import { BaseElement } from '../internal/base-element'
-import { chevronDownIcon } from '../icons/index.js'
-import {
-    AuthorizationCodeAuth,
-    Auth,
-    ClientCredentialsAuth,
-    SelfSignedAuth,
-} from '@canton-network/core-wallet-auth'
+import { AuthEditorChangeEvent } from './auth-editor.js'
+import './auth-editor.js'
 
 export type NetworkFormData = Omit<StoreNetwork, 'ledgerApi'> & {
     ledgerApi: string
 }
-
-type ServiceAccountAuthMode = 'none' | 'view' | 'edit' | 'pending-remove'
-type AuthMethod = 'authorization_code' | 'client_credentials' | 'self_signed'
 
 /**
  * Emitted when the user clicks the Cancel button on the form
@@ -59,6 +51,7 @@ export class NetworkDeleteEvent extends Event {
 /**
  * Emitted when the user clicks the Back link
  */
+// TODO can I remove that?
 export class NetworkFormBackEvent extends Event {
     constructor() {
         super('network-form-back', { bubbles: true, composed: true })
@@ -78,8 +71,6 @@ export class NetworkForm extends BaseElement {
     } as NetworkFormData
 
     @state() private _error = ''
-    @state() private _serviceAccountMode: ServiceAccountAuthMode = 'none'
-    @state() private _serviceAccountBackup?: Auth
 
     static styles = [
         BaseElement.styles,
@@ -156,71 +147,6 @@ export class NetworkForm extends BaseElement {
                 font-size: var(--wg-font-size-base);
                 font-weight: var(--wg-font-weight-bold);
                 color: var(--wg-text);
-            }
-
-            .config-panel {
-                border: 1px solid var(--wg-border);
-                border-radius: 8px;
-                padding: var(--wg-space-3);
-                background: var(--wg-input-bg);
-                display: flex;
-                flex-direction: column;
-                gap: var(--wg-space-3);
-            }
-
-            .kv-list {
-                display: grid;
-                gap: var(--wg-space-3);
-            }
-
-            .kv-item {
-                display: flex;
-                flex-direction: column;
-                gap: var(--wg-space-1);
-            }
-
-            .kv-label {
-                font-size: var(--wg-font-size-xs);
-                color: var(--wg-text-secondary);
-                font-weight: var(--wg-font-weight-semibold);
-            }
-
-            .kv-value {
-                font-size: var(--wg-font-size-sm);
-                color: var(--wg-text);
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-            }
-
-            .inline-actions {
-                display: flex;
-                gap: var(--wg-space-2);
-            }
-
-            .btn-inline {
-                border: 1px solid var(--wg-border);
-                border-radius: var(--wg-radius-full);
-                background: var(--wg-input-bg);
-                color: var(--wg-text);
-                font-size: var(--wg-font-size-sm);
-                font-weight: var(--wg-font-weight-semibold);
-                padding: 0.35rem 0.9rem;
-                cursor: pointer;
-            }
-
-            .btn-inline.danger {
-                border-color: var(--wg-error);
-                color: var(--wg-error);
-            }
-
-            .warning-banner {
-                border: 1px solid var(--wg-error);
-                border-radius: 8px;
-                background: rgba(var(--wg-error-rgb), 0.08);
-                color: var(--wg-error);
-                padding: var(--wg-space-3);
-                font-size: var(--wg-font-size-sm);
             }
 
             .delete-section {
@@ -309,211 +235,6 @@ export class NetworkForm extends BaseElement {
         `,
     ]
 
-    override willUpdate(changedProperties: Map<PropertyKey, unknown>) {
-        if (changedProperties.has('network')) {
-            this._serviceAccountBackup = this.network.serviceAccountAuth
-                ? structuredClone(this.network.serviceAccountAuth)
-                : undefined
-            this._serviceAccountMode = this.network.serviceAccountAuth
-                ? 'view'
-                : 'none'
-        }
-    }
-
-    private _maskSecret(secret?: string): string {
-        return secret ? '********' : '(not set)'
-    }
-
-    private _serviceAccountSummary(
-        auth: Auth
-    ): Array<{ key: string; value: string }> {
-        const values: Array<{ key: string; value: string }> = [
-            { key: 'Method', value: auth.method },
-            { key: 'Client Id', value: auth.clientId ?? '' },
-            { key: 'Audience', value: auth.audience ?? '' },
-            { key: 'Scope', value: auth.scope ?? '' },
-        ]
-
-        if ('issuer' in auth) {
-            values.push({
-                key: 'Issuer',
-                value: (auth as SelfSignedAuth).issuer ?? '',
-            })
-        }
-
-        if ('clientSecret' in auth) {
-            values.push({
-                key: 'Client Secret',
-                value: this._maskSecret(
-                    (auth as ClientCredentialsAuth | SelfSignedAuth)
-                        .clientSecret
-                ),
-            })
-        }
-
-        return values
-    }
-
-    private _startEditingServiceAccountAuth() {
-        this._serviceAccountBackup = this.network.serviceAccountAuth
-            ? structuredClone(this.network.serviceAccountAuth)
-            : undefined
-
-        if (!this.network.serviceAccountAuth) {
-            this.network.serviceAccountAuth = {
-                method: 'client_credentials',
-                audience: '',
-                scope: '',
-                clientId: '',
-                clientSecret: '',
-            }
-        }
-
-        this._serviceAccountMode = 'edit'
-        this.requestUpdate()
-    }
-
-    private _markServiceAccountForRemoval() {
-        if (!this.network.serviceAccountAuth) {
-            return
-        }
-
-        this._serviceAccountBackup = structuredClone(
-            this.network.serviceAccountAuth
-        )
-        this.network.serviceAccountAuth = undefined
-        this._serviceAccountMode = 'pending-remove'
-        this.requestUpdate()
-    }
-
-    private _cancelServiceAccountRemoval() {
-        if (this._serviceAccountBackup) {
-            this.network.serviceAccountAuth = structuredClone(
-                this._serviceAccountBackup
-            )
-            this._serviceAccountMode = 'view'
-        } else {
-            this._serviceAccountMode = 'none'
-        }
-        this.requestUpdate()
-    }
-
-    private _cancelServiceAccountEditing() {
-        if (this._serviceAccountBackup) {
-            this.network.serviceAccountAuth = structuredClone(
-                this._serviceAccountBackup
-            )
-            this._serviceAccountMode = 'view'
-        } else {
-            this.network.serviceAccountAuth = undefined
-            this._serviceAccountMode = 'none'
-        }
-        this.requestUpdate()
-    }
-
-    private renderServiceAccountAuthSection() {
-        if (this._serviceAccountMode === 'none') {
-            return html`
-                <h3 class="section-title">Configure service account auth</h3>
-                <div class="config-panel">
-                    <p class="field-help mb-0">
-                        No service account auth configured.
-                    </p>
-                    <div class="inline-actions">
-                        <button
-                            type="button"
-                            class="btn-inline"
-                            @click=${this._startEditingServiceAccountAuth}
-                        >
-                            Add
-                        </button>
-                    </div>
-                </div>
-            `
-        }
-
-        if (this._serviceAccountMode === 'pending-remove') {
-            return html`
-                <h3 class="section-title">Configure service account auth</h3>
-                <div class="config-panel">
-                    <div class="warning-banner">
-                        Service account auth will be removed after submitting
-                        this form.
-                    </div>
-                    <div class="inline-actions">
-                        <button
-                            type="button"
-                            class="btn-inline"
-                            @click=${this._cancelServiceAccountRemoval}
-                        >
-                            Cancel
-                        </button>
-                    </div>
-                </div>
-            `
-        }
-
-        if (
-            this._serviceAccountMode === 'view' &&
-            this.network.serviceAccountAuth
-        ) {
-            const summary = this._serviceAccountSummary(
-                this.network.serviceAccountAuth
-            )
-            return html`
-                <h3 class="section-title">Configure service account auth</h3>
-                <div class="config-panel">
-                    <div class="kv-list">
-                        ${summary.map(
-                            (item) => html`
-                                <div class="kv-item">
-                                    <span class="kv-label">${item.key}</span>
-                                    <span class="kv-value" title=${item.value}
-                                        >${item.value}</span
-                                    >
-                                </div>
-                            `
-                        )}
-                    </div>
-                    <div class="inline-actions">
-                        <button
-                            type="button"
-                            class="btn-inline"
-                            @click=${this._startEditingServiceAccountAuth}
-                        >
-                            Edit
-                        </button>
-                        <button
-                            type="button"
-                            class="btn-inline danger"
-                            @click=${this._markServiceAccountForRemoval}
-                        >
-                            Remove
-                        </button>
-                    </div>
-                </div>
-            `
-        }
-
-        return html`
-            <h3 class="section-title">Configure service account auth</h3>
-            ${this.network.serviceAccountAuth
-                ? this.renderAuthForm(this.network.serviceAccountAuth, {
-                      allowedMethods: ['client_credentials'],
-                  })
-                : nothing}
-            <div class="inline-actions">
-                <button
-                    type="button"
-                    class="btn-inline"
-                    @click=${this._cancelServiceAccountEditing}
-                >
-                    Cancel
-                </button>
-            </div>
-        `
-    }
-
     handleSubmit(e: Event) {
         e.preventDefault()
 
@@ -522,6 +243,7 @@ export class NetworkForm extends BaseElement {
             this.toStoreNetworkForValidation(this.network)
         )
 
+        // TODO This doesn't really work anymore, because it allows empty string values. Previosuly required on inputs forced non empty strings, but now that auth-editor is separate shadowRoot, HTML validation doesn't capture it anymore
         if (!parsedData.success) {
             this._error =
                 'Invalid network data, please ensure all fields are set correctly'
@@ -539,204 +261,6 @@ export class NetworkForm extends BaseElement {
             ...network,
             ledgerApi: { baseUrl: network.ledgerApi },
         } as StoreNetwork
-    }
-
-    renderAuthForm(
-        authObj: NetworkFormData['auth'],
-        options?: { allowedMethods?: AuthMethod[]; defaultMethod?: AuthMethod }
-    ) {
-        const allowedMethods = options?.allowedMethods ?? [
-            'authorization_code',
-            'client_credentials',
-            'self_signed',
-        ]
-
-        if (typeof authObj.method === 'undefined') {
-            Object.assign(authObj, {
-                method: options?.defaultMethod ?? 'authorization_code',
-                clientId: '',
-                audience: '',
-                scope: '',
-            })
-        }
-
-        const commonFields = html`
-            <div class="field-group d-flex flex-column">
-                <label class="form-label field-label mb-0">
-                    Method <span class="required">*</span>
-                </label>
-                <div class="select-wrap">
-                    <select
-                        class="form-select field-control"
-                        @change=${(e: Event) => {
-                            const select = e.target as HTMLSelectElement
-                            if (authObj.method === select.value) return
-
-                            if (select.value === 'authorization_code') {
-                                Object.assign(authObj, {
-                                    method: 'authorization_code',
-                                    clientId: authObj.clientId ?? '',
-                                    audience: authObj.audience ?? '',
-                                    scope: authObj.scope ?? '',
-                                } satisfies AuthorizationCodeAuth)
-                            } else if (select.value === 'self_signed') {
-                                Object.assign(authObj, {
-                                    method: 'self_signed',
-                                    clientId: authObj.clientId ?? '',
-                                    audience: authObj.audience ?? '',
-                                    scope: authObj.scope ?? '',
-                                    issuer:
-                                        (authObj as SelfSignedAuth).issuer ??
-                                        '',
-                                    clientSecret:
-                                        (authObj as SelfSignedAuth)
-                                            .clientSecret ?? '',
-                                } satisfies SelfSignedAuth)
-                            } else if (select.value === 'client_credentials') {
-                                Object.assign(authObj, {
-                                    method: 'client_credentials',
-                                    clientId: authObj.clientId ?? '',
-                                    audience: authObj.audience ?? '',
-                                    scope: authObj.scope ?? '',
-                                    clientSecret:
-                                        (authObj as ClientCredentialsAuth)
-                                            .clientSecret ?? '',
-                                } satisfies ClientCredentialsAuth)
-                            } else {
-                                throw new Error(
-                                    `Unsupported auth method: ${select.value}`
-                                )
-                            }
-                            this.requestUpdate()
-                        }}
-                        .value=${authObj.method}
-                    >
-                        ${allowedMethods.includes('authorization_code')
-                            ? html`<option value="authorization_code">
-                                  authorization_code
-                              </option>`
-                            : nothing}
-                        ${allowedMethods.includes('client_credentials')
-                            ? html`<option value="client_credentials">
-                                  client_credentials
-                              </option>`
-                            : nothing}
-                        ${allowedMethods.includes('self_signed')
-                            ? html`<option value="self_signed">
-                                  self_signed
-                              </option>`
-                            : nothing}
-                    </select>
-                    <span class="select-chevron">${chevronDownIcon}</span>
-                </div>
-            </div>
-
-            <div class="field-group d-flex flex-column">
-                <label class="form-label field-label mb-0">
-                    Client Id <span class="required">*</span>
-                </label>
-                <input
-                    class="form-control field-control"
-                    type="text"
-                    required
-                    .value=${authObj.clientId}
-                    @change=${(e: Event) => {
-                        authObj.clientId = (e.target as HTMLInputElement).value
-                    }}
-                />
-            </div>
-
-            <div class="field-group d-flex flex-column">
-                <label class="form-label field-label mb-0">
-                    Audience <span class="required">*</span>
-                </label>
-                <input
-                    class="form-control field-control"
-                    type="text"
-                    required
-                    .value=${authObj.audience}
-                    @change=${(e: Event) => {
-                        authObj.audience = (e.target as HTMLInputElement).value
-                    }}
-                />
-            </div>
-
-            <div class="field-group d-flex flex-column">
-                <label class="form-label field-label mb-0">
-                    Scope <span class="required">*</span>
-                </label>
-                <input
-                    class="form-control field-control"
-                    type="text"
-                    required
-                    .value=${authObj.scope}
-                    @change=${(e: Event) => {
-                        authObj.scope = (e.target as HTMLInputElement).value
-                    }}
-                />
-            </div>
-        `
-
-        if (authObj.method === 'authorization_code') {
-            return html`${commonFields}`
-        } else if (authObj.method === 'client_credentials') {
-            return html`${commonFields}
-                <div class="field-group d-flex flex-column">
-                    <label class="form-label field-label mb-0">
-                        Client Secret <span class="required">*</span>
-                    </label>
-                    <input
-                        class="form-control field-control"
-                        type="text"
-                        required
-                        .value=${(authObj as ClientCredentialsAuth)
-                            .clientSecret}
-                        @change=${(e: Event) => {
-                            ;(authObj as ClientCredentialsAuth).clientSecret = (
-                                e.target as HTMLInputElement
-                            ).value
-                        }}
-                    />
-                </div>`
-        } else if (authObj.method === 'self_signed') {
-            return html`${commonFields}
-                <div class="field-group d-flex flex-column">
-                    <label class="form-label field-label mb-0">
-                        Issuer <span class="required">*</span>
-                    </label>
-                    <input
-                        class="form-control field-control"
-                        type="text"
-                        required
-                        .value=${(authObj as SelfSignedAuth).issuer}
-                        @change=${(e: Event) => {
-                            ;(authObj as SelfSignedAuth).issuer = (
-                                e.target as HTMLInputElement
-                            ).value
-                        }}
-                    />
-                </div>
-                <div class="field-group d-flex flex-column">
-                    <label class="form-label field-label mb-0">
-                        Client Secret <span class="required">*</span>
-                    </label>
-                    <input
-                        class="form-control field-control"
-                        type="text"
-                        required
-                        .value=${(authObj as SelfSignedAuth).clientSecret}
-                        @change=${(e: Event) => {
-                            ;(authObj as SelfSignedAuth).clientSecret = (
-                                e.target as HTMLInputElement
-                            ).value
-                        }}
-                    />
-                </div>`
-        } else {
-            throw new Error(
-                `Unsupported auth method: ${JSON.stringify(authObj)}`
-            )
-        }
     }
 
     render() {
@@ -852,8 +376,40 @@ export class NetworkForm extends BaseElement {
                     </div>
 
                     <h3 class="section-title">Configure user auth</h3>
-                    ${this.renderAuthForm(this.network.auth)}
-                    ${this.renderServiceAccountAuthSection()}
+                    <auth-editor
+                        .auth=${this.network.auth}
+                        .startInEdit=${true}
+                        .showActions=${false}
+                        .showCancelInEdit=${false}
+                        @auth-change=${(e: AuthEditorChangeEvent) => {
+                            if (e.auth) {
+                                this.network = {
+                                    ...this.network,
+                                    auth: e.auth,
+                                }
+                            }
+                        }}
+                    ></auth-editor>
+
+                    <h3 class="section-title">
+                        Configure service account auth
+                    </h3>
+                    <auth-editor
+                        .auth=${this.network.serviceAccountAuth}
+                        .allowedMethods=${['client_credentials']}
+                        .optional=${true}
+                        .startInEdit=${false}
+                        .showActions=${true}
+                        .showCancelInEdit=${true}
+                        .emptyText=${'No service account auth configured.'}
+                        .pendingRemoveText=${'Service account auth will be removed after submitting this form.'}
+                        @auth-change=${(e: AuthEditorChangeEvent) => {
+                            this.network = {
+                                ...this.network,
+                                serviceAccountAuth: e.auth,
+                            }
+                        }}
+                    ></auth-editor>
                 </div>
 
                 ${this._error

--- a/core/wallet-ui-components/src/components/network-form.ts
+++ b/core/wallet-ui-components/src/components/network-form.ts
@@ -378,9 +378,6 @@ export class NetworkForm extends BaseElement {
                     <h3 class="section-title">Configure user auth</h3>
                     <auth-editor
                         .auth=${this.network.auth}
-                        .startInEdit=${true}
-                        .showActions=${false}
-                        .showCancelInEdit=${false}
                         @auth-change=${(e: AuthEditorChangeEvent) => {
                             if (e.auth) {
                                 this.network = {
@@ -395,9 +392,6 @@ export class NetworkForm extends BaseElement {
                     <auth-editor
                         .auth=${this.network.adminAuth}
                         .optional=${true}
-                        .startInEdit=${false}
-                        .showActions=${true}
-                        .showCancelInEdit=${true}
                         .emptyText=${'No admin auth configured.'}
                         .pendingRemoveText=${'Admin auth will be removed after submitting this form.'}
                         @auth-change=${(e: AuthEditorChangeEvent) => {
@@ -415,9 +409,6 @@ export class NetworkForm extends BaseElement {
                         .auth=${this.network.serviceAccountAuth}
                         .allowedMethods=${['client_credentials']}
                         .optional=${true}
-                        .startInEdit=${false}
-                        .showActions=${true}
-                        .showCancelInEdit=${true}
                         .emptyText=${'No service account auth configured.'}
                         .pendingRemoveText=${'Service account auth will be removed after submitting this form.'}
                         @auth-change=${(e: AuthEditorChangeEvent) => {

--- a/core/wallet-ui-components/src/components/network-form.ts
+++ b/core/wallet-ui-components/src/components/network-form.ts
@@ -393,7 +393,7 @@ export class NetworkForm extends BaseElement {
 
                     <h3 class="section-title">Configure admin auth</h3>
                     <auth-editor
-                        .auth=${this.network.serviceAccountAuth}
+                        .auth=${this.network.adminAuth}
                         .optional=${true}
                         .startInEdit=${false}
                         .showActions=${true}

--- a/core/wallet-ui-components/src/components/network-form.ts
+++ b/core/wallet-ui-components/src/components/network-form.ts
@@ -45,16 +45,6 @@ export class NetworkDeleteEvent extends Event {
     }
 }
 
-/**
- * Emitted when the user clicks the Back link
- */
-// TODO can I remove that?
-export class NetworkFormBackEvent extends Event {
-    constructor() {
-        super('network-form-back', { bubbles: true, composed: true })
-    }
-}
-
 @customElement('network-form')
 export class NetworkForm extends BaseElement {
     @property({ type: String })

--- a/core/wallet-ui-components/src/components/network-form.ts
+++ b/core/wallet-ui-components/src/components/network-form.ts
@@ -8,7 +8,7 @@ import {
 import { css, html, nothing } from 'lit'
 import { customElement, property, state } from 'lit/decorators.js'
 import { BaseElement } from '../internal/base-element'
-import { AuthEditorChangeEvent } from './auth-editor.js'
+import { AuthEditor, AuthEditorChangeEvent } from './auth-editor.js'
 import './auth-editor.js'
 
 export type NetworkFormData = Omit<StoreNetwork, 'ledgerApi'> & {
@@ -233,6 +233,7 @@ export class NetworkForm extends BaseElement {
                 border-width: 1px;
             }
         `,
+        AuthEditor.styles,
     ]
 
     handleSubmit(e: Event) {

--- a/core/wallet-ui-components/src/index.ts
+++ b/core/wallet-ui-components/src/index.ts
@@ -3,6 +3,7 @@
 
 export * from './components/api-key-card.js'
 export * from './components/api-key-form.js'
+export * from './components/auth-editor.js'
 export * from './components/app-header.js'
 export * from './components/app-layout.js'
 export * from './components/back-link.js'

--- a/core/wallet-ui-components/src/index.ts
+++ b/core/wallet-ui-components/src/index.ts
@@ -3,7 +3,7 @@
 
 export * from './components/api-key-card.js'
 export * from './components/api-key-form.js'
-export * from './components/auth-editor.js' // TODO should I expose that, or should it just be "private" for network-form?
+export * from './components/auth-editor.js'
 export * from './components/app-header.js'
 export * from './components/app-layout.js'
 export * from './components/back-link.js'

--- a/core/wallet-ui-components/src/index.ts
+++ b/core/wallet-ui-components/src/index.ts
@@ -3,7 +3,7 @@
 
 export * from './components/api-key-card.js'
 export * from './components/api-key-form.js'
-export * from './components/auth-editor.js'
+export * from './components/auth-editor.js' // TODO should I expose that, or should it just be "private" for network-form?
 export * from './components/app-header.js'
 export * from './components/app-layout.js'
 export * from './components/back-link.js'

--- a/wallet-gateway/remote/src/user-api/controller.ts
+++ b/wallet-gateway/remote/src/user-api/controller.ts
@@ -117,6 +117,9 @@ export const userController = (
             const adminAuth = network.adminAuth
                 ? authSchema.parse(network.adminAuth)
                 : undefined
+            const serviceAccountAuth = network.serviceAccountAuth
+                ? authSchema.parse(network.serviceAccountAuth)
+                : undefined
 
             const newNetwork: Network = {
                 name: network.name,
@@ -126,6 +129,7 @@ export const userController = (
                 identityProviderId: network.identityProviderId,
                 auth,
                 adminAuth,
+                serviceAccountAuth,
                 ledgerApi,
             }
 
@@ -1169,6 +1173,9 @@ function toNetworkDto(network: Network): ApiNetwork {
         auth: toAuthDto(network.auth),
         ...(network.adminAuth
             ? { adminAuth: toAuthDto(network.adminAuth) }
+            : {}),
+        ...(network.serviceAccountAuth
+            ? { serviceAccountAuth: toAuthDto(network.serviceAccountAuth) }
             : {}),
     }
 }

--- a/wallet-gateway/remote/src/web/frontend/networks/add/index.test.ts
+++ b/wallet-gateway/remote/src/web/frontend/networks/add/index.test.ts
@@ -6,7 +6,7 @@ import { fixture, waitUntil } from '@open-wc/testing-helpers'
 import { html } from 'lit'
 import {
     createMockUserClient,
-    makeStoreNetwork,
+    makeNetwork,
     mockNetworksPageFlow,
     mockRequest,
     networkEditSaveEvent,
@@ -116,7 +116,7 @@ describe('UserUiAddNetwork', () => {
     })
 
     it('includes synchronizerId and adminAuth when saving a network', async () => {
-        const network = makeStoreNetwork({
+        const network = makeNetwork({
             synchronizerId: 'sync::123',
             adminAuth: {
                 method: 'client_credentials',
@@ -143,39 +143,6 @@ describe('UserUiAddNetwork', () => {
                     adminAuth: expect.objectContaining({
                         clientId: 'admin-client',
                     }),
-                }),
-            },
-        })
-    })
-
-    it('uses default adminAuth when adminAuth is omitted', async () => {
-        const network = makeStoreNetwork()
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { adminAuth: _adminAuth, ...networkWithoutAdmin } = network
-
-        el.shadowRoot
-            ?.querySelector('network-form')
-            ?.dispatchEvent(
-                networkEditSaveEventFrom(
-                    networkWithoutAdmin as ReturnType<typeof makeStoreNetwork>
-                )
-            )
-
-        await waitUntil(() =>
-            mockRequest.mock.calls.some((c) => c[0]?.method === 'addNetwork')
-        )
-
-        expect(mockRequest).toHaveBeenCalledWith({
-            method: 'addNetwork',
-            params: {
-                network: expect.objectContaining({
-                    adminAuth: {
-                        method: 'client_credentials',
-                        audience: '',
-                        scope: '',
-                        clientId: '',
-                        clientSecret: '',
-                    },
                 }),
             },
         })

--- a/wallet-gateway/remote/src/web/frontend/networks/add/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/networks/add/index.ts
@@ -11,8 +11,6 @@ import {
     toRelHref,
     toRelPath,
 } from '@canton-network/core-wallet-ui-components'
-import { Auth as ApiAuth } from '@canton-network/core-wallet-user-rpc-client'
-import { Auth } from '@canton-network/core-wallet-auth'
 import { createUserClient } from '../../rpc-client'
 import { setLocationHref } from '../../navigation.js'
 import { stateManager } from '../../state-manager'
@@ -49,33 +47,10 @@ export class UserUiAddNetwork extends BaseElement {
         setLocationHref(toRelHref('/networks'))
     }
 
-    private toApiAuth(auth: Auth): ApiAuth {
-        return {
-            method: auth.method,
-            audience: auth.audience ?? '',
-            scope: auth.scope ?? '',
-            clientId: auth.clientId ?? '',
-            issuer: (auth as ApiAuth).issuer ?? '',
-            clientSecret: (auth as ApiAuth).clientSecret ?? '',
-        }
-    }
-
     private async onSave(e: NetworkEditSaveEvent) {
         this.loading = true
 
-        const auth = this.toApiAuth(e.network.auth)
-        const adminAuth = e.network.adminAuth
-            ? this.toApiAuth(e.network.adminAuth)
-            : {
-                  method: 'client_credentials',
-                  audience: '',
-                  scope: '',
-                  clientId: '',
-                  clientSecret: '',
-              }
-        const serviceAccountAuth = e.network.serviceAccountAuth
-            ? this.toApiAuth(e.network.serviceAccountAuth)
-            : undefined
+        const { auth, adminAuth, serviceAccountAuth } = e.network
 
         try {
             const userClient = await createUserClient(
@@ -94,7 +69,7 @@ export class UserUiAddNetwork extends BaseElement {
                         }),
                         ledgerApi: e.network.ledgerApi,
                         auth,
-                        adminAuth,
+                        ...(adminAuth && { adminAuth }),
                         ...(serviceAccountAuth && { serviceAccountAuth }),
                     },
                 },

--- a/wallet-gateway/remote/src/web/frontend/networks/add/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/networks/add/index.ts
@@ -89,7 +89,7 @@ export class UserUiAddNetwork extends BaseElement {
                         ...(e.network.synchronizerId && {
                             synchronizerId: e.network.synchronizerId as string,
                         }),
-                        ledgerApi: e.network.ledgerApi.baseUrl,
+                        ledgerApi: e.network.ledgerApi,
                         auth,
                         adminAuth,
                     },

--- a/wallet-gateway/remote/src/web/frontend/networks/add/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/networks/add/index.ts
@@ -73,6 +73,9 @@ export class UserUiAddNetwork extends BaseElement {
                   clientId: '',
                   clientSecret: '',
               }
+        const serviceAccountAuth = e.network.serviceAccountAuth
+            ? this.toApiAuth(e.network.serviceAccountAuth)
+            : undefined
 
         try {
             const userClient = await createUserClient(
@@ -92,6 +95,7 @@ export class UserUiAddNetwork extends BaseElement {
                         ledgerApi: e.network.ledgerApi,
                         auth,
                         adminAuth,
+                        ...(serviceAccountAuth && { serviceAccountAuth }),
                     },
                 },
             })

--- a/wallet-gateway/remote/src/web/frontend/networks/review/index.test.ts
+++ b/wallet-gateway/remote/src/web/frontend/networks/review/index.test.ts
@@ -8,7 +8,6 @@ import { NetworkEditCancelEvent } from '@canton-network/core-wallet-ui-component
 import {
     createMockUserClient,
     makeNetwork,
-    makeStoreNetwork,
     mockReviewNetworkFlow,
     mockRequest,
     networkDeleteEvent,
@@ -278,7 +277,7 @@ describe('UserUiReviewNetwork', () => {
     it('includes synchronizerId and adminAuth when saving a network', async () => {
         await waitUntil(() => el.network !== null)
 
-        const storeNetwork = makeStoreNetwork({
+        const network = makeNetwork({
             id: 'net-review',
             name: 'Review Net',
             synchronizerId: 'sync::456',
@@ -293,7 +292,7 @@ describe('UserUiReviewNetwork', () => {
 
         el.shadowRoot
             ?.querySelector('network-form')
-            ?.dispatchEvent(networkEditSaveEventFrom(storeNetwork))
+            ?.dispatchEvent(networkEditSaveEventFrom(network))
 
         await waitUntil(() =>
             mockRequest.mock.calls.some((c) => c[0]?.method === 'addNetwork')

--- a/wallet-gateway/remote/src/web/frontend/networks/review/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/networks/review/index.ts
@@ -123,7 +123,7 @@ export class UserUiReviewNetwork extends BaseElement {
                         ...(e.network.synchronizerId && {
                             synchronizerId: e.network.synchronizerId as string,
                         }),
-                        ledgerApi: e.network.ledgerApi.baseUrl,
+                        ledgerApi: e.network.ledgerApi,
                         auth,
                         adminAuth,
                     },

--- a/wallet-gateway/remote/src/web/frontend/networks/review/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/networks/review/index.ts
@@ -12,11 +12,7 @@ import {
     toRelHref,
     toRelPath,
 } from '@canton-network/core-wallet-ui-components'
-import {
-    Auth as ApiAuth,
-    Network,
-} from '@canton-network/core-wallet-user-rpc-client'
-import { Auth } from '@canton-network/core-wallet-auth'
+import { Network } from '@canton-network/core-wallet-user-rpc-client'
 import { createUserClient } from '../../rpc-client'
 import { setLocationHref } from '../../navigation.js'
 import { stateManager } from '../../state-manager'
@@ -85,31 +81,8 @@ export class UserUiReviewNetwork extends BaseElement {
         setLocationHref(toRelHref('/networks'))
     }
 
-    private toApiAuth(auth: Auth): ApiAuth {
-        return {
-            method: auth.method,
-            audience: auth.audience ?? '',
-            scope: auth.scope ?? '',
-            clientId: auth.clientId ?? '',
-            issuer: (auth as ApiAuth).issuer ?? '',
-            clientSecret: (auth as ApiAuth).clientSecret ?? '',
-        }
-    }
-
     private async onSave(e: NetworkEditSaveEvent) {
-        const auth = this.toApiAuth(e.network.auth)
-        const adminAuth = e.network.adminAuth
-            ? this.toApiAuth(e.network.adminAuth)
-            : {
-                  method: 'client_credentials',
-                  audience: '',
-                  scope: '',
-                  clientId: '',
-                  clientSecret: '',
-              }
-        const serviceAccountAuth = e.network.serviceAccountAuth
-            ? this.toApiAuth(e.network.serviceAccountAuth)
-            : undefined
+        const { auth, adminAuth, serviceAccountAuth } = e.network
 
         try {
             const userClient = await createUserClient(
@@ -128,7 +101,7 @@ export class UserUiReviewNetwork extends BaseElement {
                         }),
                         ledgerApi: e.network.ledgerApi,
                         auth,
-                        adminAuth,
+                        ...(adminAuth && { adminAuth }),
                         ...(serviceAccountAuth && { serviceAccountAuth }),
                     },
                 },

--- a/wallet-gateway/remote/src/web/frontend/networks/review/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/networks/review/index.ts
@@ -107,6 +107,9 @@ export class UserUiReviewNetwork extends BaseElement {
                   clientId: '',
                   clientSecret: '',
               }
+        const serviceAccountAuth = e.network.serviceAccountAuth
+            ? this.toApiAuth(e.network.serviceAccountAuth)
+            : undefined
 
         try {
             const userClient = await createUserClient(
@@ -126,6 +129,7 @@ export class UserUiReviewNetwork extends BaseElement {
                         ledgerApi: e.network.ledgerApi,
                         auth,
                         adminAuth,
+                        ...(serviceAccountAuth && { serviceAccountAuth }),
                     },
                 },
             })

--- a/wallet-gateway/remote/src/web/frontend/settings/index.test.ts
+++ b/wallet-gateway/remote/src/web/frontend/settings/index.test.ts
@@ -12,7 +12,7 @@ import {
 import {
     createMockUserClient,
     makeIdp,
-    makeStoreNetwork,
+    makeNetwork,
     toPublicNetwork,
     mockRequest,
     mockSettingsPageFlow,
@@ -141,7 +141,7 @@ describe('UserUiSettings', () => {
     })
 
     it('adds a network when wg-networks emits network-edit-save', async () => {
-        const network = makeStoreNetwork({
+        const network = makeNetwork({
             id: 'net-new',
             synchronizerId: 'sync-1',
             adminAuth: {
@@ -178,55 +178,6 @@ describe('UserUiSettings', () => {
         )
     })
 
-    it('adds a network when auth fields are partially omitted', async () => {
-        const network = makeStoreNetwork({
-            auth: { method: 'client_credentials' } as ReturnType<
-                typeof makeStoreNetwork
-            >['auth'],
-        })
-
-        el.shadowRoot
-            ?.querySelector('wg-networks')
-            ?.dispatchEvent(networkEditSaveEventFrom(network))
-
-        await waitUntil(() =>
-            mockRequest.mock.calls.some((c) => c[0]?.method === 'addNetwork')
-        )
-
-        const addCall = mockRequest.mock.calls.find(
-            (c) => c[0]?.method === 'addNetwork'
-        )
-        expect(addCall?.[0].params.network.auth).toEqual({
-            method: 'client_credentials',
-            audience: '',
-            scope: '',
-            clientId: '',
-            issuer: '',
-            clientSecret: '',
-        })
-    })
-
-    it('adds a network without adminAuth using default credentials', async () => {
-        el.shadowRoot
-            ?.querySelector('wg-networks')
-            ?.dispatchEvent(networkEditSaveEvent())
-
-        await waitUntil(() =>
-            mockRequest.mock.calls.some((c) => c[0]?.method === 'addNetwork')
-        )
-
-        const addCall = mockRequest.mock.calls.find(
-            (c) => c[0]?.method === 'addNetwork'
-        )
-        expect(addCall?.[0].params.network.adminAuth).toEqual({
-            method: 'client_credentials',
-            audience: '',
-            scope: '',
-            clientId: '',
-            clientSecret: '',
-        })
-    })
-
     it('calls handleErrorToast when adding a network fails', async () => {
         mockRequest.mockImplementation(async ({ method }) => {
             if (method === 'addNetwork') {
@@ -257,7 +208,7 @@ describe('UserUiSettings', () => {
     })
 
     it('removes a network when delete is confirmed', async () => {
-        const network = makeStoreNetwork({ id: 'net-del', name: 'Remove Me' })
+        const network = makeNetwork({ id: 'net-del', name: 'Remove Me' })
         el.shadowRoot
             ?.querySelector('wg-networks')
             ?.dispatchEvent(
@@ -289,7 +240,7 @@ describe('UserUiSettings', () => {
             ?.dispatchEvent(
                 new NetworkCardDeleteEvent(
                     toPublicNetwork(
-                        makeStoreNetwork({ id: 'net-del', name: 'Keep Me' })
+                        makeNetwork({ id: 'net-del', name: 'Keep Me' })
                     )
                 )
             )
@@ -325,7 +276,7 @@ describe('UserUiSettings', () => {
             ?.querySelector('wg-networks')
             ?.dispatchEvent(
                 new NetworkCardDeleteEvent(
-                    toPublicNetwork(makeStoreNetwork({ id: 'net-del' }))
+                    toPublicNetwork(makeNetwork({ id: 'net-del' }))
                 )
             )
 

--- a/wallet-gateway/remote/src/web/frontend/settings/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/settings/index.ts
@@ -128,6 +128,9 @@ export class UserUiSettings extends BaseElement {
                   clientId: '',
                   clientSecret: '',
               }
+        const serviceAccountAuth = e.network.serviceAccountAuth
+            ? this.toApiAuth(e.network.serviceAccountAuth)
+            : undefined
 
         try {
             const userClient = await createUserClient(
@@ -147,6 +150,7 @@ export class UserUiSettings extends BaseElement {
                         ledgerApi: e.network.ledgerApi,
                         auth,
                         adminAuth,
+                        ...(serviceAccountAuth && { serviceAccountAuth }),
                     },
                 },
             })

--- a/wallet-gateway/remote/src/web/frontend/settings/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/settings/index.ts
@@ -144,7 +144,7 @@ export class UserUiSettings extends BaseElement {
                         ...(e.network.synchronizerId && {
                             synchronizerId: e.network.synchronizerId as string,
                         }),
-                        ledgerApi: e.network.ledgerApi.baseUrl,
+                        ledgerApi: e.network.ledgerApi,
                         auth,
                         adminAuth,
                     },

--- a/wallet-gateway/remote/src/web/frontend/settings/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/settings/index.ts
@@ -18,14 +18,12 @@ import {
     PublicNetwork,
     Session,
     Idp,
-    Auth as ApiAuth,
 } from '@canton-network/core-wallet-user-rpc-client'
 import UserApiClient from '@canton-network/core-wallet-user-rpc-client'
 
 import '../index'
 import { stateManager } from '../state-manager'
 import { createUserClient } from '../rpc-client'
-import { Auth } from '@canton-network/core-wallet-auth'
 import { UserLevelRight } from '@canton-network/core-wallet-store'
 
 @customElement('user-ui-settings')
@@ -104,33 +102,10 @@ export class UserUiSettings extends BaseElement {
         this.idps = response.idps
     }
 
-    private toApiAuth(auth: Auth): ApiAuth {
-        return {
-            method: auth.method,
-            audience: auth.audience ?? '',
-            scope: auth.scope ?? '',
-            clientId: auth.clientId ?? '',
-            issuer: (auth as ApiAuth).issuer ?? '',
-            clientSecret: (auth as ApiAuth).clientSecret ?? '',
-        }
-    }
-
     private handleNetworkSubmit = async (e: NetworkEditSaveEvent) => {
         e.preventDefault()
 
-        const auth = this.toApiAuth(e.network.auth)
-        const adminAuth = e.network.adminAuth
-            ? this.toApiAuth(e.network.adminAuth)
-            : {
-                  method: 'client_credentials',
-                  audience: '',
-                  scope: '',
-                  clientId: '',
-                  clientSecret: '',
-              }
-        const serviceAccountAuth = e.network.serviceAccountAuth
-            ? this.toApiAuth(e.network.serviceAccountAuth)
-            : undefined
+        const { auth, adminAuth, serviceAccountAuth } = e.network
 
         try {
             const userClient = await createUserClient(
@@ -149,7 +124,7 @@ export class UserUiSettings extends BaseElement {
                         }),
                         ledgerApi: e.network.ledgerApi,
                         auth,
-                        adminAuth,
+                        ...(adminAuth && { adminAuth }),
                         ...(serviceAccountAuth && { serviceAccountAuth }),
                     },
                 },

--- a/wallet-gateway/remote/src/web/frontend/test-helpers.ts
+++ b/wallet-gateway/remote/src/web/frontend/test-helpers.ts
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { vi } from 'vitest'
-import type { Network as StoreNetwork } from '@canton-network/core-wallet-store'
 import {
     NetworkDeleteEvent,
     NetworkEditSaveEvent,
-    type NetworkFormData,
 } from '@canton-network/core-wallet-ui-components'
 import type {
     Idp,
@@ -110,66 +108,35 @@ function withoutUndefinedKeys<T extends object>(value: Partial<T>): Partial<T> {
     ) as Partial<T>
 }
 
-export function makeStoreNetwork(
-    overrides: Partial<StoreNetwork> = {}
-): StoreNetwork {
-    return {
-        id: 'net-1',
-        name: 'Test Network',
-        description: 'Test network description',
-        identityProviderId: 'idp-1',
-        ledgerApi: { baseUrl: 'http://localhost:6865' },
-        auth: {
-            method: 'client_credentials',
-            audience: 'audience',
-            scope: 'scope',
-            clientId: 'client-id',
-            clientSecret: 'client-secret',
-        },
-        ...withoutUndefinedKeys(overrides),
-    } as StoreNetwork
-}
-
-function toFormNetwork(network: StoreNetwork): NetworkFormData {
-    return {
-        ...network,
-        ledgerApi: network.ledgerApi.baseUrl,
-    } as NetworkFormData
-}
-
 export function networkEditSaveEvent(
-    overrides: Partial<StoreNetwork> = {}
+    overrides: Partial<Network> = {}
 ): NetworkEditSaveEvent {
-    return new NetworkEditSaveEvent(toFormNetwork(makeStoreNetwork(overrides)))
+    return new NetworkEditSaveEvent(
+        makeNetwork(withoutUndefinedKeys(overrides))
+    )
 }
 
 export function networkEditSaveEventFrom(
-    network: StoreNetwork
+    network: Network
 ): NetworkEditSaveEvent {
-    return new NetworkEditSaveEvent(toFormNetwork(network))
+    return new NetworkEditSaveEvent(network)
 }
 
 export function networkDeleteEvent(
-    overrides: Partial<StoreNetwork> = {}
+    overrides: Partial<Network> = {}
 ): NetworkDeleteEvent {
-    return new NetworkDeleteEvent(toFormNetwork(makeStoreNetwork(overrides)))
+    return new NetworkDeleteEvent(makeNetwork(withoutUndefinedKeys(overrides)))
 }
 
-export function toPublicNetwork(
-    network: StoreNetwork | Network
-): PublicNetwork {
+export function toPublicNetwork(network: Network): PublicNetwork {
     const auth = network.auth
-    const ledgerApi =
-        typeof network.ledgerApi === 'string'
-            ? network.ledgerApi
-            : network.ledgerApi.baseUrl
 
     return {
         id: network.id,
         name: network.name,
         description: network.description,
         identityProviderId: network.identityProviderId,
-        ledgerApi,
+        ledgerApi: network.ledgerApi,
         authMethod: auth.method,
         ...(network.synchronizerId !== undefined && {
             synchronizerId: network.synchronizerId,

--- a/wallet-gateway/remote/src/web/frontend/test-helpers.ts
+++ b/wallet-gateway/remote/src/web/frontend/test-helpers.ts
@@ -6,6 +6,7 @@ import type { Network as StoreNetwork } from '@canton-network/core-wallet-store'
 import {
     NetworkDeleteEvent,
     NetworkEditSaveEvent,
+    type NetworkFormData,
 } from '@canton-network/core-wallet-ui-components'
 import type {
     Idp,
@@ -129,8 +130,11 @@ export function makeStoreNetwork(
     } as StoreNetwork
 }
 
-function toFormNetwork(network: object): StoreNetwork {
-    return network as unknown as StoreNetwork
+function toFormNetwork(network: StoreNetwork): NetworkFormData {
+    return {
+        ...network,
+        ledgerApi: network.ledgerApi.baseUrl,
+    } as NetworkFormData
 }
 
 export function networkEditSaveEvent(


### PR DESCRIPTION
Closes: https://github.com/canton-network/wallet/pull/2077
Added serviceAccountAuth inputs and handled it in user api. 

Closes: https://github.com/canton-network/wallet/issues/2066
Fixed issues on network page:
-Add network not displaying auth inputs, making it impossible to add an network
-`adminAuth` inputs never displaying
-Existing network ledgerApi not displaying in the input and impossible to edit

Refactored network page with following changes to auth fields:
-Created reusable auth editor component and used it for auth, adminAuth and serviceAccountAuth
-Optional auths now start in readonly mode, you can add, edit it or delete it, or restore state before remove or edit
-Required auth renders inputs always as it was before
-`clientSecret` now won't show in the input. Instead if secret is set show asterisks and info that secret is hidden, otherwise just empty input with required
-Reduce conversions between network shapes used by api and store - rely almost entirely on api shape, with only exception of using zod validation from store, where ledger api shape is changed from `string` to `{ baseUrl: string }`
-Removed UI setting `adminAuth` to default but empty state with only `method`, instead user have control over it existing or not. It will result in errors 'No admin auth configured' when executing action possible only with `adminAuth` instead of more cryptic errors because of lack of other properties, especially that it was impossible to edit `adminAuth` with UI


<img width="376" height="429" alt="image" src="https://github.com/user-attachments/assets/c9ab4411-f8f9-4a50-b1c5-c0bf6e1e0627" />
<img width="376" height="241" alt="image" src="https://github.com/user-attachments/assets/d71693a3-33fb-4a37-874e-7d66cf0e6375" />
<img width="365" height="113" alt="image" src="https://github.com/user-attachments/assets/c67d1a69-f296-4f6b-a927-ee34db6b80f3" />
<img width="372" height="165" alt="image" src="https://github.com/user-attachments/assets/dd85988d-05c7-4d57-b598-2309d6af8b9c" />
