### PR TITLE
fix: stop streaming SSE after wg logout

### DIFF
--- a/wallet-gateway/remote/src/dapp-api/server.ts
+++ b/wallet-gateway/remote/src/dapp-api/server.ts
@@ -84,11 +84,21 @@ export const dapp = (
             writeSSE(res, 'messageSignature', event)
         }
 
+        const onLogout = () => {
+            logger.info(
+                { userId: context.userId },
+                'Session terinated by server. Forcing SSE teardown.'
+            )
+            cleanup()
+            res.end()
+        }
+
         notifier.on('accountsChanged', onAccountsChanged)
         notifier.on('connected', onConnected)
         notifier.on('statusChanged', onStatusChanged)
         notifier.on('txChanged', onTxChanged)
         notifier.on('messageSignature', onMessageSignature)
+        notifier.on('logout', onLogout)
 
         const cleanup = () => {
             logger.debug('SSE client disconnected')
@@ -97,6 +107,7 @@ export const dapp = (
             notifier.removeListener('statusChanged', onStatusChanged)
             notifier.removeListener('txChanged', onTxChanged)
             notifier.removeListener('messageSignature', onMessageSignature)
+            notifier.removeListener('logout', onLogout)
         }
 
         req.on('close', cleanup)

--- a/wallet-gateway/remote/src/user-api/controller.ts
+++ b/wallet-gateway/remote/src/user-api/controller.ts
@@ -825,6 +825,7 @@ export const userController = (
                 session: undefined,
                 userUrl: `${userUrl}/login/`,
             })
+            notifier.emit('logout')
 
             return null
         },


### PR DESCRIPTION
Related to https://github.com/canton-network/wallet-support/issues/22

This PR finalizes the http transmission and forces a re-shake when a user logs out of the wallet gateway. Tested using postman to subscribe to `http://localhost:3030/api/v0/dapp/events` and connected to the wallet gateway through the example dApp. While still connected via postman, I logged out of the wallet gateway (confirmed that I received the `Connection closed` in postman and re-authenticated to the WG through the example dApp and did not receive further SSE. 

Previously, when I would log out of the wallet-gateway and re-authenticated through the example dApp, I would keep getting SSE in postman, which included leaking new accessTokens. 


Here is a screen recording of the fix (to ensure that the events stopped streaming after logout):

https://github.com/user-attachments/assets/49431b0a-a827-45f9-9007-c70f284341c0

And here is a repro of the original error from the original code (events streaming to the same connection even after logging out)

https://github.com/user-attachments/assets/c6658989-95bd-49a1-b13b-0433a1160312

