### PR TITLE
fix: dfns execute tx

### DIFF
--- a/docs/dapp-building/wallet-gateway/signing-providers/index.md
+++ b/docs/dapp-building/wallet-gateway/signing-providers/index.md
@@ -109,10 +109,6 @@ Set the following environment variables:
 - Multi-party approval workflows
 - High-security production environments
 
-**How it Works:**
-
-When a transaction is submitted, the Gateway forwards the command to Dfns's participant node, which signs it using the party's key stored in the participant's keystore.
-
 ## Selecting a Provider
 
 When creating a new party through the User API or web UI, you can select which signing provider to use. The choice depends on your security requirements, infrastructure setup, and compliance needs.

--- a/docs/dapp-building/wallet-gateway/signing-providers/index.md
+++ b/docs/dapp-building/wallet-gateway/signing-providers/index.md
@@ -111,7 +111,7 @@ Set the following environment variables:
 
 **How it Works:**
 
-Dfns creates and activates Canton wallets directly through its validator integration. When the Gateway requests a wallet, Dfns provisions a Canton-formatted key, registers the party on the network, and returns the wallet ready for use. When signing a prepared transaction, Dfns broadcasts it to Canton in a single step and returns the resulting update ID. Only `Canton` and `CantonTestnet` network wallets are supported.
+When a transaction is submitted, the Gateway forwards the command to Dfns's participant node, which signs it using the party's key stored in the participant's keystore.
 
 ## Selecting a Provider
 

--- a/wallet-gateway/remote/README.md
+++ b/wallet-gateway/remote/README.md
@@ -55,7 +55,7 @@ The JSON-RPC API specs from `api-specs/` are generated into strongly-typed metho
     - `DFNS_PRIVATE_KEY` — service account private key (PEM)
     - `DFNS_AUTH_TOKEN` — service account auth token
 
-Dfns provisions and activates Canton wallets through its validator integration, so no additional Gateway configuration is required. Only `Canton` and `CantonTestnet` network wallets are supported. See [`@canton-network/core-signing-dfns`](../../core/signing-dfns/README.md) for full driver details.
+Dfns is configured as an external signing provider. The Gateway uses Dfns for key/signature operations, transaction execution follows the standard Gateway execute flow. See [`@canton-network/core-signing-dfns`](../../core/signing-dfns/README.md) for full driver details.
 
 ## Fireblocks
 

--- a/wallet-gateway/remote/README.md
+++ b/wallet-gateway/remote/README.md
@@ -55,13 +55,20 @@ The JSON-RPC API specs from `api-specs/` are generated into strongly-typed metho
     - `DFNS_PRIVATE_KEY` — service account private key (PEM)
     - `DFNS_AUTH_TOKEN` — service account auth token
 
-Dfns is configured as an external signing provider. The Gateway uses Dfns for key/signature operations, transaction execution follows the standard Gateway execute flow. See [`@canton-network/core-signing-dfns`](../../core/signing-dfns/README.md) for full driver details.
-
 ## Fireblocks
 
 1. Complete steps 1–3 from the instructions at https://github.com/canton-network/wallet/tree/main/core/signing-fireblocks
 
 2. set the environment variable `FIREBLOCKS_API_KEY` (get it from `API User (ID)` column in fireblocks api users table).
+
+# Blockdaemon
+
+1. Create a system user in the Blockdaemon dashboard and save the API key displayed after successful creation.
+
+2. set the environment variables
+
+- `BLOCKDAEMON_API_URL` - The base URL for the Blockdaemon API
+- `BLOCKDAEMON_API_KEY` - Your Blockdaemon API key
 
 ## Postgres connection
 

--- a/wallet-gateway/remote/src/ledger/transaction-service.test.ts
+++ b/wallet-gateway/remote/src/ledger/transaction-service.test.ts
@@ -426,11 +426,11 @@ describe('TransactionService', () => {
         })
 
         describe('dfns', () => {
-            it('persists the update id as the signature when signing completes', async () => {
+            it('returns the driver signature when signing completes', async () => {
                 const signTransaction = vi.fn().mockResolvedValue({
                     status: 'signed',
                     txId: 'dfns-tx-1',
-                    signature: 'update-id-123',
+                    signature: 'dfns-signature',
                 })
                 const store = createStore()
                 const service = createService(
@@ -452,7 +452,7 @@ describe('TransactionService', () => {
 
                 expect(result).toEqual({
                     status: 'signed',
-                    signature: 'update-id-123',
+                    signature: 'dfns-signature',
                     signedBy: wallet.namespace,
                     partyId: wallet.partyId,
                     externalTxId: 'dfns-tx-1',
@@ -462,54 +462,6 @@ describe('TransactionService', () => {
     })
 
     describe('execute', () => {
-        describe('dfns', () => {
-            it('marks the transaction executed using the external tx id', async () => {
-                const signedTransaction: Transaction = {
-                    ...pendingTransaction,
-                    status: 'signed',
-                    externalTxId: 'dfns-update-id',
-                }
-                const store = createStore(signedTransaction)
-                const service = createService(store, {}, notifier, logger)
-
-                const result = await service.execute(
-                    authContext.userId,
-                    walletWithProvider(SigningProvider.DFNS),
-                    signedTransaction
-                )
-
-                expect(store.setTransactionStatus).toHaveBeenCalledWith(
-                    signedTransaction.id,
-                    'executed',
-                    { externalTxId: 'dfns-update-id' }
-                )
-                expect(emit).toHaveBeenCalledWith(
-                    'txChanged',
-                    expect.objectContaining({ status: 'executed' })
-                )
-                expect(result).toEqual({ updateId: 'dfns-update-id' })
-            })
-
-            it('throws when the transaction has no external tx id', async () => {
-                const service = createService(
-                    createStore(),
-                    {},
-                    notifier,
-                    logger
-                )
-
-                await expect(
-                    service.execute(
-                        authContext.userId,
-                        walletWithProvider(SigningProvider.DFNS),
-                        pendingTransaction
-                    )
-                ).rejects.toThrow(
-                    'Cannot execute Dfns transaction without externalTxId from Dfns'
-                )
-            })
-        })
-
         describe('participant', () => {
             it('submits the prepared transaction to the ledger', async () => {
                 const participantWallet = walletWithProvider(
@@ -559,52 +511,60 @@ describe('TransactionService', () => {
         })
 
         describe('external signing providers', () => {
-            it('executes the prepared transaction with the provided signature', async () => {
-                const signedTransaction = {
-                    ...pendingTransaction,
-                    status: 'signed' as const,
+            it.each([
+                SigningProvider.WALLET_KERNEL,
+                SigningProvider.BLOCKDAEMON,
+                SigningProvider.FIREBLOCKS,
+                SigningProvider.DFNS,
+            ])(
+                'executes with the provided signature for %s',
+                async (signingProviderId) => {
+                    const signedTransaction = {
+                        ...pendingTransaction,
+                        status: 'signed' as const,
+                    }
+                    const store = createStore(signedTransaction)
+                    const postWithRetry = vi
+                        .fn()
+                        .mockResolvedValue({ updateId: 'external-update-1' })
+                    const ledgerClient = {
+                        postWithRetry,
+                    } as unknown as LedgerClient
+                    const service = createService(store, {}, notifier, logger)
+
+                    const result = await service.execute(
+                        authContext.userId,
+                        walletWithProvider(signingProviderId),
+                        signedTransaction,
+                        executeParams,
+                        ledgerClient,
+                        network
+                    )
+
+                    expect(postWithRetry).toHaveBeenCalledWith(
+                        '/v2/interactive-submission/executeAndWait',
+                        expect.objectContaining({
+                            userId: authContext.userId,
+                            preparedTransaction:
+                                pendingTransaction.preparedTransaction,
+                            submissionId: pendingTransaction.commandId,
+                            partySignatures: expect.objectContaining({
+                                signatures: [
+                                    expect.objectContaining({
+                                        party: wallet.partyId,
+                                    }),
+                                ],
+                            }),
+                        })
+                    )
+                    expect(store.setTransactionStatus).toHaveBeenCalledWith(
+                        pendingTransaction.id,
+                        'executed',
+                        { payload: { updateId: 'external-update-1' } }
+                    )
+                    expect(result).toEqual({ updateId: 'external-update-1' })
                 }
-                const store = createStore(signedTransaction)
-                const postWithRetry = vi
-                    .fn()
-                    .mockResolvedValue({ updateId: 'external-update-1' })
-                const ledgerClient = {
-                    postWithRetry,
-                } as unknown as LedgerClient
-                const service = createService(store, {}, notifier, logger)
-
-                const result = await service.execute(
-                    authContext.userId,
-                    wallet,
-                    signedTransaction,
-                    executeParams,
-                    ledgerClient,
-                    network
-                )
-
-                expect(postWithRetry).toHaveBeenCalledWith(
-                    '/v2/interactive-submission/executeAndWait',
-                    expect.objectContaining({
-                        userId: authContext.userId,
-                        preparedTransaction:
-                            pendingTransaction.preparedTransaction,
-                        submissionId: pendingTransaction.commandId,
-                        partySignatures: expect.objectContaining({
-                            signatures: [
-                                expect.objectContaining({
-                                    party: wallet.partyId,
-                                }),
-                            ],
-                        }),
-                    })
-                )
-                expect(store.setTransactionStatus).toHaveBeenCalledWith(
-                    pendingTransaction.id,
-                    'executed',
-                    { payload: { updateId: 'external-update-1' } }
-                )
-                expect(result).toEqual({ updateId: 'external-update-1' })
-            })
+            )
         })
     })
 

--- a/wallet-gateway/remote/src/ledger/transaction-service.ts
+++ b/wallet-gateway/remote/src/ledger/transaction-service.ts
@@ -151,7 +151,8 @@ export class TransactionService {
             }
             case SigningProvider.WALLET_KERNEL:
             case SigningProvider.BLOCKDAEMON:
-            case SigningProvider.FIREBLOCKS: {
+            case SigningProvider.FIREBLOCKS:
+            case SigningProvider.DFNS: {
                 if (!executeParams) {
                     throw new Error(
                         'Execute params are required for external signing'
@@ -168,9 +169,6 @@ export class TransactionService {
                     transaction,
                     ledgerClient
                 )
-            }
-            case SigningProvider.DFNS: {
-                return this.executeWithDfns(transaction)
             }
             default:
                 throw new Error(
@@ -555,12 +553,6 @@ export class TransactionService {
         }
     }
 
-    /**
-     * Dfns broadcasts the prepared transaction to Canton itself, so we get back
-     * an updateId rather than a raw signature. We persist the updateId as the
-     * signature payload (the controller short-circuits Dfns execute) and surface
-     * the same SignResult shape the other external providers use.
-     */
     private async signWithDfns(
         userId: UserId,
         wallet: Wallet,
@@ -608,7 +600,9 @@ export class TransactionService {
 
         if (signingResult.status === 'signed') {
             if (!signingResult.signature) {
-                throw new Error('No updateId returned from Dfns')
+                throw new Error(
+                    'No signature returned from Dfns signing driver'
+                )
             }
 
             const signedTx: Transaction = {
@@ -666,43 +660,6 @@ export class TransactionService {
                 partyId: wallet.partyId,
             }
         }
-    }
-
-    /**
-     * Dfns has already broadcast the transaction at sign-time, so execute is a
-     * state reconciliation: mark the stored transaction as executed and return
-     * the updateId Dfns gave us. We deliberately don't post to the ledger here.
-     */
-    private async executeWithDfns(
-        transaction: Transaction
-    ): Promise<ExecuteResult> {
-        if (!transaction.externalTxId) {
-            throw new Error(
-                'Cannot execute Dfns transaction without externalTxId from Dfns'
-            )
-        }
-
-        const executedTx: Transaction = {
-            id: transaction.id,
-            commandId: transaction.commandId,
-            status: 'executed',
-            preparedTransaction: transaction.preparedTransaction,
-            preparedTransactionHash: transaction.preparedTransactionHash,
-            origin: transaction.origin ?? null,
-            ...(transaction.createdAt && {
-                createdAt: transaction.createdAt,
-            }),
-            ...(transaction.signedAt && {
-                signedAt: transaction.signedAt,
-            }),
-            externalTxId: transaction.externalTxId,
-        }
-        await this.store.setTransactionStatus(transaction.id, 'executed', {
-            externalTxId: transaction.externalTxId,
-        })
-        this.notifier.emit('txChanged', executedTx)
-
-        return { updateId: transaction.externalTxId }
     }
 
     private async executeWithParticipant(

--- a/wallet-gateway/remote/src/signing/signing-worker.ts
+++ b/wallet-gateway/remote/src/signing/signing-worker.ts
@@ -55,8 +55,7 @@ export interface SigningWorkerOptions {
  *
  * - returns early while the provider still reports `pending` (worker logs and
  *   waits for the next tick), or
- * - calls `execute()` once signing is `signed` (Dfns is special: it broadcasts
- *   at sign-time, so execute only reconciles local state).
+ * - calls `execute()` once signing is `signed`.
  *
  * A transaction is re-read before processing so a concurrent DApp call or an
  * earlier tick that already completed it is skipped.


### PR DESCRIPTION
This aligns DFNS transaction execution with other signing providers and removes obsolete comments and updates signing providers docs to reflect current state.