### PR TITLE
fix(wallet-gateway-remote): ignore Vite timestamp files in tsx watch

### DIFF
--- a/wallet-gateway/remote/package.json
+++ b/wallet-gateway/remote/package.json
@@ -11,7 +11,7 @@
     "scripts": {
         "build": "vite build && tsc -b && tsc -b tsconfig.frontend.json",
         "clean": "tsc -b --clean && rm -rf ./dist && rm ./*.sqlite || true",
-        "dev": "NODE_ENV=development tsx watch src/index.ts -c ../test/config.json",
+        "dev": "NODE_ENV=development tsx watch --exclude 'vite.config.ts.timestamp-*.mjs' src/index.ts -c ../test/config.json",
         "test": "vitest run --project node --project browser",
         "test:coverage": "vitest run --project node --project browser --coverage",
         "start": "yarn node dist/index.js -c ../test/config.json",


### PR DESCRIPTION
Prevent tsx watch restart loop when Vite writes vite.config.ts.timestamp-*.mjs. Fixes #2092.

## Summary
- Exclude `vite.config.ts.timestamp-*.mjs` from `tsx watch` in the gateway `dev` script.
- Prevents `tsx` from restarting when Vite writes temporary config artifacts, which caused a restart loop and connection resets on `:3030`.
- Fixes #2092

## Test plan
- [x] `yarn start:all`
- [x] `curl http://localhost:3030/` returns 200
- [x] Gateway stays up; `yarn pm2 logs remote` shows no `vite.config.ts.timestamp` restart loop
- [x] Change is limited to the `dev` script; `start` / tests / build unchanged