### PR TITLE
chore: add community-contributed shell.nix

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,6 +10,8 @@
 - Yarn 4 (via Corepack)
 - Java (for Canton) - [sdkman](https://sdkman.io/install) is recommended for version management
 
+An unofficial, community-contributed [nix shell](./development/shell.nix) is available as well to provide these system dependencies.
+
 ### Environment
 
 1. Install [nvm](https://github.com/nvm-sh/nvm):

--- a/docs/development/shell.nix
+++ b/docs/development/shell.nix
@@ -9,19 +9,11 @@ let
   java = pkgs.openjdk;
 in
 pkgs.mkShell rec {
-  # Some of the scripting uses tsup, but we rely on nix instead to provision
-  # this, so replace it by a stub.
-  tsup = pkgs.writeShellScriptBin "tsup" ''
-    #!/usr/bin/env bash
-    exec true
-  '';
-
   buildInputs = [
     java
     pkgs.corepack # This provides yarn.
     pkgs.nodejs_24
     pkgs.typescript-language-server
-    tsup
   ];
 
   # nix-shell sets the $name environment variable.  This causes a "bug" in

--- a/docs/development/shell.nix
+++ b/docs/development/shell.nix
@@ -1,3 +1,7 @@
+# WARNING: This development environment is contributed by the community.
+# It is provided as a convenience and is not part of our build or CI
+# configuration. It can (and probably will) be broken many times in the future
+# as this repo evolves. Pull requests to keep it working are welcome.
 {
   pkgs ? import <nixpkgs> { },
 }:

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,30 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+let
+  java = pkgs.openjdk;
+in
+pkgs.mkShell rec {
+  # Some of the scripting uses tsup, but we rely on nix instead to provision
+  # this, so replace it by a stub.
+  tsup = pkgs.writeShellScriptBin "tsup" ''
+    #!/usr/bin/env bash
+    exec true
+  '';
+
+  buildInputs = [
+    java
+    pkgs.corepack # This provides yarn.
+    pkgs.nodejs_24
+    pkgs.typescript-language-server
+    tsup
+  ];
+
+  # nix-shell sets the $name environment variable.  This causes a "bug" in
+  # PM2 where all processes end up being named "nix-shell":
+  # <https://github.com/Unitech/pm2/issues/5747>.
+  # It should be safe to unset this.
+  shellHook = "unset name";
+
+  JAVA_HOME = "${java}";
+}


### PR DESCRIPTION
Some of the other folks in SDK were working on this repository recently and complained they were unfamiliar with setting up the TS tooling (`yarn`, `nx`, etc.).  This provides a simple `shell.nix` to make drive-by contributions a bit easier.