### PR TITLE
chore: fix allocation parsing and display

### DIFF
--- a/core/tx-parser/src/parser.test.ts
+++ b/core/tx-parser/src/parser.test.ts
@@ -217,4 +217,128 @@ describe('transaction parser', () => {
 
         expect(actual).toEqual(bobTransferObjectsExpected)
     })
+
+    it('preserves the transfer leg for an allocation reservation', async () => {
+        const partyId = 'bob::normalized'
+        const receiver = 'alice::normalized'
+        const transferLeg = {
+            sender: partyId,
+            receiver,
+            amount: '20.0000000000',
+            instrumentId: { admin: 'admin::normalized', id: 'Amulet' },
+            meta: { values: {} },
+        }
+        const choiceArgument = {
+            expectedAdmin: transferLeg.instrumentId.admin,
+            allocation: {
+                settlement: {
+                    executor: 'venue::normalized',
+                    settlementRef: { id: 'OTCTradeProposal', cid: 'trade-cid' },
+                    requestedAt: '2026-07-13T16:54:00Z',
+                    allocateBefore: '2026-07-13T17:54:00Z',
+                    settleBefore: '2026-07-13T18:54:00Z',
+                    meta: { values: {} },
+                },
+                transferLegId: 'leg1',
+                transferLeg,
+            },
+            requestedAt: '2026-07-13T16:53:45Z',
+            inputHoldingCids: ['input-cid'],
+            extraArgs: { context: { values: {} }, meta: { values: {} } },
+        }
+        const exerciseResult = {
+            output: {
+                tag: 'AllocationInstructionResult_Completed',
+                value: { allocationCid: 'allocation-cid' },
+            },
+            senderChangeCids: [],
+            meta: {
+                values: {
+                    'splice.lfdecentralizedtrust.org/sender': partyId,
+                    'splice.lfdecentralizedtrust.org/tx-kind': 'transfer',
+                },
+            },
+        }
+        const tx = {
+            updateId: 'allocation-update',
+            offset: 100,
+            recordTime: '2026-07-13T16:54:46Z',
+            synchronizerId: 'sync',
+            events: [
+                {
+                    ExercisedEvent: {
+                        offset: 100,
+                        nodeId: 0,
+                        contractId: 'factory-cid',
+                        templateId: 'pkg:Module:Factory',
+                        interfaceId:
+                            '#splice-api-token-allocation-instruction-v1:Splice.Api.Token.AllocationInstructionV1:AllocationFactory',
+                        choice: 'AllocationFactory_Allocate',
+                        choiceArgument,
+                        actingParties: [partyId],
+                        consuming: false,
+                        witnessParties: [partyId],
+                        lastDescendantNodeId: 1,
+                        exerciseResult,
+                        packageName: 'pkg',
+                        implementedInterfaces: [],
+                    },
+                },
+                {
+                    CreatedEvent: {
+                        offset: 100,
+                        nodeId: 1,
+                        contractId: 'locked-holding-cid',
+                        templateId: 'pkg:Module:LockedHolding',
+                        createArgument: {},
+                        createdEventBlob: '',
+                        interfaceViews: [
+                            {
+                                interfaceId:
+                                    '#splice-api-token-holding-v1:Splice.Api.Token.HoldingV1:Holding',
+                                viewStatus: {
+                                    code: 0,
+                                    message: '',
+                                    details: [],
+                                },
+                                viewValue: {
+                                    owner: partyId,
+                                    instrumentId: transferLeg.instrumentId,
+                                    amount: transferLeg.amount,
+                                    lock: {
+                                        holders: ['admin::normalized'],
+                                        expiresAt: '2026-07-13T18:54:00Z',
+                                        context: `allocation to ${receiver}`,
+                                    },
+                                    meta: { values: {} },
+                                },
+                                implementationPackageId: 'pkg',
+                            },
+                        ],
+                        witnessParties: [partyId],
+                        signatories: [partyId],
+                        observers: [],
+                        createdAt: '2026-07-13T16:54:46Z',
+                        packageName: 'pkg',
+                        representativePackageId: 'pkg',
+                        acsDelta: true,
+                    },
+                },
+            ],
+        } as unknown as JsTransaction
+
+        const parser = new TransactionParser(mockProvider, tx, partyId, false)
+        const parsed = await parser.parseTransaction()
+
+        expect(parsed.events).toHaveLength(1)
+        expect(parsed.events[0].label).toMatchObject({
+            type: 'MergeSplit',
+            tokenStandardChoice: {
+                name: 'AllocationFactory_Allocate',
+                choiceArgument: {
+                    allocation: { transferLeg },
+                },
+            },
+        })
+    })
 })

--- a/core/tx-parser/src/parser.ts
+++ b/core/tx-parser/src/parser.ts
@@ -448,7 +448,17 @@ export class TransactionParser {
         switch (exercise.choice) {
             case 'TransferRule_Transfer':
             case 'TransferFactory_Transfer':
+            case 'AllocationFactory_Allocate':
+            case 'Allocation_ExecuteTransfer':
                 result = await this.buildTransfer(exercise, tokenStandardChoice)
+                break
+            case 'Allocation_Withdraw':
+            case 'Allocation_Cancel':
+                result = await this.buildBasic(
+                    exercise,
+                    'Unlock',
+                    tokenStandardChoice
+                )
                 break
             case 'TransferInstruction_Accept':
             case 'TransferInstruction_Reject':

--- a/examples/portfolio/src/components/dashboard/allocation-action-dialog-content.tsx
+++ b/examples/portfolio/src/components/dashboard/allocation-action-dialog-content.tsx
@@ -234,6 +234,8 @@ function TransferLegCard({
 
     return (
         <Box
+            role="group"
+            aria-label={`Transfer leg ${index + 1}`}
             sx={{
                 border: '1px solid',
                 borderColor: 'divider',

--- a/examples/portfolio/src/components/dashboard/transaction-history-content.tsx
+++ b/examples/portfolio/src/components/dashboard/transaction-history-content.tsx
@@ -14,18 +14,18 @@ import {
     TableRow,
     Typography,
 } from '@mui/material'
-import type { Transaction } from '@canton-network/core-tx-parser'
 import { useInView } from 'react-intersection-observer'
 import { TransactionHistoryRow } from './transaction-history-row'
 import {
     getEmptyMessage,
     type TransactionFilter,
+    type TransactionHistoryEntry,
 } from './transaction-history-utils'
 
 interface TransactionHistoryContentProps {
     filter: TransactionFilter
     walletId: string
-    transactions: Transaction[]
+    entries: TransactionHistoryEntry[]
     totalLoadedTransactions: number
     isLoading: boolean
     isError: boolean
@@ -36,12 +36,12 @@ interface TransactionHistoryContentProps {
 }
 
 const TRANSACTION_HISTORY_COLUMNS = [
-    { id: 'type', label: 'Activity', width: '13%' },
+    { id: 'type', label: 'Activity', width: '18%' },
     { id: 'asset', label: 'Asset', width: '13%' },
     { id: 'amount', label: 'Amount', width: '13%' },
     { id: 'date', label: 'Date', width: '17%' },
     { id: 'update-id', label: 'Update ID', width: '22%' },
-    { id: 'counterparty', label: 'Counterparty', width: '22%' },
+    { id: 'counterparty', label: 'Counterparty', width: '17%' },
 ] as const
 
 const TRANSACTION_HISTORY_COLUMN_COUNT = TRANSACTION_HISTORY_COLUMNS.length
@@ -61,7 +61,7 @@ const headerCellSx = {
 export function TransactionHistoryContent({
     filter,
     walletId,
-    transactions,
+    entries,
     totalLoadedTransactions,
     isLoading,
     isError,
@@ -131,7 +131,7 @@ export function TransactionHistoryContent({
                 <TableBody>
                     {isLoading ? (
                         <TransactionHistorySkeletonRows />
-                    ) : transactions.length === 0 ? (
+                    ) : entries.length === 0 ? (
                         <TransactionHistoryMessageRow>
                             {getEmptyMessage({
                                 filter,
@@ -140,10 +140,10 @@ export function TransactionHistoryContent({
                             })}
                         </TransactionHistoryMessageRow>
                     ) : (
-                        transactions.map((transaction) => (
+                        entries.map((entry) => (
                             <TransactionHistoryRow
-                                key={transaction.updateId}
-                                transaction={transaction}
+                                key={`${entry.transaction.updateId}:${entry.eventIndex}`}
+                                entry={entry}
                                 walletId={walletId}
                             />
                         ))
@@ -161,9 +161,7 @@ export function TransactionHistoryContent({
                         <TransactionHistoryMessageRow muted>
                             Loading more transactions…
                         </TransactionHistoryMessageRow>
-                    ) : !hasNextPage &&
-                      !isLoading &&
-                      transactions.length > 0 ? (
+                    ) : !hasNextPage && !isLoading && entries.length > 0 ? (
                         <TransactionHistoryMessageRow muted>
                             No more transactions to load
                         </TransactionHistoryMessageRow>

--- a/examples/portfolio/src/components/dashboard/transaction-history-row.tsx
+++ b/examples/portfolio/src/components/dashboard/transaction-history-row.tsx
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Chip, TableCell, TableRow, Typography } from '@mui/material'
-import type { Transaction } from '@canton-network/core-tx-parser'
 import { CopyableIdentifier } from '@components/copyable-identifier'
-import { getTransactionDisplay } from './transaction-history-utils'
+import {
+    getTransactionDisplay,
+    type TransactionHistoryEntry,
+} from './transaction-history-utils'
 
 interface TransactionHistoryRowProps {
-    transaction: Transaction
+    entry: TransactionHistoryEntry
     walletId: string
 }
 
@@ -20,10 +22,10 @@ const bodyCellSx = {
 }
 
 export function TransactionHistoryRow({
-    transaction,
+    entry,
     walletId,
 }: TransactionHistoryRowProps) {
-    const display = getTransactionDisplay(transaction, walletId)
+    const display = getTransactionDisplay(entry, walletId)
     const amountColor =
         display.direction === 'received'
             ? 'success.main'
@@ -100,7 +102,11 @@ export function TransactionHistoryRow({
             </TableCell>
 
             <TableCell sx={bodyCellSx}>
-                {display.counterparty ? (
+                {display.counterparty === 'Self' ? (
+                    <Typography variant="body1" color="text.secondary">
+                        Self
+                    </Typography>
+                ) : display.counterparty ? (
                     <CopyableIdentifier
                         value={display.counterparty}
                         maxLength={10}

--- a/examples/portfolio/src/components/dashboard/transaction-history-utils.ts
+++ b/examples/portfolio/src/components/dashboard/transaction-history-utils.ts
@@ -10,6 +10,21 @@ export type TransactionDirection = 'received' | 'sent' | 'unknown'
 
 type TransactionEvent = Transaction['events'][number]
 
+type AllocationTransferLeg = {
+    sender: string
+    receiver: string
+    amount: string
+    instrumentId: { admin: string; id: string }
+}
+
+type AllocationLifecycle = 'reserved' | 'withdrawn' | 'cancelled' | null
+
+export type TransactionHistoryEntry = {
+    transaction: Transaction
+    event: TransactionEvent
+    eventIndex: number
+}
+
 export type TransactionDisplay = {
     type: string
     date: string
@@ -26,43 +41,46 @@ export const FILTER_LABEL_BY_FILTER = {
     sent: 'Sent',
 } satisfies Record<TransactionFilter, string>
 
-export function filterTransactions(
-    transactions: Transaction[],
+export function createTransactionHistoryEntries(
+    transactions: Transaction[]
+): TransactionHistoryEntry[] {
+    return transactions.flatMap((transaction) =>
+        transaction.events.map((event, eventIndex) => ({
+            transaction,
+            event,
+            eventIndex,
+        }))
+    )
+}
+
+export function filterTransactionHistoryEntries(
+    entries: TransactionHistoryEntry[],
     walletId: string,
     filter: TransactionFilter
 ) {
-    if (filter === 'all') return transactions
+    if (filter === 'all') return entries
 
-    return transactions.filter(
-        (transaction) =>
-            getTransactionDirection(transaction, walletId) === filter
+    return entries.filter(
+        ({ event }) => getTransactionDirection(event, walletId) === filter
     )
 }
 
 export function getTransactionDisplay(
-    transaction: Transaction,
+    entry: TransactionHistoryEntry,
     walletId: string
 ): TransactionDisplay {
-    const event = getPrimaryEvent(transaction)
-    const direction = getTransactionDirection(transaction, walletId)
-    const amount = getTransactionAmount(event)
-    // console.log('Event', event)
+    const { transaction, event } = entry
+    const direction = getTransactionDirection(event, walletId)
 
     return {
         type: getTransactionType(event, direction),
         date: formatDateTimeString(transaction.recordTime),
         asset: getTransactionAsset(event),
-        amount,
+        amount: getTransactionAmount(event),
         direction,
         counterparty: getCounterparty(event, walletId),
         updateId: transaction.updateId,
     }
-}
-
-export function getCounterpartyLabel(direction: TransactionDirection) {
-    if (direction === 'received') return 'Sender'
-    if (direction === 'sent') return 'Recipient'
-    return 'Counterparty'
 }
 
 export function getEmptyMessage({
@@ -85,12 +103,6 @@ export function getEmptyMessage({
         : `No ${filter} transactions.`
 }
 
-function getPrimaryEvent(
-    transaction: Transaction
-): TransactionEvent | undefined {
-    return transaction.events[0]
-}
-
 /**
  * Returns the user-facing Activity label for a parsed transaction event.
  *
@@ -100,13 +112,18 @@ function getPrimaryEvent(
  * so multiple rows from the same logical transfer do not look like duplicates.
  */
 function getTransactionType(
-    event: TransactionEvent | undefined,
+    event: TransactionEvent,
     direction: TransactionDirection
 ): string {
+    const allocationLifecycle = getAllocationLifecycle(event)
+    if (allocationLifecycle === 'reserved') return 'Allocation reserved'
+    if (allocationLifecycle === 'withdrawn') return 'Allocation withdrawn'
+    if (allocationLifecycle === 'cancelled') return 'Allocation cancelled'
+
     // Only honor status tags when a real transfer view exists. The synthetic
     // instruction the parser builds for direct transfers carries a placeholder
     // 'Pending' status.
-    const status = event?.transferInstruction?.transfer
+    const status = event.transferInstruction?.transfer
         ? event.transferInstruction.status.current?.tag
         : undefined
 
@@ -126,19 +143,22 @@ function getTransactionType(
     if (status === 'Withdrawn') return 'Offer withdrawn'
     if (status === 'Failed') return 'Offer failed'
 
-    if (event?.label.type === 'TransferOut') return 'Transfer sent ↗'
-    if (event?.label.type === 'TransferIn') return 'Transfer received ↘'
-    if (event?.label.type === 'MergeSplit') return 'Merge/Split'
-    if (event?.label.type === 'ExpireDust') return 'Dust expired'
+    if (event.label.type === 'TransferOut') return 'Transfer sent ↗'
+    if (event.label.type === 'TransferIn') return 'Transfer received ↘'
+    if (event.label.type === 'MergeSplit') return 'Merge/Split'
+    if (event.label.type === 'ExpireDust') return 'Dust expired'
 
     if (direction === 'received') return 'Received ↘'
     if (direction === 'sent') return 'Sent ↗'
 
-    return event?.label.type ?? 'Unknown'
+    return event.label.type
 }
 
-function getTransactionAsset(event: TransactionEvent | undefined): string {
-    if (!event) return '—'
+function getTransactionAsset(event: TransactionEvent): string {
+    const allocationLeg = getAllocationTransferLeg(event)
+    if (allocationLeg?.instrumentId) {
+        return allocationLeg.instrumentId.id || allocationLeg.instrumentId.admin
+    }
 
     const transfer = event.transferInstruction?.transfer
     if (transfer?.instrumentId) {
@@ -154,33 +174,34 @@ function getTransactionAsset(event: TransactionEvent | undefined): string {
     return '—'
 }
 
-function getTransactionAmount(
-    event: TransactionEvent | undefined
-): string | null {
-    if (!event) return null
+function getTransactionAmount(event: TransactionEvent): string | null {
+    const allocationLeg = getAllocationTransferLeg(event)
+    if (allocationLeg) return formatAmount(allocationLeg.amount)
 
     const transfer = event.transferInstruction?.transfer
-    if (transfer) {
-        return formatAmount(transfer.amount ?? '0')
+    if (transfer) return formatAmount(transfer.amount ?? '0')
+
+    if (event.label.type === 'TransferOut') {
+        const total = sumAmounts(
+            event.label.receiverAmounts.map(({ amount }) => amount)
+        )
+        if (total) return formatAmount(total)
     }
 
     const summary = getHoldingSummary(event)
     if (!summary?.amountChange) return null
 
     const amountChange = toDecimalOrNull(summary.amountChange)
-    if (amountChange) {
-        return formatAmount(amountChange.abs())
-    }
+    if (amountChange) return formatAmount(amountChange.abs())
 
     return formatAmount(summary.amountChange)
 }
 
 function getTransactionDirection(
-    transaction: Transaction,
+    event: TransactionEvent,
     walletId: string
 ): TransactionDirection {
-    const event = getPrimaryEvent(transaction)
-    if (!event) return 'unknown'
+    if (getAllocationLifecycle(event)) return 'unknown'
 
     const transfer = event.transferInstruction?.transfer
     if (transfer) {
@@ -204,10 +225,21 @@ function getTransactionDirection(
 }
 
 function getCounterparty(
-    event: TransactionEvent | undefined,
+    event: TransactionEvent,
     walletId: string
 ): string | null {
-    if (!event) return null
+    const allocationLifecycle = getAllocationLifecycle(event)
+    const allocationLeg = getAllocationTransferLeg(event)
+    if (allocationLifecycle === 'reserved' && allocationLeg) {
+        if (allocationLeg.sender === walletId) return allocationLeg.receiver
+        if (allocationLeg.receiver === walletId) return allocationLeg.sender
+    }
+    if (
+        allocationLifecycle === 'withdrawn' ||
+        allocationLifecycle === 'cancelled'
+    ) {
+        return 'Self'
+    }
 
     const transfer = event.transferInstruction?.transfer
     if (transfer) {
@@ -225,8 +257,48 @@ function getCounterparty(
             .find((receiver) => receiver !== walletId)
         return receiver ?? null
     }
+    if (event.label.type === 'MergeSplit') return 'Self'
 
     return null
+}
+
+function getAllocationLifecycle(event: TransactionEvent): AllocationLifecycle {
+    const choiceName = getTokenStandardChoiceName(event)
+    if (choiceName === 'AllocationFactory_Allocate') return 'reserved'
+    if (choiceName === 'Allocation_Withdraw') return 'withdrawn'
+    if (choiceName === 'Allocation_Cancel') return 'cancelled'
+    return null
+}
+
+function getAllocationTransferLeg(
+    event: TransactionEvent
+): AllocationTransferLeg | null {
+    if (getTokenStandardChoiceName(event) !== 'AllocationFactory_Allocate') {
+        return null
+    }
+
+    const choice = getTokenStandardChoice(event)
+    return (
+        (choice?.choiceArgument?.allocation
+            ?.transferLeg as AllocationTransferLeg) ?? null
+    )
+}
+
+function getTokenStandardChoice(event: TransactionEvent) {
+    return 'tokenStandardChoice' in event.label
+        ? event.label.tokenStandardChoice
+        : null
+}
+
+function getTokenStandardChoiceName(event: TransactionEvent) {
+    return getTokenStandardChoice(event)?.name
+}
+
+function sumAmounts(amounts: string[]) {
+    return amounts.reduce((total, amount) => {
+        const parsed = toDecimalOrNull(amount)
+        return total && parsed ? total.plus(parsed) : null
+    }, toDecimalOrNull('0'))
 }
 
 function getHoldingSummary(event: TransactionEvent) {

--- a/examples/portfolio/src/components/dashboard/transaction-history.tsx
+++ b/examples/portfolio/src/components/dashboard/transaction-history.tsx
@@ -10,8 +10,9 @@ import {
 import { TransactionHistoryContent } from './transaction-history-content'
 import { TransactionHistoryTabs } from './transaction-history-tabs'
 import {
+    createTransactionHistoryEntries,
     FILTER_LABEL_BY_FILTER,
-    filterTransactions,
+    filterTransactionHistoryEntries,
     type TransactionFilter,
 } from './transaction-history-utils'
 
@@ -26,9 +27,13 @@ export function TransactionHistory({ walletId }: TransactionHistoryProps) {
         () => deduplicateTransactionHistory(history.data),
         [history.data]
     )
-    const visibleTransactions = useMemo(
-        () => filterTransactions(transactions, walletId, filter),
-        [transactions, walletId, filter]
+    const entries = useMemo(
+        () => createTransactionHistoryEntries(transactions),
+        [transactions]
+    )
+    const visibleEntries = useMemo(
+        () => filterTransactionHistoryEntries(entries, walletId, filter),
+        [entries, walletId, filter]
     )
     const handleLoadMore = useCallback(() => {
         void history.fetchNextPage()
@@ -58,9 +63,9 @@ export function TransactionHistory({ walletId }: TransactionHistoryProps) {
                 <TransactionHistoryContent
                     filter={filter}
                     walletId={walletId}
-                    transactions={visibleTransactions}
-                    totalLoadedTransactions={transactions.length}
-                    isLoading={history.isPending && transactions.length === 0}
+                    entries={visibleEntries}
+                    totalLoadedTransactions={entries.length}
+                    isLoading={history.isPending && entries.length === 0}
                     isError={history.isError}
                     error={history.error}
                     hasNextPage={history.hasNextPage ?? false}

--- a/examples/portfolio/tests/allocation-next.spec.ts
+++ b/examples/portfolio/tests/allocation-next.spec.ts
@@ -9,6 +9,7 @@ import {
     gotoConnect,
     setupRegistry,
     switchWallet,
+    tap,
     tapAndCreateAllocation,
 } from './next-utils'
 
@@ -63,6 +64,60 @@ const expectHistoryRow = async (
     await expect(row).toHaveCount(1, { timeout: HISTORY_TIMEOUT })
 }
 
+const setupOtcTrade = async (page: Page) => {
+    const rnd = Math.floor(Math.random() * 100000)
+    const wg = createWalletGateway(page)
+
+    await gotoConnect(page)
+    await wg.connect({ network: 'LocalNet' })
+
+    const venueHint = `venue-${rnd}`
+    const aliceHint = `alice-${rnd}`
+    const bobHint = `bob-${rnd}`
+    const charlieHint = `charlie-${rnd}`
+    const venue = await wg.createWalletIfNotExists({
+        partyHint: venueHint,
+        signingProvider: 'participant',
+    })
+    const alice = await wg.createWalletIfNotExists({
+        partyHint: aliceHint,
+        signingProvider: 'participant',
+    })
+    const bob = await wg.createWalletIfNotExists({
+        partyHint: bobHint,
+        signingProvider: 'participant',
+    })
+    const charlie = await wg.createWalletIfNotExists({
+        partyHint: charlieHint,
+        signingProvider: 'participant',
+    })
+
+    await wg.setPrimaryWallet(alice)
+    await setupRegistry(page)
+
+    const logger = pino({ name: 'otc-trade', level: 'info' })
+    const otcTrade = new OTCTrade({
+        logger,
+        venue,
+        alice,
+        bob,
+        charlie,
+    })
+    const otcTradeDetails = await otcTrade.setup()
+
+    return {
+        wg,
+        otcTrade,
+        otcTradeDetails,
+        alice,
+        aliceHint,
+        bob,
+        bobHint,
+        charlie,
+        charlieHint,
+    }
+}
+
 test.describe('OTC allocations', () => {
     // OTC setup includes multiple taps, allocations, and settlement.
     test.setTimeout(180_000)
@@ -70,45 +125,17 @@ test.describe('OTC allocations', () => {
     test('shows reservations and every settlement leg', async ({
         page: dappPage,
     }) => {
-        const rnd = Math.floor(Math.random() * 100000)
-        const wg = createWalletGateway(dappPage)
-
-        await gotoConnect(dappPage)
-        await wg.connect({ network: 'LocalNet' })
-
-        const venueHint = `venue-${rnd}`
-        const aliceHint = `alice-${rnd}`
-        const bobHint = `bob-${rnd}`
-        const charlieHint = `charlie-${rnd}`
-        const venue = await wg.createWalletIfNotExists({
-            partyHint: venueHint,
-            signingProvider: 'participant',
-        })
-        const alice = await wg.createWalletIfNotExists({
-            partyHint: aliceHint,
-            signingProvider: 'participant',
-        })
-        const bob = await wg.createWalletIfNotExists({
-            partyHint: bobHint,
-            signingProvider: 'participant',
-        })
-        const charlie = await wg.createWalletIfNotExists({
-            partyHint: charlieHint,
-            signingProvider: 'participant',
-        })
-
-        await wg.setPrimaryWallet(alice)
-        await setupRegistry(dappPage)
-
-        const logger = pino({ name: 'otc-trade', level: 'info' })
-        const otcTrade = new OTCTrade({
-            logger,
-            venue,
+        const {
+            wg,
+            otcTrade,
+            otcTradeDetails,
             alice,
+            aliceHint,
             bob,
+            bobHint,
             charlie,
-        })
-        const otcTradeDetails = await otcTrade.setup()
+            charlieHint,
+        } = await setupOtcTrade(dappPage)
 
         await tapAndCreateAllocation(dappPage, wg, '1000', 2)
 
@@ -184,6 +211,71 @@ test.describe('OTC allocations', () => {
             activity: 'Transfer sent ↗',
             amount: '-80',
             counterpartyHint: aliceHint,
+        })
+    })
+
+    test('withdraws an allocation and restores the leg', async ({
+        page: dappPage,
+    }) => {
+        const { wg, alice, aliceHint, bobHint } = await setupOtcTrade(dappPage)
+
+        await tap(dappPage, wg, '1000')
+
+        const allocationRequest = dappPage
+            .getByRole('button', { name: 'Open Allocation Request' })
+            .first()
+        await expect(allocationRequest).toBeVisible({ timeout: 15_000 })
+        await allocationRequest.click()
+
+        const dialog = dappPage.getByRole('dialog')
+        await expect(
+            dialog.getByRole('heading', { name: 'Allocation Request' })
+        ).toBeVisible()
+
+        const aliceToBobLeg = dialog.getByRole('group', {
+            name: 'Transfer leg 1',
+        })
+        await expect(
+            aliceToBobLeg.getByText('-100 Amulet', { exact: true })
+        ).toBeVisible()
+        await expect(aliceToBobLeg).toContainText(bobHint.slice(0, 10))
+
+        await wg.approveTransaction(() =>
+            aliceToBobLeg.getByRole('button', { name: 'Allocate' }).click()
+        )
+        await expect(
+            aliceToBobLeg.getByRole('button', { name: 'Withdraw' })
+        ).toBeVisible({ timeout: 15_000 })
+
+        await dialog.getByLabel('Close allocation request dialog').click()
+        await expect(dialog).not.toBeVisible({ timeout: 10_000 })
+        await expect(allocationRequest).toBeVisible({ timeout: 15_000 })
+        await allocationRequest.click()
+
+        const withdrawButton = aliceToBobLeg.getByRole('button', {
+            name: 'Withdraw',
+        })
+        await expect(withdrawButton).toBeVisible({ timeout: 15_000 })
+        await wg.approveTransaction(() => withdrawButton.click())
+
+        await expect(
+            aliceToBobLeg.getByRole('button', { name: 'Allocate' })
+        ).toBeVisible({ timeout: 15_000 })
+        await expect(withdrawButton).not.toBeVisible()
+
+        await dialog.getByLabel('Close allocation request dialog').click()
+        await expect(dialog).not.toBeVisible({ timeout: 10_000 })
+
+        await gotoWalletHistory(dappPage, alice, aliceHint)
+        await expectHistoryRow(dappPage, {
+            activity: 'Allocation reserved',
+            amount: '100',
+            counterpartyHint: bobHint,
+        })
+        await expectHistoryRow(dappPage, {
+            activity: 'Allocation withdrawn',
+            amount: '100',
+            counterpartyHint: 'Self',
         })
     })
 })

--- a/examples/portfolio/tests/allocation-next.spec.ts
+++ b/examples/portfolio/tests/allocation-next.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { pino } from 'pino'
-import { test } from '@playwright/test'
+import { expect, type Page, test } from '@playwright/test'
 import { OTCTrade } from '@canton-network/core-wallet-test-utils'
 import {
     createWalletGateway,
@@ -12,53 +12,178 @@ import {
     tapAndCreateAllocation,
 } from './next-utils'
 
-// Extend default 30s because allocation test involves OTC trade setup, multiple taps, and allocations.
-test.setTimeout(180_000)
+const BASE_URL = 'http://localhost:8081'
+const HISTORY_TIMEOUT = 30_000
 
-test('allocation via OTC trade', async ({ page: dappPage }) => {
-    const rnd = Math.floor(Math.random() * 100000)
-    const wg = createWalletGateway(dappPage)
+type ExpectedHistoryRow = {
+    activity: string
+    amount: string
+    counterpartyHint: string
+}
 
-    await gotoConnect(dappPage)
-    await wg.connect({ network: 'LocalNet' })
+const gotoWalletHistory = async (
+    page: Page,
+    walletId: string,
+    walletHint: string
+): Promise<void> => {
+    await page.goto(
+        `${BASE_URL}/next/dashboard/wallet/${encodeURIComponent(walletId)}`
+    )
 
-    const venue = await wg.createWalletIfNotExists({
-        partyHint: `venue-${rnd}`,
-        signingProvider: 'participant',
+    const main = page.locator('main')
+    await expect(main.getByRole('heading', { name: walletHint })).toBeVisible({
+        timeout: 10_000,
     })
-    const alice = await wg.createWalletIfNotExists({
-        partyHint: `alice-${rnd}`,
-        signingProvider: 'participant',
+    await expect(
+        main.getByRole('table', { name: 'Transaction history' })
+    ).toBeVisible({ timeout: HISTORY_TIMEOUT })
+}
+
+const expectHistoryRow = async (
+    page: Page,
+    expected: ExpectedHistoryRow
+): Promise<void> => {
+    const row = page
+        .getByRole('table', { name: 'Transaction history' })
+        .getByRole('row')
+        .filter({
+            has: page.getByRole('cell', {
+                name: expected.activity,
+                exact: true,
+            }),
+        })
+        .filter({
+            has: page.getByRole('cell', {
+                name: expected.amount,
+                exact: true,
+            }),
+        })
+        .filter({ hasText: expected.counterpartyHint.slice(0, 10) })
+
+    await expect(row).toHaveCount(1, { timeout: HISTORY_TIMEOUT })
+}
+
+test.describe('OTC allocations', () => {
+    // OTC setup includes multiple taps, allocations, and settlement.
+    test.setTimeout(180_000)
+
+    test('shows reservations and every settlement leg', async ({
+        page: dappPage,
+    }) => {
+        const rnd = Math.floor(Math.random() * 100000)
+        const wg = createWalletGateway(dappPage)
+
+        await gotoConnect(dappPage)
+        await wg.connect({ network: 'LocalNet' })
+
+        const venueHint = `venue-${rnd}`
+        const aliceHint = `alice-${rnd}`
+        const bobHint = `bob-${rnd}`
+        const charlieHint = `charlie-${rnd}`
+        const venue = await wg.createWalletIfNotExists({
+            partyHint: venueHint,
+            signingProvider: 'participant',
+        })
+        const alice = await wg.createWalletIfNotExists({
+            partyHint: aliceHint,
+            signingProvider: 'participant',
+        })
+        const bob = await wg.createWalletIfNotExists({
+            partyHint: bobHint,
+            signingProvider: 'participant',
+        })
+        const charlie = await wg.createWalletIfNotExists({
+            partyHint: charlieHint,
+            signingProvider: 'participant',
+        })
+
+        await wg.setPrimaryWallet(alice)
+        await setupRegistry(dappPage)
+
+        const logger = pino({ name: 'otc-trade', level: 'info' })
+        const otcTrade = new OTCTrade({
+            logger,
+            venue,
+            alice,
+            bob,
+            charlie,
+        })
+        const otcTradeDetails = await otcTrade.setup()
+
+        await tapAndCreateAllocation(dappPage, wg, '1000', 2)
+
+        await switchWallet(dappPage, wg, bob)
+        await tapAndCreateAllocation(dappPage, wg, '1000')
+
+        await switchWallet(dappPage, wg, charlie)
+        await tapAndCreateAllocation(dappPage, wg, '1000')
+
+        await otcTrade.settle(otcTradeDetails)
+
+        await gotoWalletHistory(dappPage, alice, aliceHint)
+        await expectHistoryRow(dappPage, {
+            activity: 'Allocation reserved',
+            amount: '100',
+            counterpartyHint: bobHint,
+        })
+        await expectHistoryRow(dappPage, {
+            activity: 'Allocation reserved',
+            amount: '50',
+            counterpartyHint: charlieHint,
+        })
+        await expectHistoryRow(dappPage, {
+            activity: 'Transfer sent ↗',
+            amount: '-100',
+            counterpartyHint: bobHint,
+        })
+        await expectHistoryRow(dappPage, {
+            activity: 'Transfer received ↘',
+            amount: '+20',
+            counterpartyHint: bobHint,
+        })
+        await expectHistoryRow(dappPage, {
+            activity: 'Transfer sent ↗',
+            amount: '-50',
+            counterpartyHint: charlieHint,
+        })
+        await expectHistoryRow(dappPage, {
+            activity: 'Transfer received ↘',
+            amount: '+80',
+            counterpartyHint: charlieHint,
+        })
+
+        await gotoWalletHistory(dappPage, bob, bobHint)
+        await expectHistoryRow(dappPage, {
+            activity: 'Allocation reserved',
+            amount: '20',
+            counterpartyHint: aliceHint,
+        })
+        await expectHistoryRow(dappPage, {
+            activity: 'Transfer received ↘',
+            amount: '+100',
+            counterpartyHint: aliceHint,
+        })
+        await expectHistoryRow(dappPage, {
+            activity: 'Transfer sent ↗',
+            amount: '-20',
+            counterpartyHint: aliceHint,
+        })
+
+        await gotoWalletHistory(dappPage, charlie, charlieHint)
+        await expectHistoryRow(dappPage, {
+            activity: 'Allocation reserved',
+            amount: '80',
+            counterpartyHint: aliceHint,
+        })
+        await expectHistoryRow(dappPage, {
+            activity: 'Transfer received ↘',
+            amount: '+50',
+            counterpartyHint: aliceHint,
+        })
+        await expectHistoryRow(dappPage, {
+            activity: 'Transfer sent ↗',
+            amount: '-80',
+            counterpartyHint: aliceHint,
+        })
     })
-    const bob = await wg.createWalletIfNotExists({
-        partyHint: `bob-${rnd}`,
-        signingProvider: 'participant',
-    })
-    const charlie = await wg.createWalletIfNotExists({
-        partyHint: `charlie-${rnd}`,
-        signingProvider: 'participant',
-    })
-
-    await wg.setPrimaryWallet(alice)
-    await setupRegistry(dappPage)
-
-    const logger = pino({ name: 'otc-trade', level: 'info' })
-    const otcTrade = new OTCTrade({
-        logger,
-        venue,
-        alice,
-        bob,
-        charlie,
-    })
-    const otcTradeDetails = await otcTrade.setup()
-
-    await tapAndCreateAllocation(dappPage, wg, '1000', 2)
-
-    await switchWallet(dappPage, wg, bob)
-    await tapAndCreateAllocation(dappPage, wg, '1000')
-
-    await switchWallet(dappPage, wg, charlie)
-    await tapAndCreateAllocation(dappPage, wg, '1000')
-
-    await otcTrade.settle(otcTradeDetails)
 })


### PR DESCRIPTION
Requires https://github.com/canton-network/wallet/pull/2136 to be merged first

Closes #1794 
Closes #1657 


 - The parser now preserves allocation creation, execution, withdrawal, and cancellation context instead of exposing allocations as balance changes.
 - Allocation reservations show as “Allocation reserved” instead of “Merge/Split.”
 - Reserved amounts use neutral styling because funds are locked, not transferred.
 - Parser and end-to-end tests cover the complete Alice/Bob/Charlie OTC allocation flow.
<img width="1395" height="1261" alt="image" src="https://github.com/user-attachments/assets/dfdc6672-220a-432f-958a-93752d49e627" />
