### PR TITLE
fix: add security headers to all WG responses

### DIFF
--- a/wallet-gateway/remote/src/init.ts
+++ b/wallet-gateway/remote/src/init.ts
@@ -46,6 +46,7 @@ import { sql } from 'kysely'
 import { Env } from './env.js'
 import { SigningWorker } from './signing/signing-worker.js'
 import { apiKeyAuth } from './middleware/apiKeyAuth.js'
+import { securityHeaders } from './middleware/securityHeaders.js'
 
 let isReady = false
 let signingWorker: SigningWorker | undefined
@@ -242,6 +243,7 @@ export async function initialize(opts: CliOptions, logger: Logger) {
 
     const app = express()
     app.set('trust proxy', config.server.trustProxy)
+    app.use(securityHeaders())
 
     const server = app.listen(port, () => {
         logger.info(`Remote Wallet Gateway starting on ${serviceUrl})`)

--- a/wallet-gateway/remote/src/middleware/securityHeaders.test.ts
+++ b/wallet-gateway/remote/src/middleware/securityHeaders.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest'
+import type { NextFunction, Request, Response } from 'express'
+import { securityHeaders } from './securityHeaders.js'
+
+describe('securityHeaders', () => {
+    it('sets the expected security response headers', () => {
+        const setHeader = vi.fn()
+        const next = vi.fn() as NextFunction
+        const middleware = securityHeaders()
+        const req = {} as Request
+        const res = { setHeader } as unknown as Response
+
+        middleware(req, res, next)
+
+        expect(setHeader).toHaveBeenCalledWith('X-Frame-Options', 'DENY')
+        expect(setHeader).toHaveBeenCalledWith(
+            'Content-Security-Policy',
+            "frame-ancestors 'none';"
+        )
+        expect(setHeader).toHaveBeenCalledWith(
+            'X-Content-Type-Options',
+            'nosniff'
+        )
+
+        expect(next).toHaveBeenCalledOnce()
+    })
+})

--- a/wallet-gateway/remote/src/middleware/securityHeaders.ts
+++ b/wallet-gateway/remote/src/middleware/securityHeaders.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { NextFunction, Request, Response } from 'express'
+
+export function securityHeaders() {
+    return (_req: Request, res: Response, next: NextFunction) => {
+        res.setHeader('X-Frame-Options', 'DENY')
+        res.setHeader('Content-Security-Policy', "frame-ancestors 'none';")
+        res.setHeader('X-Content-Type-Options', 'nosniff')
+        next()
+    }
+}


### PR DESCRIPTION
Added a middleware that attaches security headers to all wallet gateway responses.
```
'X-Frame-Options', 'DENY'
'Content-Security-Policy', "frame-ancestors 'none';"
'X-Content-Type-Options', 'nosniff'
```
These headers strengthen browser protection against unauthorized embedding, clickjacking and XSS.