### PR TITLE
fix: remove InteractiveSubmissionService/GetPreferredPackageVersion #29742 #33861 - Ping example fix

### DIFF
--- a/examples/ping/src/components/LedgerQuery.tsx
+++ b/examples/ping/src/components/LedgerQuery.tsx
@@ -25,11 +25,15 @@ export function LedgerQuery(props: {
                         setLoading(true)
                         const packageName = 'canton-builtin-admin-workflow-ping'
                         sdk.ledgerApi({
-                            requestMethod: 'get',
-                            resource: `/v2/interactive-submission/preferred-package-version`,
-                            query: {
-                                'package-name': packageName,
-                                parties: props.primaryParty!,
+                            requestMethod: 'post',
+                            resource: `/v2/interactive-submission/preferred-packages`,
+                            body: {
+                                packageVettingRequirements: [
+                                    {
+                                        parties: [props.primaryParty!],
+                                        packageName,
+                                    },
+                                ],
                             },
                         }).then((response) => {
                             setQueryResponses((prev) => [
@@ -40,7 +44,7 @@ export function LedgerQuery(props: {
                         })
                     }}
                 >
-                    query preferred package version
+                    query preferred packages
                 </button>
 
                 {loading && <p>Loading...</p>}


### PR DESCRIPTION
## Summary

Replaces the deprecated Ledger API endpoint `GET /v2/interactive-submission/preferred-package-version` with its successor `POST /v2/interactive-submission/preferred-packages` in the `ping` example dApp — the only hand-written call site for this endpoint in the repo.

Fixes #29742

## Motivation

The Ledger API is migrating this interactive-submission endpoint from a single-package `GET` query to a batch, request-body based `POST` (mirroring the upstream `GetPreferredPackageVersion` → `GetPreferredPackages` rename). Generated clients/types for the new endpoint already exist; this PR updates the one remaining consumer of the old endpoint.

## Changes

- `examples/ping/src/components/LedgerQuery.tsx`
    - Switched the `sdk.ledgerApi(...)` call from `GET /v2/interactive-submission/preferred-package-version` (query params) to `POST /v2/interactive-submission/preferred-packages` (JSON body), sending a `GetPreferredPackagesRequest`-shaped `packageVettingRequirements` array.
    - `parties` is now passed as an array (`[props.primaryParty!]`) per `PackageVettingRequirement.parties: string[]`, fixing a pre-existing mismatch where a single string was passed into an array-typed field.
    - Updated the button label from "query preferred package version" to "query preferred packages".

No SDK or type-generation changes were needed: `sdk.ledgerApi` (`sdk/dapp-sdk/src/sdk.ts`) is a generic pass-through that already supports `POST` + `body`, and the request/response types (`GetPreferredPackagesRequest`, `GetPreferredPackagesResponse`, `PackageVettingRequirement`, `PackageReference`) are already generated in `core/ledger-client-types/src/generated-clients/`.

## Testing

- [ ] Ran the `ping` example against a local ledger, connected a wallet, and confirmed the "query preferred packages" button returns a `200` response containing `packageReferences` / `synchronizerId` in the Ledger Query panel.
