### PR TITLE
chore: add shared eslint config package

### DIFF
--- a/core/eslint-config/index.mjs
+++ b/core/eslint-config/index.mjs
@@ -1,0 +1,80 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+import { defineConfig } from 'eslint/config'
+import { includeIgnoreFile } from '@eslint/compat'
+import { join } from 'node:path'
+import headers from 'eslint-plugin-headers'
+import nxeslint from '@nx/eslint-plugin'
+
+/**
+ * Shared ESLint flat config for the monorepo.
+ * @param {{ rootDir: string }} options
+ */
+export function createConfig({ rootDir }) {
+    const gitignorePath = join(rootDir, '.gitignore')
+    const headerFilePath = join(rootDir, 'header.txt')
+
+    return defineConfig([
+        includeIgnoreFile(gitignorePath),
+        {
+            ignores: [
+                '**/dist',
+                '**/build',
+                '**/_proto',
+                '**/.venv',
+                '**/vite-env.d.ts',
+                '.yarn/**',
+                '.commitlintrc.js',
+                '.pnp.*',
+                'core/wallet-dapp-rpc-client',
+                'core/wallet-dapp-remote-rpc-client',
+                'core/wallet-user-rpc-client',
+                'core/ledger-client/src/generated-clients',
+                'core/ledger-client-types/src/generated-clients',
+                'damljs/**',
+                'docs/wallet-integration-guide/examples/**',
+                'examples/ping/playwright-report/**',
+                'core/rpc-generator/templates/client/typescript/src/index.ts',
+            ],
+        },
+        {
+            files: ['**/*.{js,mjs,cjs,ts,tsx,mts,cts}'],
+            languageOptions: {
+                parserOptions: {
+                    tsconfigRootDir: rootDir,
+                },
+                globals: { ...globals.browser, ...globals.node },
+            },
+            extends: ['js/recommended'],
+            plugins: { js, headers },
+            rules: {
+                'headers/header-format': [
+                    'error',
+                    {
+                        source: 'file',
+                        path: headerFilePath,
+                        style: 'line',
+                        trailingNewlines: 2,
+                        variables: {
+                            year: `${new Date().getFullYear()}`,
+                        },
+                    },
+                ],
+            },
+        },
+        tseslint.configs.recommended,
+        {
+            files: ['**/*.{js,mjs,cjs,ts,tsx,mts,cts}'],
+            languageOptions: {
+                parserOptions: {
+                    tsconfigRootDir: rootDir,
+                },
+            },
+            plugins: { '@nx': nxeslint },
+        },
+    ])
+}

--- a/core/eslint-config/package.json
+++ b/core/eslint-config/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "@canton-network/core-eslint-config",
+    "version": "0.0.0",
+    "private": true,
+    "type": "module",
+    "description": "Shared ESLint flat config for the wallet monorepo",
+    "license": "Apache-2.0",
+    "exports": {
+        ".": "./index.mjs"
+    },
+    "dependencies": {
+        "@eslint/compat": "^2.1.0",
+        "@eslint/js": "^10.0.1",
+        "@nx/eslint-plugin": "22.7.6",
+        "eslint-plugin-headers": "^1.3.4",
+        "globals": "^17.7.0",
+        "typescript-eslint": "^8.63.0"
+    },
+    "peerDependencies": {
+        "eslint": "^10.0.0"
+    }
+}

--- a/core/rpc-generator/src/components/client.ts
+++ b/core/rpc-generator/src/components/client.ts
@@ -103,12 +103,15 @@ const hooks: IHooks = {
     afterCopyStatic: [
         async (dest, frm, component): Promise<void> => {
             if (component.language === 'typescript') {
-                return await move(
+                await move(
                     path.join(dest, '_package.json'),
                     path.join(dest, 'package.json'),
-                    {
-                        overwrite: true,
-                    }
+                    { overwrite: true }
+                )
+                return await move(
+                    path.join(dest, '_eslint.config.mjs'),
+                    path.join(dest, 'eslint.config.mjs'),
+                    { overwrite: true }
                 )
             }
         },

--- a/core/rpc-generator/templates/client/typescript/_eslint.config.mjs
+++ b/core/rpc-generator/templates/client/typescript/_eslint.config.mjs
@@ -1,0 +1,29 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createConfig } from '@canton-network/core-eslint-config'
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '../..')
+
+export default [
+    ...createConfig({ rootDir }),
+    { ignores: ['docs/**'] },
+    {
+        files: ['**/*.{ts,tsx}'],
+        rules: {
+            'headers/header-format': 'off',
+        },
+    },
+    {
+        files: ['src/**/*.{ts,tsx}'],
+        rules: {
+            '@typescript-eslint/no-explicit-any': 'warn',
+            '@typescript-eslint/no-unused-vars': [
+                'warn',
+                { argsIgnorePattern: '^_' },
+            ],
+        },
+    },
+]

--- a/core/rpc-generator/templates/client/typescript/_package.json
+++ b/core/rpc-generator/templates/client/typescript/_package.json
@@ -32,17 +32,12 @@
         "lodash": "^4.18.1"
     },
     "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@canton-network/core-eslint-config": "workspace:^",
         "@types/isomorphic-fetch": "^0.0.39",
         "@types/json-schema": "7.0.15",
         "@types/lodash": "^4.17.24",
         "@types/ws": "^8.18.1",
-        "@typescript-eslint/eslint-plugin": "^8.63.0",
-        "@typescript-eslint/parser": "^8.63.0",
         "eslint": "^10.6.0",
-        "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-prettier": "^5.5.6",
-        "globals": "^17.7.0",
         "prettier": "3.9.4",
         "tsup": "^8.5.1",
         "typedoc": "^0.28.20",

--- a/core/wallet-dapp-remote-rpc-client/package.json
+++ b/core/wallet-dapp-remote-rpc-client/package.json
@@ -34,17 +34,12 @@
         "lodash": "^4.18.1"
     },
     "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@canton-network/core-eslint-config": "workspace:^",
         "@types/isomorphic-fetch": "^0.0.39",
         "@types/json-schema": "7.0.15",
         "@types/lodash": "^4.17.24",
         "@types/ws": "^8.18.1",
-        "@typescript-eslint/eslint-plugin": "^8.63.0",
-        "@typescript-eslint/parser": "^8.63.0",
         "eslint": "^10.6.0",
-        "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-prettier": "^5.5.6",
-        "globals": "^17.7.0",
         "prettier": "3.9.4",
         "tsup": "^8.5.1",
         "typedoc": "^0.28.20",

--- a/core/wallet-dapp-rpc-client/eslint.config.mjs
+++ b/core/wallet-dapp-rpc-client/eslint.config.mjs
@@ -1,67 +1,29 @@
-import eslint from '@eslint/js'
-import tseslint from '@typescript-eslint/eslint-plugin'
-import tsParser from '@typescript-eslint/parser'
-import prettierConfig from 'eslint-config-prettier'
-import prettierPlugin from 'eslint-plugin-prettier'
-import { fileURLToPath } from 'url'
-import { dirname } from 'path'
-import globals from 'globals'
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createConfig } from '@canton-network/core-eslint-config'
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '../..')
 
 export default [
-    eslint.configs.recommended,
+    ...createConfig({ rootDir }),
+    { ignores: ['docs/**'] },
     {
         files: ['**/*.{ts,tsx}'],
-        languageOptions: {
-            parser: tsParser,
-            parserOptions: {
-                project: ['./tsconfig.json'],
-                tsconfigRootDir: __dirname,
-                ecmaVersion: 2022,
-                sourceType: 'module',
-                ecmaFeatures: {},
-            },
-            globals: {
-                ...globals.node,
-                ...globals.es6,
-                chrome: 'readonly',
-                browser: 'readonly',
-            },
-        },
-        plugins: {
-            '@typescript-eslint': tseslint,
-            prettier: prettierPlugin,
-        },
         rules: {
-            ...tseslint.configs['recommended'].rules,
-            '@typescript-eslint/explicit-function-return-type': 'off',
-            '@typescript-eslint/explicit-module-boundary-types': 'off',
+            'headers/header-format': 'off',
+        },
+    },
+    {
+        files: ['src/**/*.{ts,tsx}'],
+        rules: {
             '@typescript-eslint/no-explicit-any': 'warn',
             '@typescript-eslint/no-unused-vars': [
                 'warn',
                 { argsIgnorePattern: '^_' },
             ],
-            'no-console': ['warn', { allow: ['warn', 'error'] }],
-            'prettier/prettier': 'error',
-        },
-        ignores: [
-            'package.json',
-            'node_modules/',
-            '**/*/dist/',
-            'build/',
-            'coverage/',
-            '*.config.js',
-            '**/*.config.ts',
-            'vitest.config.ts',
-            'vite.config.ts',
-        ],
-        settings: {
-            react: {
-                version: 'detect',
-            },
         },
     },
-    prettierConfig,
 ]

--- a/core/wallet-dapp-rpc-client/package.json
+++ b/core/wallet-dapp-rpc-client/package.json
@@ -34,17 +34,12 @@
         "lodash": "^4.18.1"
     },
     "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@canton-network/core-eslint-config": "workspace:^",
         "@types/isomorphic-fetch": "^0.0.39",
         "@types/json-schema": "7.0.15",
         "@types/lodash": "^4.17.24",
         "@types/ws": "^8.18.1",
-        "@typescript-eslint/eslint-plugin": "^8.63.0",
-        "@typescript-eslint/parser": "^8.63.0",
         "eslint": "^10.6.0",
-        "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-prettier": "^5.5.6",
-        "globals": "^17.7.0",
         "prettier": "3.9.4",
         "tsup": "^8.5.1",
         "typedoc": "^0.28.20",

--- a/core/wallet-user-rpc-client/eslint.config.mjs
+++ b/core/wallet-user-rpc-client/eslint.config.mjs
@@ -1,67 +1,29 @@
-import eslint from '@eslint/js'
-import tseslint from '@typescript-eslint/eslint-plugin'
-import tsParser from '@typescript-eslint/parser'
-import prettierConfig from 'eslint-config-prettier'
-import prettierPlugin from 'eslint-plugin-prettier'
-import { fileURLToPath } from 'url'
-import { dirname } from 'path'
-import globals from 'globals'
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createConfig } from '@canton-network/core-eslint-config'
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '../..')
 
 export default [
-    eslint.configs.recommended,
+    ...createConfig({ rootDir }),
+    { ignores: ['docs/**'] },
     {
         files: ['**/*.{ts,tsx}'],
-        languageOptions: {
-            parser: tsParser,
-            parserOptions: {
-                project: ['./tsconfig.json'],
-                tsconfigRootDir: __dirname,
-                ecmaVersion: 2022,
-                sourceType: 'module',
-                ecmaFeatures: {},
-            },
-            globals: {
-                ...globals.node,
-                ...globals.es6,
-                chrome: 'readonly',
-                browser: 'readonly',
-            },
-        },
-        plugins: {
-            '@typescript-eslint': tseslint,
-            prettier: prettierPlugin,
-        },
         rules: {
-            ...tseslint.configs['recommended'].rules,
-            '@typescript-eslint/explicit-function-return-type': 'off',
-            '@typescript-eslint/explicit-module-boundary-types': 'off',
+            'headers/header-format': 'off',
+        },
+    },
+    {
+        files: ['src/**/*.{ts,tsx}'],
+        rules: {
             '@typescript-eslint/no-explicit-any': 'warn',
             '@typescript-eslint/no-unused-vars': [
                 'warn',
                 { argsIgnorePattern: '^_' },
             ],
-            'no-console': ['warn', { allow: ['warn', 'error'] }],
-            'prettier/prettier': 'error',
-        },
-        ignores: [
-            'package.json',
-            'node_modules/',
-            '**/*/dist/',
-            'build/',
-            'coverage/',
-            '*.config.js',
-            '**/*.config.ts',
-            'vitest.config.ts',
-            'vite.config.ts',
-        ],
-        settings: {
-            react: {
-                version: 'detect',
-            },
         },
     },
-    prettierConfig,
 ]

--- a/core/wallet-user-rpc-client/package.json
+++ b/core/wallet-user-rpc-client/package.json
@@ -34,17 +34,12 @@
         "lodash": "^4.18.1"
     },
     "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@canton-network/core-eslint-config": "workspace:^",
         "@types/isomorphic-fetch": "^0.0.39",
         "@types/json-schema": "7.0.15",
         "@types/lodash": "^4.17.24",
         "@types/ws": "^8.18.1",
-        "@typescript-eslint/eslint-plugin": "^8.63.0",
-        "@typescript-eslint/parser": "^8.63.0",
         "eslint": "^10.6.0",
-        "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-prettier": "^5.5.6",
-        "globals": "^17.7.0",
         "prettier": "3.9.4",
         "tsup": "^8.5.1",
         "typedoc": "^0.28.20",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,66 +1,10 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import js from '@eslint/js'
-import globals from 'globals'
-import tseslint from 'typescript-eslint'
-import { defineConfig } from 'eslint/config'
-import { includeIgnoreFile } from '@eslint/compat'
+import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
-import headers from 'eslint-plugin-headers'
-import nxeslint from '@nx/eslint-plugin'
+import { createConfig } from '@canton-network/core-eslint-config'
 
-const repoRoot = dirname(fileURLToPath(import.meta.url))
-const gitignorePath = join(repoRoot, '.gitignore')
-const headerFilePath = join(repoRoot, 'header.txt')
+const rootDir = dirname(fileURLToPath(import.meta.url))
 
-export default defineConfig([
-    includeIgnoreFile(gitignorePath),
-    {
-        ignores: [
-            '**/dist',
-            '**/build',
-            '**/_proto',
-            '**/.venv',
-            '**/vite-env.d.ts',
-            '.yarn/**',
-            '.commitlintrc.js',
-            '.pnp.*',
-            'core/wallet-dapp-rpc-client',
-            'core/wallet-dapp-remote-rpc-client',
-            'core/wallet-user-rpc-client',
-            'core/ledger-client/src/generated-clients',
-            'core/ledger-client-types/src/generated-clients',
-            'damljs/**',
-            'docs/wallet-integration-guide/examples/**',
-            'examples/ping/playwright-report/**',
-            'core/rpc-generator/templates/client/typescript/src/index.ts',
-        ],
-    },
-    {
-        files: ['**/*.{js,mjs,cjs,ts,mts,cts}'],
-        languageOptions: { globals: { ...globals.browser, ...globals.node } },
-        extends: ['js/recommended'],
-        plugins: { js, headers },
-        rules: {
-            'headers/header-format': [
-                'error',
-                {
-                    source: 'file',
-                    path: headerFilePath,
-                    style: 'line',
-                    trailingNewlines: 2,
-                    variables: {
-                        year: `${new Date().getFullYear()}`,
-                    },
-                },
-            ],
-        },
-    },
-    tseslint.configs.recommended,
-    {
-        files: ['**/*.{ts,tsx,mts,cts}'],
-        plugins: { '@nx': nxeslint },
-    },
-])
+export default createConfig({ rootDir })

--- a/examples/ping/eslint.config.js
+++ b/examples/ping/eslint.config.js
@@ -1,31 +1,29 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import js from '@eslint/js'
-import globals from 'globals'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import { createConfig } from '@canton-network/core-eslint-config'
 
-export default tseslint.config(
-    { ignores: ['dist'] },
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '../..')
+
+export default [
+    ...createConfig({ rootDir }),
     {
-        extends: [js.configs.recommended, ...tseslint.configs.recommended],
         files: ['**/*.{ts,tsx}'],
-        languageOptions: {
-            ecmaVersion: 2020,
-            globals: globals.browser,
-        },
         plugins: {
             'react-hooks': reactHooks,
             'react-refresh': reactRefresh,
         },
         rules: {
+            'headers/header-format': 'off',
             ...reactHooks.configs.recommended.rules,
             'react-refresh/only-export-components': [
                 'warn',
                 { allowConstantExport: true },
             ],
         },
-    }
-)
+    },
+]

--- a/examples/ping/package.json
+++ b/examples/ping/package.json
@@ -18,10 +18,10 @@
         "react-dom": "^19.2.7"
     },
     "devDependencies": {
+        "@canton-network/core-eslint-config": "workspace:^",
         "@canton-network/core-tx-visualizer": "workspace:^",
         "@canton-network/core-wallet-test-utils": "workspace:^",
         "@canton-network/core-wallet-ui-components": "workspace:^",
-        "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.61.1",
         "@types/node": "^25.9.4",
         "@types/react": "^19.2.17",
@@ -30,10 +30,8 @@
         "eslint": "^10.6.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
-        "globals": "^17.7.0",
         "nx": "^22.7.6",
         "typescript": "~5.9.3",
-        "typescript-eslint": "^8.63.0",
         "vite": "^7.3.6"
     },
     "nx": {

--- a/examples/portfolio/eslint.config.js
+++ b/examples/portfolio/eslint.config.js
@@ -1,26 +1,24 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import js from '@eslint/js'
-import globals from 'globals'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import { createConfig } from '@canton-network/core-eslint-config'
 
-export default tseslint.config(
-    { ignores: ['dist'] },
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '../..')
+
+export default [
+    ...createConfig({ rootDir }),
     {
-        extends: [js.configs.recommended, ...tseslint.configs.recommended],
         files: ['**/*.{ts,tsx}'],
-        languageOptions: {
-            ecmaVersion: 2020,
-            globals: globals.browser,
-        },
         plugins: {
             'react-hooks': reactHooks,
             'react-refresh': reactRefresh,
         },
         rules: {
+            'headers/header-format': 'off',
             ...reactHooks.configs.recommended.rules,
             'react-refresh/only-export-components': [
                 'warn',
@@ -33,5 +31,5 @@ export default tseslint.config(
         rules: {
             'react-refresh/only-export-components': 'off',
         },
-    }
-)
+    },
+]

--- a/examples/portfolio/package.json
+++ b/examples/portfolio/package.json
@@ -49,8 +49,8 @@
         "zod": "^4.4.3"
     },
     "devDependencies": {
+        "@canton-network/core-eslint-config": "workspace:^",
         "@canton-network/core-wallet-test-utils": "workspace:^",
-        "@eslint/js": "^10.0.1",
         "@inquirer/prompts": "^8.5.2",
         "@playwright/test": "^1.61.1",
         "@types/node": "^25.9.4",
@@ -60,11 +60,9 @@
         "eslint": "^10.6.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
-        "globals": "^17.7.0",
         "nx": "^22.7.6",
         "tsx": "^4.23.0",
         "typescript": "~5.9.3",
-        "typescript-eslint": "^8.63.0",
         "vite": "^7.3.6",
         "vite-tsconfig-paths": "^6.1.1"
     },

--- a/examples/walletconnect/eslint.config.js
+++ b/examples/walletconnect/eslint.config.js
@@ -9,21 +9,10 @@ const rootDir = join(dirname(fileURLToPath(import.meta.url)), '../..')
 
 export default [
     ...createConfig({ rootDir }),
-    { ignores: ['docs/**'] },
     {
         files: ['**/*.{ts,tsx}'],
         rules: {
             'headers/header-format': 'off',
-        },
-    },
-    {
-        files: ['src/**/*.{ts,tsx}'],
-        rules: {
-            '@typescript-eslint/no-explicit-any': 'warn',
-            '@typescript-eslint/no-unused-vars': [
-                'warn',
-                { argsIgnorePattern: '^_' },
-            ],
         },
     },
 ]

--- a/examples/walletconnect/package.json
+++ b/examples/walletconnect/package.json
@@ -21,9 +21,11 @@
         "react-dom": "^19.2.7"
     },
     "devDependencies": {
+        "@canton-network/core-eslint-config": "workspace:^",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.2.0",
+        "eslint": "^10.6.0",
         "typescript": "~5.9.3",
         "vite": "^7.3.6"
     }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "wallet-gateway/**"
     ],
     "devDependencies": {
+        "@canton-network/core-eslint-config": "workspace:^",
         "@commitlint/config-conventional": "^20.5.3",
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,6 +1400,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@canton-network/core-eslint-config@workspace:^, @canton-network/core-eslint-config@workspace:core/eslint-config":
+  version: 0.0.0-use.local
+  resolution: "@canton-network/core-eslint-config@workspace:core/eslint-config"
+  dependencies:
+    "@eslint/compat": "npm:^2.1.0"
+    "@eslint/js": "npm:^10.0.1"
+    "@nx/eslint-plugin": "npm:22.7.6"
+    eslint-plugin-headers: "npm:^1.3.4"
+    globals: "npm:^17.7.0"
+    typescript-eslint: "npm:^8.63.0"
+  peerDependencies:
+    eslint: ^10.0.0
+  languageName: unknown
+  linkType: soft
+
 "@canton-network/core-ledger-client-types@workspace:^, @canton-network/core-ledger-client-types@workspace:core/ledger-client-types":
   version: 0.0.0-use.local
   resolution: "@canton-network/core-ledger-client-types@workspace:core/ledger-client-types"
@@ -1858,19 +1873,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@canton-network/core-wallet-dapp-remote-rpc-client@workspace:core/wallet-dapp-remote-rpc-client"
   dependencies:
+    "@canton-network/core-eslint-config": "workspace:^"
     "@canton-network/core-rpc-transport": "workspace:^"
     "@canton-network/core-types": "workspace:^"
-    "@eslint/js": "npm:^10.0.1"
     "@types/isomorphic-fetch": "npm:^0.0.39"
     "@types/json-schema": "npm:7.0.15"
     "@types/lodash": "npm:^4.17.24"
     "@types/ws": "npm:^8.18.1"
-    "@typescript-eslint/eslint-plugin": "npm:^8.63.0"
-    "@typescript-eslint/parser": "npm:^8.63.0"
     eslint: "npm:^10.6.0"
-    eslint-config-prettier: "npm:^10.1.8"
-    eslint-plugin-prettier: "npm:^5.5.6"
-    globals: "npm:^17.7.0"
     lodash: "npm:^4.18.1"
     prettier: "npm:3.9.4"
     tsup: "npm:^8.5.1"
@@ -1883,19 +1893,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@canton-network/core-wallet-dapp-rpc-client@workspace:core/wallet-dapp-rpc-client"
   dependencies:
+    "@canton-network/core-eslint-config": "workspace:^"
     "@canton-network/core-rpc-transport": "workspace:^"
     "@canton-network/core-types": "workspace:^"
-    "@eslint/js": "npm:^10.0.1"
     "@types/isomorphic-fetch": "npm:^0.0.39"
     "@types/json-schema": "npm:7.0.15"
     "@types/lodash": "npm:^4.17.24"
     "@types/ws": "npm:^8.18.1"
-    "@typescript-eslint/eslint-plugin": "npm:^8.63.0"
-    "@typescript-eslint/parser": "npm:^8.63.0"
     eslint: "npm:^10.6.0"
-    eslint-config-prettier: "npm:^10.1.8"
-    eslint-plugin-prettier: "npm:^5.5.6"
-    globals: "npm:^17.7.0"
     lodash: "npm:^4.18.1"
     prettier: "npm:3.9.4"
     tsup: "npm:^8.5.1"
@@ -2028,19 +2033,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@canton-network/core-wallet-user-rpc-client@workspace:core/wallet-user-rpc-client"
   dependencies:
+    "@canton-network/core-eslint-config": "workspace:^"
     "@canton-network/core-rpc-transport": "workspace:^"
     "@canton-network/core-types": "workspace:^"
-    "@eslint/js": "npm:^10.0.1"
     "@types/isomorphic-fetch": "npm:^0.0.39"
     "@types/json-schema": "npm:7.0.15"
     "@types/lodash": "npm:^4.17.24"
     "@types/ws": "npm:^8.18.1"
-    "@typescript-eslint/eslint-plugin": "npm:^8.63.0"
-    "@typescript-eslint/parser": "npm:^8.63.0"
     eslint: "npm:^10.6.0"
-    eslint-config-prettier: "npm:^10.1.8"
-    eslint-plugin-prettier: "npm:^5.5.6"
-    globals: "npm:^17.7.0"
     lodash: "npm:^4.18.1"
     prettier: "npm:3.9.4"
     tsup: "npm:^8.5.1"
@@ -2088,13 +2088,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@canton-network/example-ping@workspace:examples/ping"
   dependencies:
+    "@canton-network/core-eslint-config": "workspace:^"
     "@canton-network/core-tx-visualizer": "workspace:^"
     "@canton-network/core-types": "workspace:^"
     "@canton-network/core-wallet-test-utils": "workspace:^"
     "@canton-network/core-wallet-ui-components": "workspace:^"
     "@canton-network/dapp-sdk": "workspace:^"
     "@canton-network/wallet-sdk": "workspace:^"
-    "@eslint/js": "npm:^10.0.1"
     "@playwright/test": "npm:^1.61.1"
     "@types/node": "npm:^25.9.4"
     "@types/react": "npm:^19.2.17"
@@ -2103,12 +2103,10 @@ __metadata:
     eslint: "npm:^10.6.0"
     eslint-plugin-react-hooks: "npm:^7.1.1"
     eslint-plugin-react-refresh: "npm:^0.5.3"
-    globals: "npm:^17.7.0"
     nx: "npm:^22.7.6"
     react: "npm:^19.2.7"
     react-dom: "npm:^19.2.7"
     typescript: "npm:~5.9.3"
-    typescript-eslint: "npm:^8.63.0"
     vite: "npm:^7.3.6"
   languageName: unknown
   linkType: soft
@@ -2119,6 +2117,7 @@ __metadata:
   dependencies:
     "@canton-network/core-acs-reader": "workspace:^"
     "@canton-network/core-amulet-service": "workspace:^"
+    "@canton-network/core-eslint-config": "workspace:^"
     "@canton-network/core-ledger-client": "workspace:^"
     "@canton-network/core-provider-ledger": "workspace:^"
     "@canton-network/core-splice-client": "workspace:^"
@@ -2132,7 +2131,6 @@ __metadata:
     "@canton-network/wallet-sdk": "workspace:^"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.1"
-    "@eslint/js": "npm:^10.0.1"
     "@fontsource/inter": "npm:^5.2.8"
     "@inquirer/prompts": "npm:^8.5.2"
     "@mui/icons-material": "npm:^9.2.0"
@@ -2158,7 +2156,6 @@ __metadata:
     eslint: "npm:^10.6.0"
     eslint-plugin-react-hooks: "npm:^7.1.1"
     eslint-plugin-react-refresh: "npm:^0.5.3"
-    globals: "npm:^17.7.0"
     nx: "npm:^22.7.6"
     pino: "npm:^10.3.1"
     react: "npm:^19.2.7"
@@ -2167,7 +2164,6 @@ __metadata:
     sonner: "npm:^2.0.7"
     tsx: "npm:^4.23.0"
     typescript: "npm:~5.9.3"
-    typescript-eslint: "npm:^8.63.0"
     uuid: "npm:^14.0.1"
     vite: "npm:^7.3.6"
     vite-tsconfig-paths: "npm:^6.1.1"
@@ -2179,6 +2175,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@canton-network/example-walletconnect@workspace:examples/walletconnect"
   dependencies:
+    "@canton-network/core-eslint-config": "workspace:^"
     "@canton-network/core-wallet-auth": "workspace:^"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.1"
@@ -2190,6 +2187,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^5.2.0"
     "@walletconnect/core": "npm:^2.23.10"
     "@walletconnect/types": "npm:^2.23.10"
+    eslint: "npm:^10.6.0"
     react: "npm:^19.2.7"
     react-dom: "npm:^19.2.7"
     typescript: "npm:~5.9.3"
@@ -6037,13 +6035,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkgr/core@npm:^0.3.6":
-  version: 0.3.6
-  resolution: "@pkgr/core@npm:0.3.6"
-  checksum: 10c0/153f0f4563f505faeba13c733efa0e05e467ce1c6b941055a5fd3b4560da60fbf1dff4b11da0075f034ddda11f2842b90395f60895dde5825875b616edccc11c
-  languageName: node
-  linkType: hard
-
 "@playwright/test@npm:^1.61.1":
   version: 1.61.1
   resolution: "@playwright/test@npm:1.61.1"
@@ -8452,7 +8443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.63.0, @typescript-eslint/eslint-plugin@npm:^8.63.0":
+"@typescript-eslint/eslint-plugin@npm:8.63.0":
   version: 8.63.0
   resolution: "@typescript-eslint/eslint-plugin@npm:8.63.0"
   dependencies:
@@ -12343,17 +12334,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:^10.1.8":
-  version: 10.1.8
-  resolution: "eslint-config-prettier@npm:10.1.8"
-  peerDependencies:
-    eslint: ">=7.0.0"
-  bin:
-    eslint-config-prettier: bin/cli.js
-  checksum: 10c0/e1bcfadc9eccd526c240056b1e59c5cd26544fe59feb85f38f4f1f116caed96aea0b3b87868e68b3099e55caaac3f2e5b9f58110f85db893e83a332751192682
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-headers@npm:^1.3.4":
   version: 1.3.4
   resolution: "eslint-plugin-headers@npm:1.3.4"
@@ -12369,26 +12349,6 @@ __metadata:
   peerDependencies:
     eslint: ^9 || ^10
   checksum: 10c0/c3dc2636ec698d4e4b7bc5bb744e8bf24975dc513b5dc9aaf616df5a32392ae5f5eaed91050b8a647cfa1ec717edea6e870d0418887d62a8afa8f1f5fcc1ed0c
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-prettier@npm:^5.5.6":
-  version: 5.5.6
-  resolution: "eslint-plugin-prettier@npm:5.5.6"
-  dependencies:
-    prettier-linter-helpers: "npm:^1.0.1"
-    synckit: "npm:^0.11.13"
-  peerDependencies:
-    "@types/eslint": ">=8.0.0"
-    eslint: ">=8.0.0"
-    eslint-config-prettier: ">= 7.0.0 <10.0.0 || >=10.1.0"
-    prettier: ">=3.0.0"
-  peerDependenciesMeta:
-    "@types/eslint":
-      optional: true
-    eslint-config-prettier:
-      optional: true
-  checksum: 10c0/af37126c947ff3e87ff1ea76408db8cb1c7da966ebdaba68c6dd5924da7eb1b43b1abc4796d753a97b1bc26ea94c5497093e6ab9f8588fffe558d5a554e19bbf
   languageName: node
   linkType: hard
 
@@ -12855,13 +12815,6 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
-  languageName: node
-  linkType: hard
-
-"fast-diff@npm:^1.1.2":
-  version: 1.3.0
-  resolution: "fast-diff@npm:1.3.0"
-  checksum: 10c0/5c19af237edb5d5effda008c891a18a585f74bf12953be57923f17a3a4d0979565fc64dbc73b9e20926b9d895f5b690c618cbb969af0cf022e3222471220ad29
   languageName: node
   linkType: hard
 
@@ -17278,15 +17231,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-linter-helpers@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "prettier-linter-helpers@npm:1.0.1"
-  dependencies:
-    fast-diff: "npm:^1.1.2"
-  checksum: 10c0/91cea965681bc5f62c9d26bd3ca6358b81557261d4802e96ec1cf0acbd99d4b61632d53320cd2c3ec7d7f7805a81345644108a41ef46ddc9688e783a9ac792d1
-  languageName: node
-  linkType: hard
-
 "prettier@npm:3.9.4":
   version: 3.9.4
   resolution: "prettier@npm:3.9.4"
@@ -19113,15 +19057,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"synckit@npm:^0.11.13":
-  version: 0.11.13
-  resolution: "synckit@npm:0.11.13"
-  dependencies:
-    "@pkgr/core": "npm:^0.3.6"
-  checksum: 10c0/5a6c19f4f79045aaa7994106401bff6dbe7cca23a6d0a0723ff14eb8b1bebeb4a71729118f6914905598e304ea2fa13509885e11ba07d92e7cb68a06740cb328
-  languageName: node
-  linkType: hard
-
 "systeminformation@npm:^5.7":
   version: 5.31.6
   resolution: "systeminformation@npm:5.31.6"
@@ -20404,6 +20339,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wallet-kernel@workspace:."
   dependencies:
+    "@canton-network/core-eslint-config": "workspace:^"
     "@commitlint/config-conventional": "npm:^20.5.3"
     "@eslint/compat": "npm:^2.1.0"
     "@eslint/js": "npm:^10.0.1"


### PR DESCRIPTION
Move root eslint setup into core/eslint-config and wire workspaces so root and per-workspace lint resolve the same config. Fixes #374.

## Summary

Fixes inconsistent ESLint resolution described in #374: root `yarn eslint` and per-workspace `yarn workspaces foreach -A run eslint` were not always loading the same config.

Adds a private shared package `@canton-network/core-eslint-config` at `core/eslint-config` that owns the monorepo flat config (`createConfig({ rootDir })`). The root `eslint.config.mjs` and workspace configs become thin wrappers that import it, so root and workspace lint resolve one source of truth.

Wired and thinned:
- Root package + lockfile
- `core/wallet-dapp-rpc-client`, `core/wallet-dapp-remote-rpc-client`, `core/wallet-user-rpc-client` (shared config + local overrides: ignore `docs/**`, header rule off, `any` / unused as warn on `src`)
- Examples `ping`, `portfolio`, `walletconnect` (shared config + React where needed; header format off; walletconnect gets a new `eslint.config.js` so Nx/CI lint picks it up)

Also aligns a few shared-config details that were missing from the old root-only story: include `*.tsx` in files globs and set `tsconfigRootDir` from the caller’s `rootDir`.

Closes #374

## Test plan

- [x] `yarn lint` (Nx CI path) — all projects green
- [x] `yarn build:all` — green
- [x] `yarn playwright install` then `yarn test:all` — green