### PR TITLE
fix: improve auth callback page

### DIFF
--- a/wallet-gateway/remote/src/web/frontend/callback/index.html
+++ b/wallet-gateway/remote/src/web/frontend/callback/index.html
@@ -7,6 +7,6 @@
     </head>
     <body>
         <login-callback></login-callback>
-        <script type="module" src="./login-callback.ts"></script>
+        <script type="module" src="./index.ts"></script>
     </body>
 </html>

--- a/wallet-gateway/remote/src/web/frontend/callback/index.test.ts
+++ b/wallet-gateway/remote/src/web/frontend/callback/index.test.ts
@@ -31,8 +31,8 @@ vi.mock('../state-manager.js', () => ({
     },
 }))
 
-import './login-callback.js'
-import { LoginCallback } from './login-callback.js'
+import './index.js'
+import { LoginCallback } from './index.js'
 
 const oauthState = {
     configUrl: 'https://idp.example/.well-known/openid-configuration',
@@ -111,10 +111,15 @@ describe('LoginCallback', () => {
         vi.unstubAllGlobals()
     })
 
-    it('renders the logged-in heading', async () => {
+    it('renders the loading state', async () => {
         el = await fixture<LoginCallback>(componentFixture)
 
-        expect(el.shadowRoot?.textContent).toContain('Logged in!')
+        const loadingState = el.shadowRoot?.querySelector(
+            'wg-loading-state'
+        ) as (HTMLElement & { text?: string }) | null
+
+        expect(loadingState).not.toBeNull()
+        expect(loadingState?.text).toBe('Logging in...')
     })
 
     it('does nothing when both code and state are missing', async () => {

--- a/wallet-gateway/remote/src/web/frontend/callback/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/callback/index.ts
@@ -88,6 +88,8 @@ export class LoginCallback extends LitElement {
     }
 
     render() {
-        return html`<h2>Logged in!</h2>`
+        return html`<wg-loading-state
+            .text=${'Logging in...'}
+        ></wg-loading-state>`
     }
 }


### PR DESCRIPTION
small fix to make the callback page UI fit better with the overall app. The callback usually flashes only for a moment before it redirects you, but you can still catch a glimpse of the completely unstyled `"<h2>Logged in!</h2>"` for a second. 

Also the page could get stuck in the event of an error calling `addSession`, so the page would look a bit nicer in that case too


https://github.com/user-attachments/assets/5516d69b-c8e1-4e00-a6d1-e345f661f1e5

