### PR TITLE
fix: minor bugs around allocations

### DIFF
--- a/examples/portfolio/src/components/dashboard/allocation-action-dialog-content.tsx
+++ b/examples/portfolio/src/components/dashboard/allocation-action-dialog-content.tsx
@@ -394,9 +394,10 @@ function TransferLegCard({
                         >
                             {canCreateAllocation ? (
                                 <PillButton
+                                    size="small"
                                     disabled={actionDisabled}
                                     onClick={onCreateAllocation}
-                                    sx={{ minWidth: 104, px: 2, fontSize: 16 }}
+                                    sx={{ minWidth: 90, fontSize: 14 }}
                                 >
                                     {isLegLoading ? (
                                         <CircularProgress
@@ -411,14 +412,15 @@ function TransferLegCard({
                             {canWithdrawAllocation ? (
                                 <PillButton
                                     variant="outlined"
-                                    color="warning"
+                                    color="secondary"
+                                    size="small"
                                     disabled={isLoading}
                                     onClick={() =>
                                         onWithdrawAllocation(
                                             allocationContractId
                                         )
                                     }
-                                    sx={{ minWidth: 104, px: 2, fontSize: 16 }}
+                                    sx={{ minWidth: 90, fontSize: 14 }}
                                 >
                                     {isLegLoading ? (
                                         <CircularProgress

--- a/examples/portfolio/src/components/offers/offer-row.tsx
+++ b/examples/portfolio/src/components/offers/offer-row.tsx
@@ -183,9 +183,14 @@ const interactiveOfferRowSx: SxProps<Theme> = {
 const STATUS_THEME_KEY_BY_STATUS = {
     Pending: 'pending',
     'Action Required': 'action-required',
+    'Partially Allocated': 'partially-allocated',
     Allocated: 'allocated',
     Expired: 'expired',
 } satisfies Record<
     OfferStatus,
-    'pending' | 'action-required' | 'allocated' | 'expired'
+    | 'pending'
+    | 'action-required'
+    | 'partially-allocated'
+    | 'allocated'
+    | 'expired'
 >

--- a/examples/portfolio/src/hooks/useActionRequiredItems.ts
+++ b/examples/portfolio/src/hooks/useActionRequiredItems.ts
@@ -18,7 +18,8 @@ export function useActionRequiredItems(): ActionRequiredItemsResult {
             offers.all.filter((offer) => {
                 const hasActionableStatus =
                     offer.status === 'Pending' ||
-                    offer.status === 'Action Required'
+                    offer.status === 'Action Required' ||
+                    offer.status === 'Partially Allocated'
                 const isOutgoingTransfer =
                     'direction' in offer && offer.direction === 'outgoing'
 

--- a/examples/portfolio/src/hooks/useOffers.ts
+++ b/examples/portfolio/src/hooks/useOffers.ts
@@ -6,7 +6,6 @@ import type {
     ActionItem,
     AllocationActionItem,
     TransferActionItem,
-    TransferLegWithAllocation,
 } from '@components/types'
 import { isExpired } from '@utils/date-format'
 import { useOfferItems, type OfferItemsResult } from './useOfferItems'
@@ -14,7 +13,11 @@ import { useOfferItems, type OfferItemsResult } from './useOfferItems'
 export type OfferDirection = 'incoming' | 'outgoing'
 export type OfferCategory = 'transfers' | 'allocations'
 export type OfferStatus =
-    'Pending' | 'Action Required' | 'Allocated' | 'Expired'
+    | 'Pending'
+    | 'Action Required'
+    | 'Partially Allocated'
+    | 'Allocated'
+    | 'Expired'
 
 export type TransferOfferItem = {
     id: string
@@ -102,34 +105,28 @@ function deriveTransferOffer(
 function deriveAllocationOffer(
     item: AllocationActionItem
 ): AllocationOfferItem {
-    const isAllocated = areCurrentPartySenderLegsAllocated(item)
-    const status = isAllocated
-        ? 'Allocated'
-        : isExpired(item.expiry)
-          ? 'Expired'
-          : 'Action Required'
-
     return {
         id: `${item.contractId}-allocation`,
         source: item,
-        status,
+        status: deriveAllocationStatus(item),
     }
 }
 
-function areCurrentPartySenderLegsAllocated(item: AllocationActionItem) {
-    const senderLegs = item.transferLegs.filter((leg) =>
-        isCurrentPartySender(item.currentPartyId, leg)
+function deriveAllocationStatus(item: AllocationActionItem): OfferStatus {
+    const senderLegs = item.transferLegs.filter(
+        (leg) => leg.transferLeg.sender === item.currentPartyId
     )
+    const allocatedSenderLegCount = senderLegs.filter(
+        (leg) => leg.allocations.length > 0
+    ).length
 
-    return (
+    if (
         senderLegs.length === 0 ||
-        senderLegs.every((leg) => leg.allocations.length > 0)
-    )
-}
-
-function isCurrentPartySender(
-    currentPartyId: string,
-    leg: TransferLegWithAllocation
-) {
-    return leg.transferLeg.sender === currentPartyId
+        allocatedSenderLegCount === senderLegs.length
+    ) {
+        return 'Allocated'
+    }
+    if (allocatedSenderLegCount > 0) return 'Partially Allocated'
+    if (isExpired(item.expiry)) return 'Expired'
+    return 'Action Required'
 }

--- a/examples/portfolio/src/lib/theme.ts
+++ b/examples/portfolio/src/lib/theme.ts
@@ -34,6 +34,7 @@ declare module '@mui/material/styles' {
             status: {
                 pending: { background: string; text: string }
                 'action-required': { background: string; text: string }
+                'partially-allocated': { background: string; text: string }
                 allocated: { background: string; text: string }
                 expired: { background: string; text: string }
             }
@@ -122,6 +123,10 @@ export const darkPortfolioTokens: ThemeOptions = {
                 background: portfolioColors.yellow99,
                 text: portfolioColors.black,
             },
+            'partially-allocated': {
+                background: portfolioColors.yellow99,
+                text: portfolioColors.black,
+            },
             allocated: {
                 background: portfolioColors.purple30,
                 text: portfolioColors.black,
@@ -194,6 +199,10 @@ export const lightPortfolioTokens: ThemeOptions = {
                 text: portfolioColors.white,
             },
             'action-required': {
+                background: portfolioColors.grey69,
+                text: portfolioColors.white,
+            },
+            'partially-allocated': {
                 background: portfolioColors.grey69,
                 text: portfolioColors.white,
             },

--- a/examples/portfolio/tests/allocation-next.spec.ts
+++ b/examples/portfolio/tests/allocation-next.spec.ts
@@ -240,22 +240,28 @@ test.describe('OTC allocations', () => {
         ).toBeVisible()
         await expect(aliceToBobLeg).toContainText(bobHint.slice(0, 10))
 
-        await wg.approveTransaction(() =>
-            aliceToBobLeg.getByRole('button', { name: 'Allocate' }).click()
-        )
+        const allocateButton = aliceToBobLeg.getByRole('button', {
+            name: 'Allocate',
+        })
+        await expect(allocateButton).toHaveClass(/MuiButton-sizeSmall/)
+        await wg.approveTransaction(() => allocateButton.click())
         await expect(
             aliceToBobLeg.getByRole('button', { name: 'Withdraw' })
         ).toBeVisible({ timeout: 15_000 })
 
         await dialog.getByLabel('Close allocation request dialog').click()
         await expect(dialog).not.toBeVisible({ timeout: 10_000 })
-        await expect(allocationRequest).toBeVisible({ timeout: 15_000 })
+        await expect(allocationRequest).toContainText('Partially Allocated', {
+            timeout: 15_000,
+        })
         await allocationRequest.click()
 
         const withdrawButton = aliceToBobLeg.getByRole('button', {
             name: 'Withdraw',
         })
         await expect(withdrawButton).toBeVisible({ timeout: 15_000 })
+        await expect(withdrawButton).toHaveClass(/MuiButton-sizeSmall/)
+        await expect(withdrawButton).toHaveClass(/MuiButton-colorSecondary/)
         await wg.approveTransaction(() => withdrawButton.click())
 
         await expect(


### PR DESCRIPTION
- Withdraw button for allocation dialog should be a secondary button not a warning red button
- Set Allocate/Withdraw button size to small and reduce width by 10-15px
- If one of the legs for an allocation request with you as the sender has been allocated, status should be "Partially Allocated" not Pending
- Update e2e spec

Part of #2149