### PR TITLE
chore: make wallet SDK connection and registry aware

### DIFF
--- a/examples/portfolio/src/contexts/ConnectionContext.tsx
+++ b/examples/portfolio/src/contexts/ConnectionContext.tsx
@@ -9,6 +9,7 @@ type Connection = {
     status?: sdk.dappAPI.StatusEvent
     accounts: sdk.dappAPI.Wallet[]
     error?: string
+    sessionTokenVersion: number
 
     connect: () => void
     open: () => void

--- a/examples/portfolio/src/contexts/ConnectionProvider.tsx
+++ b/examples/portfolio/src/contexts/ConnectionProvider.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import * as sdk from '@canton-network/dapp-sdk'
 import { WalletConnectAdapter } from '@canton-network/dapp-sdk'
@@ -25,32 +25,67 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
     >()
     const [accounts, setAccounts] = useState<sdk.dappAPI.Wallet[]>([])
     const [error, setError] = useState<string | undefined>()
+    const [sessionTokenVersion, setSessionTokenVersion] = useState(0)
+    const currentSessionToken = useRef<string | undefined>(undefined)
+
+    const clearWalletConnectionQueries = useCallback(() => {
+        queryClient.removeQueries({
+            queryKey: queryKeys.walletConnection.all,
+        })
+    }, [queryClient])
+
+    const updateSessionToken = useCallback(
+        (status: sdk.dappAPI.StatusEvent) => {
+            const nextToken = status.session?.accessToken
+            if (nextToken && nextToken !== currentSessionToken.current) {
+                clearResolvedServices()
+                currentSessionToken.current = nextToken
+                setSessionTokenVersion((version) => version + 1)
+            }
+        },
+        []
+    )
+
+    const publishConnectedStatus = useCallback(
+        (status: sdk.dappAPI.StatusEvent, connectionBoundary: boolean) => {
+            if (connectionBoundary) {
+                clearWalletConnectionQueries()
+                clearResolvedServices()
+                currentSessionToken.current = undefined
+                setAccounts([])
+            }
+            updateSessionToken(status)
+            setConnectionStatus(status)
+            setError(undefined)
+        },
+        [clearWalletConnectionQueries, updateSessionToken]
+    )
 
     const connect = useCallback(() => {
         sdk.connect()
             .then(() => sdk.status())
-            .then((status) => {
+            .then((status) => publishConnectedStatus(status, true))
+            .catch((err: unknown) => {
+                clearWalletConnectionQueries()
                 clearResolvedServices()
-                setConnectionStatus(status)
-                setAccounts([])
-            })
-            .catch((err) => {
-                clearResolvedServices()
+                currentSessionToken.current = undefined
                 setConnectionStatus(undefined)
-                setError(err.details)
+                setError(err instanceof Error ? err.message : String(err))
                 setAccounts([])
             })
-    }, [])
+    }, [clearWalletConnectionQueries, publishConnectedStatus])
 
     const open = useCallback(() => sdk.open(), [])
 
     const doDisconnect = useCallback(() => {
+        clearWalletConnectionQueries()
         clearResolvedServices()
+        currentSessionToken.current = undefined
         setConnectionStatus(undefined)
         setAccounts([])
         setError(undefined)
         sdk.disconnect().catch(() => {})
-    }, [])
+    }, [clearWalletConnectionQueries])
 
     const disconnect = useCallback(() => {
         doDisconnect()
@@ -63,8 +98,7 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
             .then(() => sdk.status())
             .then((status) => {
                 if (active) {
-                    setConnectionStatus(status)
-                    setError(undefined)
+                    publishConnectedStatus(status, true)
                 }
             })
             .catch((reason) => {
@@ -88,19 +122,18 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
         return () => {
             active = false
         }
-    }, [])
+    }, [publishConnectedStatus])
 
     // Listen for status changes when connected (re-registers after each connect/disconnect)
     useEffect(() => {
         if (!connectionStatus?.connection?.isConnected) return
 
         const onStatusChanged = (status: sdk.dappAPI.StatusEvent) => {
-            clearResolvedServices()
             if (!status.connection?.isConnected) {
                 doDisconnect()
                 return
             }
-            setConnectionStatus(status)
+            publishConnectedStatus(status, false)
         }
 
         sdk.onStatusChanged(onStatusChanged)
@@ -108,9 +141,13 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
         return () => {
             void sdk.removeOnStatusChanged(onStatusChanged)
         }
-    }, [connectionStatus?.connection?.isConnected, doDisconnect])
+    }, [
+        connectionStatus?.connection?.isConnected,
+        doDisconnect,
+        publishConnectedStatus,
+    ])
 
-    // Second effect: request accounts only when connected
+    // Request accounts and listen for provider events only while connected.
     useEffect(() => {
         const provider = sdk.getConnectedProvider()
         if (!provider || !connectionStatus?.connection?.isConnected) return
@@ -133,10 +170,10 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
             console.log('incoming event', event)
             if (event.status === 'executed') {
                 await queryClient.invalidateQueries({
-                    queryKey: queryKeys.listPendingTransfers.all,
+                    queryKey: queryKeys.walletConnection.pendingTransfers.all,
                 })
                 await queryClient.invalidateQueries({
-                    queryKey: queryKeys.getTransactionHistory.all,
+                    queryKey: queryKeys.walletConnection.transactionHistory.all,
                 })
             }
         }
@@ -160,6 +197,7 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
                 status: connectionStatus,
                 accounts,
                 error,
+                sessionTokenVersion,
                 connect,
                 open,
                 disconnect,

--- a/examples/portfolio/src/hooks/query-keys.ts
+++ b/examples/portfolio/src/hooks/query-keys.ts
@@ -1,92 +1,116 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+const walletConnection = ['walletConnection'] as const
+
 export const queryKeys = {
-    getTransactionHistory: {
-        all: ['getTransactionHistory'],
-        forParty: (party: string | undefined) => [
-            'getTransactionHistory',
-            party,
-        ],
-    },
+    walletConnection: {
+        all: walletConnection,
 
-    listPendingTransfers: {
-        all: ['listPendingTransfers'],
-        forParty: (party: string | undefined) => [
-            'listPendingTransfers',
-            party,
-        ],
-    },
+        walletSdk: {
+            all: [...walletConnection, 'walletSdk'] as const,
+            forConfig: ({
+                tokenVersion,
+                registryUrls,
+            }: {
+                tokenVersion: number
+                registryUrls: readonly string[]
+            }) =>
+                [
+                    ...walletConnection,
+                    'walletSdk',
+                    tokenVersion,
+                    registryUrls,
+                ] as const,
+        },
 
-    listHoldings: {
-        all: ['holdings'],
-        forParty: (party: string | undefined) => ['holdings', party],
-    },
+        holdings: {
+            all: [...walletConnection, 'holdings'] as const,
+            forParty: (party: string | undefined) =>
+                [...walletConnection, 'holdings', party] as const,
+        },
 
-    listAllocationRequests: {
-        all: ['listAllocationRequests'],
-        forParty: (party: string | undefined) => [
-            'listAllocationRequests',
-            party,
-        ],
-    },
+        pendingTransfers: {
+            all: [...walletConnection, 'pendingTransfers'] as const,
+            forParty: (party: string | undefined) =>
+                [...walletConnection, 'pendingTransfers', party] as const,
+        },
 
-    listAllocations: {
-        all: ['listAllocations'],
-        forParty: (party: string | undefined) => ['listAllocations', party],
+        allocations: {
+            all: [...walletConnection, 'allocations'] as const,
+            forParty: (party: string | undefined) =>
+                [...walletConnection, 'allocations', party] as const,
+        },
+
+        allocationRequests: {
+            all: [...walletConnection, 'allocationRequests'] as const,
+            forParty: (party: string | undefined) =>
+                [...walletConnection, 'allocationRequests', party] as const,
+        },
+
+        transactionHistory: {
+            all: [...walletConnection, 'transactionHistory'] as const,
+            forParty: (party: string | undefined) =>
+                [...walletConnection, 'transactionHistory', party] as const,
+        },
+
+        transactionHistoryService: {
+            all: [...walletConnection, 'transactionHistoryService'] as const,
+            forParty: (party: string) =>
+                [
+                    ...walletConnection,
+                    'transactionHistoryService',
+                    party,
+                ] as const,
+        },
+
+        preapprovals: {
+            all: [...walletConnection, 'preapprovals'] as const,
+            status: ({
+                party,
+                kind,
+                registryPartyId,
+                instrumentId,
+            }: {
+                party: string | undefined
+                kind: string
+                registryPartyId: string
+                instrumentId: string
+            }) =>
+                [
+                    ...walletConnection,
+                    'preapprovals',
+                    'status',
+                    party,
+                    kind,
+                    registryPartyId,
+                    instrumentId,
+                ] as const,
+        },
     },
 
     isDevNet: {
-        all: ['isDevNet'],
-    },
-
-    walletSdk: {
-        all: ['walletSdk'],
-        forConnection: (sessionToken: string | undefined) => [
-            'walletSdk',
-            sessionToken,
-        ],
+        all: ['isDevNet'] as const,
     },
 
     instruments: {
-        all: ['instruments'],
-        forRegistry: (party: string, url: string) => [
-            'instruments',
-            party,
-            url,
-        ],
+        all: ['instruments'] as const,
+        forRegistry: (party: string, url: string) =>
+            ['instruments', party, url] as const,
     },
 
     registries: {
-        all: ['registries'],
+        all: ['registries'] as const,
     },
 
     registryInfo: {
-        all: ['registryInfo'],
-        forRegistry: (url: string) => ['registryInfo', url],
+        all: ['registryInfo'] as const,
+        forRegistry: (url: string) => ['registryInfo', url] as const,
     },
 
     utilityOperators: {
-        all: ['utilityOperators'],
-        forRegistry: (registryPartyId: string, registryUrl: string) => [
-            'utilityOperators',
-            registryPartyId,
-            registryUrl,
-        ],
-    },
-
-    preapprovals: {
-        all: ['preapprovals'],
-        status: ({
-            party,
-            kind,
-            registryPartyId,
-            instrumentId,
-        }: {
-            party: string | undefined
-            kind: string
-            registryPartyId: string
-            instrumentId: string
-        }) => ['preapprovals', party, kind, registryPartyId, instrumentId],
+        all: ['utilityOperators'] as const,
+        forRegistry: (registryPartyId: string, registryUrl: string) =>
+            ['utilityOperators', registryPartyId, registryUrl] as const,
     },
 }

--- a/examples/portfolio/src/hooks/query-options.ts
+++ b/examples/portfolio/src/hooks/query-options.ts
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { queryOptions, type QueryClient } from '@tanstack/react-query'
+import * as dappSdk from '@canton-network/dapp-sdk'
+import type { LedgerProvider } from '@canton-network/core-provider-ledger'
 import { usePortfolio } from '../contexts/PortfolioContext'
 import { usePortfolioConfig } from '../contexts/PortfolioConfigContext'
+import { useConnection } from '../contexts/ConnectionContext'
 import { queryKeys } from './query-keys'
-import type { useWalletSdk } from './useWalletSdk'
+import type { WalletSdk } from './useWalletSdk'
 import type { PreapprovalRow } from '../types/preapprovals'
-
-type WalletSdk = ReturnType<typeof useWalletSdk>['sdk'] | undefined
+import { logger } from '@lib/logger'
+import { TransactionHistoryService } from '../services/transaction-history-service'
 
 const UTILITY_OPERATOR_ENDPOINT = '/api/utilities/v0/operator'
 
@@ -52,13 +55,36 @@ export const utilityOperatorQueryOptions = ({
         staleTime: Infinity,
     })
 
+export const transactionHistoryServiceQueryOptions = (partyId: string) =>
+    queryOptions({
+        queryKey:
+            queryKeys.walletConnection.transactionHistoryService.forParty(
+                partyId
+            ),
+        queryFn: () => {
+            const provider = dappSdk.getConnectedProvider()
+            if (!provider) {
+                throw new Error('Dapp provider is not available')
+            }
+
+            return new TransactionHistoryService({
+                logger,
+                provider: provider as unknown as LedgerProvider,
+                party: partyId,
+            })
+        },
+        staleTime: Infinity,
+        gcTime: Infinity,
+    })
+
 export const usePendingTransfersQueryOptions = (party: string | undefined) => {
     const { listPendingTransfers } = usePortfolio()
+    const { status } = useConnection()
     return queryOptions({
         retry: 10,
-        queryKey: queryKeys.listPendingTransfers.forParty(party),
-        queryFn: async () =>
-            party ? listPendingTransfers({ party: party! }) : [],
+        queryKey: queryKeys.walletConnection.pendingTransfers.forParty(party),
+        queryFn: () => listPendingTransfers({ party: party! }),
+        enabled: !!status?.connection?.isConnected && !!party,
     })
 }
 
@@ -66,19 +92,21 @@ export const useAllocationRequestsQueryOptions = (
     party: string | undefined
 ) => {
     const { listAllocationRequests } = usePortfolio()
+    const { status } = useConnection()
     return queryOptions({
-        queryKey: queryKeys.listAllocationRequests.forParty(party),
+        queryKey: queryKeys.walletConnection.allocationRequests.forParty(party),
         queryFn: () => listAllocationRequests({ party: party! }),
-        enabled: !!party,
+        enabled: !!status?.connection?.isConnected && !!party,
     })
 }
 
 export const useAllocationsQueryOptions = (party: string | undefined) => {
     const { listAllocations } = usePortfolio()
+    const { status } = useConnection()
     return queryOptions({
-        queryKey: queryKeys.listAllocations.forParty(party),
+        queryKey: queryKeys.walletConnection.allocations.forParty(party),
         queryFn: () => listAllocations({ party: party! }),
-        enabled: !!party,
+        enabled: !!status?.connection?.isConnected && !!party,
     })
 }
 
@@ -108,7 +136,7 @@ export const preapprovalStatusQueryOptions = ({
     queryClient: QueryClient
 }) =>
     queryOptions({
-        queryKey: queryKeys.preapprovals.status({
+        queryKey: queryKeys.walletConnection.preapprovals.status({
             party,
             kind: row.kind,
             registryPartyId: row.registryPartyId,

--- a/examples/portfolio/src/hooks/useAggregatedHoldings.ts
+++ b/examples/portfolio/src/hooks/useAggregatedHoldings.ts
@@ -9,14 +9,16 @@ import {
     enrichWithInstrumentInfo,
 } from '../utils/aggregate-holdings'
 import { queryKeys } from './query-keys'
+import { useConnection } from '../contexts/ConnectionContext'
 
 export const useAggregatedHoldings = (partyId: string | undefined) => {
     const instruments = useInstruments()
+    const { status } = useConnection()
 
     const holdingsQuery = useQuery({
-        queryKey: queryKeys.listHoldings.forParty(partyId),
+        queryKey: queryKeys.walletConnection.holdings.forParty(partyId),
         queryFn: () => listHoldings({ party: partyId as string }),
-        enabled: !!partyId,
+        enabled: !!status?.connection?.isConnected && !!partyId,
         select: (holdings) =>
             enrichWithInstrumentInfo(aggregateHoldings(holdings), instruments),
     })

--- a/examples/portfolio/src/hooks/useAllAccountAssets.ts
+++ b/examples/portfolio/src/hooks/useAllAccountAssets.ts
@@ -12,6 +12,7 @@ import {
 } from '../utils/aggregate-holdings'
 import { useAccounts } from './useAccounts'
 import { queryKeys } from './query-keys'
+import { useConnection } from '../contexts/ConnectionContext'
 
 export interface PortfolioAssetWalletBalanceView {
     id: string
@@ -38,11 +39,16 @@ export interface PortfolioAssetsResult {
 export const useAllAccountAssets = (): PortfolioAssetsResult => {
     const accounts = useAccounts()
     const registryInstruments = useInstruments()
+    const { status } = useConnection()
+    const isConnected = status?.connection?.isConnected ?? false
 
     const holdingsQueries = useQueries({
         queries: accounts.map((account) => ({
-            queryKey: queryKeys.listHoldings.forParty(account.partyId),
+            queryKey: queryKeys.walletConnection.holdings.forParty(
+                account.partyId
+            ),
             queryFn: () => listHoldings({ party: account.partyId }),
+            enabled: isConnected,
         })),
     })
 

--- a/examples/portfolio/src/hooks/useCreateAllocation.ts
+++ b/examples/portfolio/src/hooks/useCreateAllocation.ts
@@ -25,10 +25,14 @@ export const useCreateAllocation = () => {
         onSuccess: async (_, args) => {
             await Promise.all([
                 queryClient.invalidateQueries({
-                    queryKey: queryKeys.listAllocations.forParty(args.party),
+                    queryKey: queryKeys.walletConnection.allocations.forParty(
+                        args.party
+                    ),
                 }),
                 queryClient.invalidateQueries({
-                    queryKey: queryKeys.listHoldings.forParty(args.party),
+                    queryKey: queryKeys.walletConnection.holdings.forParty(
+                        args.party
+                    ),
                 }),
             ])
         },

--- a/examples/portfolio/src/hooks/useCreatePreapprovalContracts.ts
+++ b/examples/portfolio/src/hooks/useCreatePreapprovalContracts.ts
@@ -2,17 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useMutation } from '@tanstack/react-query'
-import { v4 } from 'uuid'
 import type { AssetBody } from '@canton-network/wallet-sdk'
 import type { PartyId } from '@canton-network/core-types'
-import * as dappSdk from '@canton-network/dapp-sdk'
 import { WalletSDKUtilitiesPluginName } from '@lib/utilities-wallet-sdk-plugin'
-import { useWalletSdk } from '@hooks/useWalletSdk'
-
-type WalletSdkWithUtilities = ReturnType<typeof useWalletSdk>['sdk']
+import { useWalletSdk, type ReadyWalletSdk } from '@hooks/useWalletSdk'
+import { submitViaProvider } from '@lib/submit'
 
 type CreatePreapprovalContractsInput = {
-    sdk: WalletSdkWithUtilities
+    sdk: ReadyWalletSdk
     receiver: PartyId
     operator: PartyId
     instrumentAdmin: PartyId
@@ -42,16 +39,7 @@ const createPreapprovalContracts = async ({
         })),
     })
 
-    const provider = dappSdk.getConnectedProvider()
-    await provider?.request({
-        method: 'prepareExecuteAndWait',
-        params: {
-            commands: [preapprovalCommand],
-            commandId: v4(),
-            actAs: [receiver],
-            disclosedContracts,
-        },
-    })
+    await submitViaProvider([preapprovalCommand, disclosedContracts], receiver)
 }
 
 export const useCreatePreapprovalContracts = () => {

--- a/examples/portfolio/src/hooks/useCreateTransfer.ts
+++ b/examples/portfolio/src/hooks/useCreateTransfer.ts
@@ -29,13 +29,13 @@ export const useCreateTransfer = () => {
             }),
         onSuccess: async () => {
             await queryClient.invalidateQueries({
-                queryKey: queryKeys.listPendingTransfers.all,
+                queryKey: queryKeys.walletConnection.pendingTransfers.all,
             })
             await queryClient.invalidateQueries({
-                queryKey: queryKeys.listHoldings.all,
+                queryKey: queryKeys.walletConnection.holdings.all,
             })
             await queryClient.invalidateQueries({
-                queryKey: queryKeys.getTransactionHistory.all,
+                queryKey: queryKeys.walletConnection.transactionHistory.all,
             })
         },
     })

--- a/examples/portfolio/src/hooks/useExerciseTransfer.ts
+++ b/examples/portfolio/src/hooks/useExerciseTransfer.ts
@@ -25,13 +25,15 @@ export const useExerciseTransfer = () => {
             }),
         onSuccess: async (_, args) => {
             await queryClient.invalidateQueries({
-                queryKey: queryKeys.listPendingTransfers.forParty(args.party),
+                queryKey: queryKeys.walletConnection.pendingTransfers.forParty(
+                    args.party
+                ),
             })
             await queryClient.invalidateQueries({
-                queryKey: queryKeys.listHoldings.all,
+                queryKey: queryKeys.walletConnection.holdings.all,
             })
             await queryClient.invalidateQueries({
-                queryKey: queryKeys.getTransactionHistory.all,
+                queryKey: queryKeys.walletConnection.transactionHistory.all,
             })
         },
     })

--- a/examples/portfolio/src/hooks/usePreapprovalStatuses.ts
+++ b/examples/portfolio/src/hooks/usePreapprovalStatuses.ts
@@ -3,10 +3,8 @@
 
 import { useQueries, useQueryClient } from '@tanstack/react-query'
 import { preapprovalStatusQueryOptions } from './query-options'
-import type { useWalletSdk } from './useWalletSdk'
+import type { WalletSdk } from './useWalletSdk'
 import type { PreapprovalRow } from '../types/preapprovals'
-
-type WalletSdk = ReturnType<typeof useWalletSdk>['sdk'] | undefined
 
 type UsePreapprovalStatusesArgs = {
     rows: PreapprovalRow[]

--- a/examples/portfolio/src/hooks/useTogglePreapproval.ts
+++ b/examples/portfolio/src/hooks/useTogglePreapproval.ts
@@ -2,17 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { v4 } from 'uuid'
 import { toast } from 'sonner'
-import * as dappSdk from '@canton-network/dapp-sdk'
-import type { LedgerTypes } from '@canton-network/wallet-sdk'
+import type { PreparedCommand } from '@canton-network/wallet-sdk'
 import { utilityOperatorQueryOptions } from './query-options'
 import { queryKeys } from './query-keys'
-import type { useWalletSdk } from './useWalletSdk'
+import type { WalletSdk } from './useWalletSdk'
 import { WalletSDKUtilitiesPluginName } from '@lib/utilities-wallet-sdk-plugin'
+import { submitViaProvider } from '@lib/submit'
 import type { PreapprovalRow } from '../types/preapprovals'
-
-type WalletSdk = ReturnType<typeof useWalletSdk>['sdk'] | undefined
 
 type TogglePreapprovalInput = {
     row: PreapprovalRow
@@ -48,25 +45,17 @@ export function useTogglePreapproval({
                         }
                     )
 
-                    await submitPreapprovalCommand({
-                        command,
-                        disclosedContracts: [],
-                        receiver: primaryParty,
-                    })
+                    await submitPreapprovalCommand([command, []], primaryParty)
                     await sdk.amulet.preapproval.fetchStatus(primaryParty)
                     return
                 }
 
-                const [command, disclosedContracts] =
+                const preparedCommand =
                     await sdk.amulet.preapproval.command.cancel({
                         parties: { receiver: primaryParty },
                     })
 
-                await submitPreapprovalCommand({
-                    command,
-                    disclosedContracts,
-                    receiver: primaryParty,
-                })
+                await submitPreapprovalCommand(preparedCommand, primaryParty)
                 await sdk.amulet.preapproval.fetchStatus(primaryParty, {
                     cancelled: true,
                 })
@@ -88,7 +77,7 @@ export function useTogglePreapproval({
             }
 
             if (enabled) {
-                const [command, disclosedContracts] = sdk[
+                const preparedCommand = sdk[
                     WalletSDKUtilitiesPluginName
                 ].preapprovalTransfer.create({
                     receiver: primaryParty,
@@ -97,34 +86,26 @@ export function useTogglePreapproval({
                     instrumentAllowances: [{ id: row.instrument.id }],
                 })
 
-                await submitPreapprovalCommand({
-                    command,
-                    disclosedContracts,
-                    receiver: primaryParty,
-                })
+                await submitPreapprovalCommand(preparedCommand, primaryParty)
                 await sdk[
                     WalletSDKUtilitiesPluginName
                 ].preapprovalTransfer.fetchStatus(args)
                 return
             }
 
-            const [command, disclosedContracts] =
+            const preparedCommand =
                 await sdk[
                     WalletSDKUtilitiesPluginName
                 ].preapprovalTransfer.cancel(args)
 
-            await submitPreapprovalCommand({
-                command,
-                disclosedContracts,
-                receiver: primaryParty,
-            })
+            await submitPreapprovalCommand(preparedCommand, primaryParty)
             await sdk[
                 WalletSDKUtilitiesPluginName
             ].preapprovalTransfer.fetchStatus(args, { cancelled: true })
         },
         onSuccess: async (_data, variables) => {
             await queryClient.invalidateQueries({
-                queryKey: queryKeys.preapprovals.status({
+                queryKey: queryKeys.walletConnection.preapprovals.status({
                     party: primaryParty,
                     kind: variables.row.kind,
                     registryPartyId: variables.row.registryPartyId,
@@ -147,33 +128,11 @@ export function useTogglePreapproval({
     })
 }
 
-type SubmitPreapprovalCommandArgs = {
-    command: LedgerTypes['Command'] | null
-    disclosedContracts?: readonly LedgerTypes['DisclosedContract'][]
+async function submitPreapprovalCommand(
+    [command, disclosedContracts]:
+        PreparedCommand | readonly [null, readonly []],
     receiver: string
-}
-
-async function submitPreapprovalCommand({
-    command,
-    disclosedContracts = [],
-    receiver,
-}: SubmitPreapprovalCommandArgs) {
-    if (!command) {
-        return
-    }
-
-    const provider = dappSdk.getConnectedProvider()
-    if (!provider) {
-        throw new Error('Dapp provider is not available')
-    }
-
-    await provider.request({
-        method: 'prepareExecuteAndWait',
-        params: {
-            commands: [command],
-            commandId: v4(),
-            actAs: [receiver],
-            disclosedContracts: [...disclosedContracts],
-        },
-    })
+) {
+    if (!command) return
+    await submitViaProvider([command, [...disclosedContracts]], receiver)
 }

--- a/examples/portfolio/src/hooks/useTransactionHistory.ts
+++ b/examples/portfolio/src/hooks/useTransactionHistory.ts
@@ -3,35 +3,41 @@
 
 import { useMemo } from 'react'
 import {
-    skipToken,
     useInfiniteQuery,
+    useQueryClient,
     type UseInfiniteQueryResult,
     type InfiniteData,
 } from '@tanstack/react-query'
 import { type Transaction } from '@canton-network/core-tx-parser'
-import { usePortfolio } from '../contexts/PortfolioContext'
+import { useConnection } from '../contexts/ConnectionContext'
 import { usePrimaryAccount } from '../hooks/useAccounts'
 import type { TransactionHistoryResponse } from '../services/transaction-history-service'
 import { queryKeys } from './query-keys'
+import { transactionHistoryServiceQueryOptions } from './query-options'
 
 export const useTransactionHistoryForParty = (
     partyId: string | undefined
 ): UseInfiniteQueryResult<InfiniteData<TransactionHistoryResponse>, Error> => {
-    const { getTransactionHistory } = usePortfolio()
+    const queryClient = useQueryClient()
+    const { status } = useConnection()
+    const isConnected = status?.connection?.isConnected ?? false
+
     return useInfiniteQuery({
         initialPageParam: null,
-        queryKey: queryKeys.getTransactionHistory.forParty(partyId),
-        queryFn: ({ pageParam }) =>
-            partyId
-                ? getTransactionHistory({
-                      party: partyId,
-                      request: pageParam,
-                  })
-                : skipToken,
-        getNextPageParam: (
-            lastPage: TransactionHistoryResponse | typeof skipToken
-        ) => {
-            if (lastPage === skipToken) return undefined
+        queryKey:
+            queryKeys.walletConnection.transactionHistory.forParty(partyId),
+        enabled: isConnected && !!partyId,
+        queryFn: async ({ pageParam }) => {
+            if (!partyId) {
+                throw new Error('Party is unavailable')
+            }
+
+            const service = await queryClient.ensureQueryData(
+                transactionHistoryServiceQueryOptions(partyId)
+            )
+            return service.query(pageParam)
+        },
+        getNextPageParam: (lastPage: TransactionHistoryResponse) => {
             if (lastPage.beginIsLedgerStart) return undefined
             return { endInclusive: lastPage.beginExclusive }
         },

--- a/examples/portfolio/src/hooks/useWalletHoldings.ts
+++ b/examples/portfolio/src/hooks/useWalletHoldings.ts
@@ -12,6 +12,7 @@ import {
     type AggregatedHolding,
 } from '../utils/aggregate-holdings'
 import { queryKeys } from './query-keys'
+import { useConnection } from '../contexts/ConnectionContext'
 
 export interface WalletHoldingsResult {
     instruments: AggregatedHolding[]
@@ -26,11 +27,12 @@ export const useWalletHoldings = (
     partyId: string | undefined
 ): WalletHoldingsResult => {
     const registryInstruments = useInstruments()
+    const { status } = useConnection()
 
     const holdingsQuery = useQuery({
-        queryKey: queryKeys.listHoldings.forParty(partyId),
+        queryKey: queryKeys.walletConnection.holdings.forParty(partyId),
         queryFn: () => listHoldings({ party: partyId as string }),
-        enabled: !!partyId,
+        enabled: !!status?.connection?.isConnected && !!partyId,
     })
 
     const aggregatedInstruments = useMemo(() => {

--- a/examples/portfolio/src/hooks/useWalletSdk.ts
+++ b/examples/portfolio/src/hooks/useWalletSdk.ts
@@ -1,12 +1,14 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import * as dappSdk from '@canton-network/dapp-sdk'
 import * as walletSdk from '@canton-network/wallet-sdk'
 import { useConnection } from '../contexts/ConnectionContext'
 import { usePortfolioConfig } from '@contexts/PortfolioConfigContext'
 import { queryKeys } from './query-keys'
+import { useReachableRegistryUrls } from './useRegistryUrls'
 import { WalletSDKUtilitiesPlugin } from '@lib/utilities-wallet-sdk-plugin'
 
 const deriveScanApiUrl = (registryUrl: string): URL => {
@@ -18,14 +20,22 @@ const deriveScanApiUrl = (registryUrl: string): URL => {
 }
 
 export const useWalletSdk = () => {
-    const { status } = useConnection()
-    const { amulet } = usePortfolioConfig()
+    const { status, sessionTokenVersion } = useConnection()
+    const { amulet, token } = usePortfolioConfig()
+    const { reachableRegistryUrls, isChecking } = useReachableRegistryUrls()
     const sessionToken = status?.session?.accessToken
     const isConnected = status?.connection?.isConnected ?? false
+    const sdkRegistryUrls = useMemo(
+        () => [...new Set(reachableRegistryUrls.values())].sort(),
+        [reachableRegistryUrls]
+    )
 
     const walletSdkQuery = useQuery({
-        queryKey: queryKeys.walletSdk.forConnection(sessionToken),
-        enabled: isConnected && !!sessionToken,
+        queryKey: queryKeys.walletConnection.walletSdk.forConfig({
+            tokenVersion: sessionTokenVersion,
+            registryUrls: sdkRegistryUrls,
+        }),
+        enabled: isConnected && !!sessionToken && !isChecking,
         staleTime: Infinity,
         gcTime: 0,
         refetchInterval: false,
@@ -41,13 +51,23 @@ export const useWalletSdk = () => {
                 throw new Error('Dapp provider is not available')
             }
 
+            const auth = { method: 'static' as const, token: sessionToken }
             const sdk = await walletSdk.SDK.create({
                 ledgerProvider: provider as never,
                 amulet: {
                     validatorUrl: amulet.validatorUrl,
                     scanApiUrl: deriveScanApiUrl(amulet.registry),
                     registryUrl: amulet.registry,
-                    auth: { method: 'static', token: sessionToken },
+                    auth,
+                },
+                token: {
+                    validatorUrl: token.validatorUrl,
+                    registries: sdkRegistryUrls,
+                    auth,
+                },
+                asset: {
+                    registries: sdkRegistryUrls,
+                    auth,
                 },
             })
 
@@ -56,8 +76,9 @@ export const useWalletSdk = () => {
     })
 
     return {
-        sdk: walletSdkQuery.data!,
-        isLoading: walletSdkQuery.isLoading || walletSdkQuery.isFetching,
+        sdk: walletSdkQuery.data,
+        isLoading:
+            isChecking || walletSdkQuery.isLoading || walletSdkQuery.isFetching,
         error:
             walletSdkQuery.error instanceof Error
                 ? walletSdkQuery.error.message
@@ -69,3 +90,6 @@ export const useWalletSdk = () => {
         },
     }
 }
+
+export type WalletSdk = ReturnType<typeof useWalletSdk>['sdk']
+export type ReadyWalletSdk = NonNullable<WalletSdk>

--- a/examples/portfolio/src/hooks/useWithdrawAllocation.ts
+++ b/examples/portfolio/src/hooks/useWithdrawAllocation.ts
@@ -25,10 +25,14 @@ export const useWithdrawAllocation = () => {
         onSuccess: async (_, args) => {
             await Promise.all([
                 queryClient.invalidateQueries({
-                    queryKey: queryKeys.listAllocations.forParty(args.party),
+                    queryKey: queryKeys.walletConnection.allocations.forParty(
+                        args.party
+                    ),
                 }),
                 queryClient.invalidateQueries({
-                    queryKey: queryKeys.listHoldings.forParty(args.party),
+                    queryKey: queryKeys.walletConnection.holdings.forParty(
+                        args.party
+                    ),
                 }),
             ])
         },

--- a/examples/portfolio/src/lib/logger.ts
+++ b/examples/portfolio/src/lib/logger.ts
@@ -1,0 +1,6 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { pino } from 'pino'
+
+export const logger = pino({ name: 'example-portfolio', level: 'debug' })

--- a/examples/portfolio/src/lib/submit.ts
+++ b/examples/portfolio/src/lib/submit.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { v4 } from 'uuid'
+import * as dappSdk from '@canton-network/dapp-sdk'
+import type { PartyId } from '@canton-network/core-types'
+import type { PreparedCommand } from '@canton-network/wallet-sdk'
+
+export const submitViaProvider = async (
+    [command, disclosedContracts]: PreparedCommand,
+    actAs: PartyId
+): Promise<void> => {
+    const provider = dappSdk.getConnectedProvider()
+    if (!provider) {
+        throw new Error('Dapp provider is not available')
+    }
+
+    await provider.request({
+        method: 'prepareExecuteAndWait',
+        params: {
+            commands: [command],
+            commandId: v4(),
+            actAs: [actAs],
+            disclosedContracts,
+        },
+    })
+}

--- a/examples/portfolio/src/routes/_legacy/index.component.tsx
+++ b/examples/portfolio/src/routes/_legacy/index.component.tsx
@@ -13,7 +13,7 @@ import {
     useAllocationRequestsQueryOptions,
     useAllocationsQueryOptions,
 } from '../../hooks/query-options'
-import { useSuspenseQuery, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { WalletsPreview } from '../../components/wallets-preview'
 import type {
     ActionItem,
@@ -24,7 +24,7 @@ import type {
 export function Index() {
     const primaryParty = usePrimaryAccount()?.partyId
 
-    const pendingTransfers = useSuspenseQuery(
+    const pendingTransfers = useQuery(
         usePendingTransfersQueryOptions(primaryParty)
     )
 

--- a/examples/portfolio/src/services/portfolio-service-implementation.ts
+++ b/examples/portfolio/src/services/portfolio-service-implementation.ts
@@ -20,15 +20,7 @@ import {
     type AllocationSpecification,
     type AllocationView,
 } from '@canton-network/core-token-standard'
-import {
-    resolveTokenStandardService,
-    resolveTransactionHistoryService,
-    resolveAmuletService,
-} from './resolve'
-import type {
-    TransactionHistoryRequest,
-    TransactionHistoryResponse,
-} from './transaction-history-service'
+import { resolveTokenStandardService, resolveAmuletService } from './resolve'
 
 // PortfolioService is a fat interface that tries to capture everything our
 // portflio can do.  Separating the interface from the implementation will
@@ -288,19 +280,6 @@ export const listAllocationInstructions = async ({
             party
         )
     return contracts
-}
-
-export const getTransactionHistory = async ({
-    party,
-    request,
-}: {
-    party: PartyId
-    request: TransactionHistoryRequest
-}): Promise<TransactionHistoryResponse> => {
-    const transactionHistoryService = await resolveTransactionHistoryService({
-        party,
-    })
-    return transactionHistoryService.query(request)
 }
 
 export const tap = async ({

--- a/examples/portfolio/src/services/portfolio-service.ts
+++ b/examples/portfolio/src/services/portfolio-service.ts
@@ -13,10 +13,6 @@ import type {
     AllocationSpecification,
     AllocationView,
 } from '@canton-network/core-token-standard'
-import type {
-    TransactionHistoryRequest,
-    TransactionHistoryResponse,
-} from './transaction-history-service'
 
 // PortfolioService is a fat interface that tries to capture everything our
 // portflio can do.  Separating the interface from the implementation will
@@ -68,12 +64,6 @@ export interface PortfolioService {
     listAllocationInstructions: (_: {
         party: PartyId
     }) => Promise<PrettyContract<AllocationInstructionView>[]>
-
-    // History
-    getTransactionHistory: (_: {
-        party: PartyId
-        request: TransactionHistoryRequest
-    }) => Promise<TransactionHistoryResponse>
 
     // Network info
     isDevNet: (_: {

--- a/examples/portfolio/src/services/resolve.ts
+++ b/examples/portfolio/src/services/resolve.ts
@@ -1,18 +1,18 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type Logger, pino } from 'pino'
+import { type Logger } from 'pino'
 import { LedgerClient } from '@canton-network/core-ledger-client'
 import { TokenStandardService } from '@canton-network/core-token-standard-service'
 import { AmuletService } from '@canton-network/core-amulet-service'
 import { ScanProxyClient } from '@canton-network/core-splice-client'
-import { TransactionHistoryService } from './transaction-history-service'
 import type { LedgerProvider } from '@canton-network/core-provider-ledger'
 import * as sdk from '@canton-network/dapp-sdk'
 import {
     AuthTokenProvider,
     type AccessTokenProvider,
 } from '@canton-network/core-wallet-auth'
+import { logger } from '@lib/logger'
 
 // This module allows us to resolve (i.e. get an instance of) the different
 // dependency services used throughout the project.
@@ -73,7 +73,6 @@ const createAmuletService = async ({
 }
 
 // Global, but so is the dApp SDK.
-const logger = pino({ name: 'example-portfolio', level: 'debug' })
 const ledgerClient: { singleton: LedgerClient | undefined } = {
     singleton: undefined,
 }
@@ -81,14 +80,12 @@ const tokenStandardService: { singleton: TokenStandardService | undefined } = {
     singleton: undefined,
 }
 const amuletServices = new Map<string, AmuletService>()
-const transactionHistoryServices = new Map()
 
 // Can be called to reset clients on disconnects.
 export const clear = () => {
     ledgerClient.singleton = undefined
     tokenStandardService.singleton = undefined
     amuletServices.clear()
-    transactionHistoryServices.clear()
 }
 
 export const resolveTokenStandardService =
@@ -118,26 +115,6 @@ export const resolveAmuletService = async ({
     })
     amuletServices.set(key, amuletService)
     return amuletService
-}
-
-export const resolveTransactionHistoryService = async ({
-    party,
-}: {
-    party: string
-}): Promise<TransactionHistoryService> => {
-    const key = party
-    const provider = resolveLedgerProvider()
-
-    if (transactionHistoryServices.has(key))
-        return transactionHistoryServices.get(key)
-
-    const transactionHistoryService = new TransactionHistoryService({
-        logger,
-        provider,
-        party,
-    })
-    transactionHistoryServices.set(key, transactionHistoryService)
-    return transactionHistoryService
 }
 
 const noAuthAccessTokenProvider: AccessTokenProvider = {

--- a/examples/portfolio/src/services/transaction-history-service.ts
+++ b/examples/portfolio/src/services/transaction-history-service.ts
@@ -11,7 +11,6 @@ import {
 } from '@canton-network/core-tx-parser'
 import { type Transaction } from '@canton-network/core-tx-parser'
 import { LedgerProvider, type Ops } from '@canton-network/core-provider-ledger'
-import { resolveLedgerProvider } from './resolve'
 
 type FiltersByParty = Types['Map_Filters']
 
@@ -224,9 +223,8 @@ export class TransactionHistoryService {
 
             const newUnprocessed: JsTransaction[] = []
             for (const jsTransaction of unapplied) {
-                const provider = resolveLedgerProvider()
                 const parser = new TransactionParser(
-                    provider,
+                    this.provider,
                     jsTransaction,
                     this.party,
                     false // isMasterUser


### PR DESCRIPTION
Another set of refactoring for #1795 . Most of the changes/cleanups are to deal with the fgact that a wallet-sdk instance is immutable. 

 - Clear provider-backed queries and legacy services when connections change
 - Recreate the Wallet SDK when authentication tokens or reachable registries change
 - Preserve unrelated wallet data when registry configuration changes
 - Moved transaction-history service ownership into React Query (will come in handy for reuse in extension :wink:)
 - Ensure transaction history remains bound to the provider that created it.
 - Updated mutation invalidation to use the new wallet-connection query hierarchy (invalidate `walletConnection` when anything changes and all child queries go poof :dash: )