### PR TITLE
ci: add workflow dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,12 @@ name: CI on PRs
 run-name: ${{ github.actor }} is perfoming a Pull Request
 
 on:
+    push:
+        branches: [main]
     pull_request:
         types: [opened, reopened, synchronize, edited]
+    workflow_dispatch:
+
 # Repository vars (e.g. BLOCKDAEMON_*) are not available to workflows from fork PRs.
 env:
     CI_SECRET_DEPENDENCY: ${{ github.event.pull_request.head.repo.fork == false }}


### PR DESCRIPTION
This will allow us to manually trigger the build from main (useful for generating the test coverage report)