### PR TITLE
Adding custom wallet display + copy in WG ui

### DIFF
--- a/core/wallet-ui-components/src/components/app-header.test.ts
+++ b/core/wallet-ui-components/src/components/app-header.test.ts
@@ -5,7 +5,9 @@ import { fixture, elementUpdated } from '@open-wc/testing-helpers'
 import { html } from 'lit'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import './app-header.js'
+import './copy-button.js'
 import { LogoutEvent } from './app-header.js'
+import { WgCopyButton } from './copy-button.js'
 
 describe('app-header', () => {
     afterEach(() => {
@@ -61,5 +63,29 @@ describe('app-header', () => {
                 .shadowRoot!.querySelector<HTMLElement>('.dropdown')!
                 .classList.contains('open')
         ).toBe(false)
+    })
+
+    it('renders the gateway URL with a copy button', async () => {
+        const el = await fixture(
+            html`<app-header
+                .gatewayUrl=${'http://example.com/v0/dapp/hello/imcool'}
+            ></app-header>`
+        )
+
+        el.shadowRoot!.querySelector<HTMLButtonElement>(
+            '.page-trigger'
+        )!.click()
+        await elementUpdated(el)
+
+        const urlRow = el.shadowRoot!.querySelector<HTMLElement>('.menu-url')!
+        expect(urlRow.querySelector('.url-text')!.textContent).toBe(
+            'http://example.com/v0/dapp/hello/imcool'
+        )
+
+        const copyButton = urlRow.querySelector<WgCopyButton>('wg-copy-button')!
+        expect(copyButton).not.toBeNull()
+        expect(copyButton!.value).toBe(
+            'http://example.com/v0/dapp/hello/imcool'
+        )
     })
 })

--- a/core/wallet-ui-components/src/components/app-header.ts
+++ b/core/wallet-ui-components/src/components/app-header.ts
@@ -19,6 +19,8 @@ export class AppHeader extends BaseElement {
     @property({ type: String }) iconSrc: string = 'images/icon.png'
     @property({ type: String }) networkName: string = 'No network connected'
     @property({ type: Boolean }) networkConnected = false
+    @property({ type: String }) gatewayUrl: string =
+        'http://www.katiepang.wallet-gateyway.com/v0/dapp/hello/imcool'
 
     @state() private menuOpen = false
     @state() private darkMode = localStorage.getItem('theme') === 'dark'
@@ -189,6 +191,23 @@ export class AppHeader extends BaseElement {
                 background: var(--wg-border);
                 margin: var(--wg-space-2) 0;
             }
+
+            .menu-url {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: var(--wg-space-3);
+                padding: 0.5rem 0.6rem;
+                min-width: 0;
+            }
+
+            .menu-url .url-text {
+                font-size: var(--wg-font-size-sm);
+                color: var(--wg-text-secondary);
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
         `,
     ]
 
@@ -310,6 +329,16 @@ export class AppHeader extends BaseElement {
                         >
                             <span>Identity Providers</span>
                         </button>
+
+                        <div class="menu-divider"></div>
+
+                        <div class="menu-url" title=${this.gatewayUrl}>
+                            <span class="url-text">${this.gatewayUrl}</span>
+                            <wg-copy-button
+                                .value=${this.gatewayUrl}
+                                label="Copy gateway URL"
+                            ></wg-copy-button>
+                        </div>
 
                         <div class="menu-divider"></div>
 

--- a/core/wallet-ui-components/src/components/app-header.ts
+++ b/core/wallet-ui-components/src/components/app-header.ts
@@ -194,10 +194,24 @@ export class AppHeader extends BaseElement {
 
             .menu-url {
                 display: flex;
+                flex-direction: column;
+                align-items: stretch;
+                gap: 0.25rem;
+                padding: 0.5rem 0.6rem;
+                min-width: 0;
+            }
+
+            .menu-url-label {
+                font-size: 12px;
+                color: var(--wg-text-secondary);
+                opacity: 0.8;
+            }
+
+            .menu-url-row {
+                display: flex;
                 align-items: center;
                 justify-content: space-between;
                 gap: var(--wg-space-3);
-                padding: 0.5rem 0.6rem;
                 min-width: 0;
             }
 
@@ -333,11 +347,14 @@ export class AppHeader extends BaseElement {
                         <div class="menu-divider"></div>
 
                         <div class="menu-url" title=${this.gatewayUrl}>
-                            <span class="url-text">${this.gatewayUrl}</span>
-                            <wg-copy-button
-                                .value=${this.gatewayUrl}
-                                label="Copy gateway URL"
-                            ></wg-copy-button>
+                            <span class="menu-url-label">Dapp Connect URL</span>
+                            <div class="menu-url-row">
+                                <span class="url-text">${this.gatewayUrl}</span>
+                                <wg-copy-button
+                                    .value=${this.gatewayUrl}
+                                    label="Copy gateway URL"
+                                ></wg-copy-button>
+                            </div>
                         </div>
 
                         <div class="menu-divider"></div>


### PR DESCRIPTION
fixes #2234 

1. Added custom wallet url in menu dropdown
2. Added url copy alongside it 

<img width="306" height="373" alt="Screenshot 2026-08-05 at 16 32 14" src="https://github.com/user-attachments/assets/842ad798-f0ba-4492-9335-c4622495a800" />
