### PR TITLE
feat: add Dapp API URL copy action in Wallet Gateway header

### DIFF
--- a/core/wallet-ui-components/src/components/app-header.test.ts
+++ b/core/wallet-ui-components/src/components/app-header.test.ts
@@ -5,7 +5,7 @@ import { fixture, elementUpdated } from '@open-wc/testing-helpers'
 import { html } from 'lit'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import './app-header.js'
-import { LogoutEvent } from './app-header.js'
+import { CopyDappApiUrlEvent, LogoutEvent } from './app-header.js'
 
 describe('app-header', () => {
     afterEach(() => {
@@ -56,6 +56,34 @@ describe('app-header', () => {
 
         expect(listener).toHaveBeenCalledOnce()
         expect(listener.mock.calls[0][0]).toBeInstanceOf(LogoutEvent)
+        expect(
+            el
+                .shadowRoot!.querySelector<HTMLElement>('.dropdown')!
+                .classList.contains('open')
+        ).toBe(false)
+    })
+
+    it('dispatches CopyDappApiUrlEvent from the menu', async () => {
+        const el = await fixture(html`<app-header></app-header>`)
+        const listener = vi.fn()
+        el.addEventListener('copy-dapp-api-url', listener)
+
+        el.shadowRoot!.querySelector<HTMLButtonElement>(
+            '.page-trigger'
+        )!.click()
+        await elementUpdated(el)
+
+        const copyButton = Array.from(
+            el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.menu-item')
+        ).find((button) => button.textContent?.includes('Dapp API URL'))!
+
+        expect(copyButton.querySelector('.menu-item-icon svg')).not.toBeNull()
+
+        copyButton.click()
+        await elementUpdated(el)
+
+        expect(listener).toHaveBeenCalledOnce()
+        expect(listener.mock.calls[0][0]).toBeInstanceOf(CopyDappApiUrlEvent)
         expect(
             el
                 .shadowRoot!.querySelector<HTMLElement>('.dropdown')!

--- a/core/wallet-ui-components/src/components/app-header.test.ts
+++ b/core/wallet-ui-components/src/components/app-header.test.ts
@@ -90,4 +90,25 @@ describe('app-header', () => {
                 .classList.contains('open')
         ).toBe(false)
     })
+
+    it('shows the dApp API URL on hover via title', async () => {
+        const dappApiUrl = 'http://localhost:3030/api/v0/dapp'
+        const el = await fixture(
+            html`<app-header .dappApiUrl=${dappApiUrl}></app-header>`
+        )
+
+        el.shadowRoot!.querySelector<HTMLButtonElement>(
+            '.page-trigger'
+        )!.click()
+        await elementUpdated(el)
+
+        const copyButton = Array.from(
+            el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.menu-item')
+        ).find((button) => button.textContent?.includes('Dapp API URL'))!
+
+        expect(copyButton.title).toBe(dappApiUrl)
+        expect(copyButton.getAttribute('aria-label')).toBe(
+            `Copy dApp API URL: ${dappApiUrl}`
+        )
+    })
 })

--- a/core/wallet-ui-components/src/components/app-header.ts
+++ b/core/wallet-ui-components/src/components/app-header.ts
@@ -25,6 +25,7 @@ export class AppHeader extends BaseElement {
     @property({ type: String }) iconSrc: string = 'images/icon.png'
     @property({ type: String }) networkName: string = 'No network connected'
     @property({ type: Boolean }) networkConnected = false
+    @property({ type: String }) dappApiUrl: string = ''
 
     @state() private menuOpen = false
     @state() private darkMode = localStorage.getItem('theme') === 'dark'
@@ -335,6 +336,12 @@ export class AppHeader extends BaseElement {
                         <button
                             type="button"
                             class="menu-item menu-item-with-icon"
+                            title=${this.dappApiUrl || 'Copy dApp API URL'}
+                            aria-label=${
+                                this.dappApiUrl
+                                    ? `Copy dApp API URL: ${this.dappApiUrl}`
+                                    : 'Copy dApp API URL'
+                            }
                             @click=${this.copyDappApiUrl}
                         >
                             <span>Dapp API URL</span>

--- a/core/wallet-ui-components/src/components/app-header.ts
+++ b/core/wallet-ui-components/src/components/app-header.ts
@@ -5,12 +5,18 @@ import { css, html } from 'lit'
 import { customElement, property, state } from 'lit/decorators.js'
 import { BaseElement } from '../internal/base-element'
 import { toRelPath } from '../routing'
-import { menuIcon } from '../icons'
+import { menuIcon, clipboardIcon } from '../icons'
 import cantonLogo from '../../images/logos/canton-logo.png'
 
 export class LogoutEvent extends Event {
     constructor() {
         super('logout', { bubbles: true, composed: true })
+    }
+}
+
+export class CopyDappApiUrlEvent extends Event {
+    constructor() {
+        super('copy-dapp-api-url', { bubbles: true, composed: true })
     }
 }
 
@@ -180,6 +186,17 @@ export class AppHeader extends BaseElement {
                 gap: var(--wg-space-3);
             }
 
+            .menu-item-with-icon {
+                justify-content: space-between;
+                gap: var(--wg-space-2);
+            }
+
+            .menu-item-icon {
+                display: inline-flex;
+                align-items: center;
+                flex-shrink: 0;
+            }
+
             .menu-item:hover {
                 background: rgba(var(--wg-accent-rgb), 0.1);
             }
@@ -233,6 +250,11 @@ export class AppHeader extends BaseElement {
     private logout() {
         this.menuOpen = false
         this.dispatchEvent(new LogoutEvent())
+    }
+
+    private copyDappApiUrl() {
+        this.menuOpen = false
+        this.dispatchEvent(new CopyDappApiUrlEvent())
     }
 
     render() {
@@ -309,6 +331,16 @@ export class AppHeader extends BaseElement {
                                 this.navigateTo('/identity-providers/')}
                         >
                             <span>Identity Providers</span>
+                        </button>
+                        <button
+                            type="button"
+                            class="menu-item menu-item-with-icon"
+                            @click=${this.copyDappApiUrl}
+                        >
+                            <span>Dapp API URL</span>
+                            <span class="menu-item-icon" aria-hidden="true"
+                                >${clipboardIcon}</span
+                            >
                         </button>
 
                         <div class="menu-divider"></div>

--- a/core/wallet-ui-components/src/components/app-layout.ts
+++ b/core/wallet-ui-components/src/components/app-layout.ts
@@ -14,6 +14,7 @@ export class AppLayout extends BaseElement {
     @property({ type: String }) networkName = 'No network connected'
     @property({ type: Boolean }) networkConnected = false
     @property({ type: String }) currentPage = ''
+    @property({ type: String }) dappApiUrl = ''
 
     static styles = [
         BaseElement.styles,
@@ -63,6 +64,7 @@ export class AppLayout extends BaseElement {
                 .networkName=${this.networkName}
                 .networkConnected=${this.networkConnected}
                 .currentPage=${this.currentPage}
+                .dappApiUrl=${this.dappApiUrl}
             ></app-header>
             <div class="container" id="mainContent">
                 <slot></slot>

--- a/wallet-gateway/remote/src/init.ts
+++ b/wallet-gateway/remote/src/init.ts
@@ -404,7 +404,7 @@ export async function initialize(opts: CliOptions, logger: Logger) {
     )
 
     // register web handler
-    web(app, server, userApiUrl)
+    web(app, server, userApiUrl, dappApiUrl)
     isReady = true
 
     logger.info(

--- a/wallet-gateway/remote/src/web/frontend/index.test.ts
+++ b/wallet-gateway/remote/src/web/frontend/index.test.ts
@@ -6,6 +6,7 @@ import { fixture, waitUntil } from '@open-wc/testing-helpers'
 import { html } from 'lit'
 import { WalletEvent } from '@canton-network/core-types'
 import {
+    CopyDappApiUrlEvent,
     LogoutEvent,
     type AllowedRoute,
 } from '@canton-network/core-wallet-ui-components'
@@ -29,12 +30,18 @@ const {
     setLocationHref,
     getCurrentRoute,
     isAllowedRoute,
+    showToast,
+    fetchDappApiUrl,
 } = vi.hoisted(() => ({
     mockCreateUserClient: vi.fn(),
     mockAttemptRemoveSession: vi.fn().mockResolvedValue(undefined),
     setLocationHref: vi.fn(),
     getCurrentRoute: vi.fn(),
     isAllowedRoute: vi.fn(),
+    showToast: vi.fn(),
+    fetchDappApiUrl: vi
+        .fn()
+        .mockResolvedValue('http://localhost:3030/api/v0/dapp'),
 }))
 
 vi.mock('@canton-network/core-wallet-ui-components', async (importOriginal) => {
@@ -56,6 +63,7 @@ vi.mock('./rpc-client.js', () => ({
     createUserClient: mockCreateUserClient,
     attemptRemoveSession: mockAttemptRemoveSession,
 }))
+vi.mock('./utils.js', () => ({ showToast, fetchDappApiUrl }))
 vi.mock('./state-manager.js', () => ({
     stateManager: {
         accessToken: {
@@ -240,6 +248,9 @@ describe('UserApp', () => {
         mockCreateUserClient.mockReset()
         mockRequest.mockReset()
         setLocationHref.mockReset()
+        showToast.mockReset()
+        fetchDappApiUrl.mockReset()
+        fetchDappApiUrl.mockResolvedValue('http://localhost:3030/api/v0/dapp')
         mockCreateUserClient.mockResolvedValue(createMockUserClient())
         setValidAuth()
         mockSessionList()
@@ -263,6 +274,30 @@ describe('UserApp', () => {
         }
         expect(layout.networkName).toBe('network1')
         expect(layout.networkConnected).toBe(true)
+    })
+
+    it('copies the dApp API URL to the clipboard', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined)
+        vi.stubGlobal('navigator', {
+            ...navigator,
+            clipboard: { writeText },
+        })
+
+        el.shadowRoot
+            ?.querySelector('app-layout')
+            ?.dispatchEvent(new CopyDappApiUrlEvent())
+
+        await waitUntil(() => writeText.mock.calls.length > 0)
+
+        expect(fetchDappApiUrl).toHaveBeenCalled()
+        expect(writeText).toHaveBeenCalledWith(
+            'http://localhost:3030/api/v0/dapp'
+        )
+        expect(showToast).toHaveBeenCalledWith(
+            'Copied',
+            'Dapp API URL copied to clipboard.',
+            'success'
+        )
     })
 
     it('redirects to login on logout when there is no access token', async () => {

--- a/wallet-gateway/remote/src/web/frontend/index.test.ts
+++ b/wallet-gateway/remote/src/web/frontend/index.test.ts
@@ -265,15 +265,28 @@ describe('UserApp', () => {
         document.body.innerHTML = ''
     })
 
-    it('renders layout with the connected network name', () => {
+    it('renders layout with the connected network name', async () => {
+        await waitUntil(
+            () =>
+                (
+                    el.shadowRoot?.querySelector(
+                        'app-layout'
+                    ) as HTMLElement & {
+                        dappApiUrl: string
+                    }
+                )?.dappApiUrl === 'http://localhost:3030/api/v0/dapp'
+        )
+
         const layout = el.shadowRoot?.querySelector(
             'app-layout'
         ) as HTMLElement & {
             networkName: string
             networkConnected: boolean
+            dappApiUrl: string
         }
         expect(layout.networkName).toBe('network1')
         expect(layout.networkConnected).toBe(true)
+        expect(layout.dappApiUrl).toBe('http://localhost:3030/api/v0/dapp')
     })
 
     it('copies the dApp API URL to the clipboard', async () => {

--- a/wallet-gateway/remote/src/web/frontend/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/index.ts
@@ -48,10 +48,12 @@ export const redirectToIntendedOrDefault = async (): Promise<void> => {
 @customElement('user-app')
 export class UserApp extends LitElement {
     @state() accessor currentOrigin: string | null = null
+    @state() accessor dappApiUrl: string = ''
 
     async connectedCallback(): Promise<void> {
         super.connectedCallback()
         this.currentOrigin = await detectCurrentOrigin()
+        this.dappApiUrl = await fetchDappApiUrl()
     }
 
     private async handleLogout() {
@@ -114,6 +116,7 @@ export class UserApp extends LitElement {
                 iconSrc=${toRelPath('/icon.png')}
                 .networkName=${networkName}
                 .networkConnected=${networkConnected}
+                .dappApiUrl=${this.dappApiUrl}
                 @logout=${this.handleLogout}
                 @copy-dapp-api-url=${this.handleCopyDappApiUrl}
             >

--- a/wallet-gateway/remote/src/web/frontend/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/index.ts
@@ -24,6 +24,7 @@ import {
 } from '@canton-network/core-wallet-ui-components'
 import './listeners'
 import { detectCurrentOrigin } from './listeners'
+import { fetchDappApiUrl, showToast } from './utils'
 
 const globalPageResetStyle = document.createElement('style')
 globalPageResetStyle.textContent = `
@@ -88,6 +89,21 @@ export class UserApp extends LitElement {
         }
     }
 
+    private async handleCopyDappApiUrl(): Promise<void> {
+        try {
+            const dappApiUrl = await fetchDappApiUrl()
+            await navigator.clipboard.writeText(dappApiUrl)
+            showToast('Copied', 'Dapp API URL copied to clipboard.', 'success')
+        } catch (error) {
+            console.debug('Failed to copy dApp API URL: ', error)
+            showToast(
+                'Copy failed',
+                'Could not copy the Dapp API URL.',
+                'error'
+            )
+        }
+    }
+
     protected render() {
         const networkId = stateManager.networkId.get(this.currentOrigin || '')
         const networkName = networkId || 'No network connected'
@@ -99,6 +115,7 @@ export class UserApp extends LitElement {
                 .networkName=${networkName}
                 .networkConnected=${networkConnected}
                 @logout=${this.handleLogout}
+                @copy-dapp-api-url=${this.handleCopyDappApiUrl}
             >
                 <user-ui-auth-redirect></user-ui-auth-redirect>
                 <slot></slot>

--- a/wallet-gateway/remote/src/web/frontend/utils.test.ts
+++ b/wallet-gateway/remote/src/web/frontend/utils.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import '@canton-network/core-wallet-ui-components'
-import { showToast } from './utils.js'
+import { fetchDappApiUrl, showToast } from './utils.js'
 
 describe('showToast', () => {
     afterEach(() => {
@@ -21,5 +21,37 @@ describe('showToast', () => {
             'Message body'
         )
         expect((toast as HTMLElement & { type: string }).type).toBe('success')
+    })
+})
+
+describe('fetchDappApiUrl', () => {
+    const originalFetch = globalThis.fetch
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch
+    })
+
+    it('returns dappApiUrl from the well-known gateway config', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    userPath: 'http://localhost:3030/api/v0/user',
+                    dappApiUrl: 'http://localhost:3030/api/v0/dapp',
+                }),
+                { status: 200 }
+            )
+        )
+
+        await expect(fetchDappApiUrl()).resolves.toBe(
+            'http://localhost:3030/api/v0/dapp'
+        )
+    })
+
+    it('falls back to the default dapp path when config fetch fails', async () => {
+        globalThis.fetch = vi.fn().mockRejectedValue(new Error('network error'))
+
+        await expect(fetchDappApiUrl()).resolves.toBe(
+            `${window.location.origin}/api/v0/dapp`
+        )
     })
 })

--- a/wallet-gateway/remote/src/web/frontend/utils.ts
+++ b/wallet-gateway/remote/src/web/frontend/utils.ts
@@ -4,7 +4,9 @@
 import {
     Toast,
     ToastMessageType,
+    toRelPath,
 } from '@canton-network/core-wallet-ui-components'
+
 export const showToast = (
     title: string,
     message: string,
@@ -15,4 +17,25 @@ export const showToast = (
     toast.message = message
     toast.type = type
     document.body.appendChild(toast)
+}
+
+/** Resolves this Wallet Gateway instance's dApp API URL for clipboard copy. */
+export async function fetchDappApiUrl(): Promise<string> {
+    const defaultUrl = new URL(
+        toRelPath('/api/v0/dapp'),
+        window.location.origin
+    ).toString()
+
+    try {
+        const response = await fetch(
+            toRelPath('/.well-known/wallet-gateway-config')
+        )
+        if (!response.ok) {
+            return defaultUrl
+        }
+        const config = (await response.json()) as { dappApiUrl?: string }
+        return config.dappApiUrl || defaultUrl
+    } catch {
+        return defaultUrl
+    }
 }

--- a/wallet-gateway/remote/src/web/server.ts
+++ b/wallet-gateway/remote/src/web/server.ts
@@ -8,10 +8,15 @@ import { fileURLToPath } from 'url'
 import ViteExpress from 'vite-express'
 import { GATEWAY_VERSION } from '../version.js'
 
-export const web = (app: express.Express, server: Server, userPath: string) => {
-    // Expose userPath via well-known configuration endpoint
+export const web = (
+    app: express.Express,
+    server: Server,
+    userPath: string,
+    dappApiUrl: string
+) => {
+    // Expose API URLs via well-known configuration endpoint
     app.get('/.well-known/wallet-gateway-config', (_req, res) => {
-        res.json({ userPath })
+        res.json({ userPath, dappApiUrl })
     })
     if (process.env.NODE_ENV === 'development') {
         // Enable live reloading and Vite dev server for frontend in development

--- a/wallet-gateway/remote/vitest.setup.browser.ts
+++ b/wallet-gateway/remote/vitest.setup.browser.ts
@@ -18,6 +18,7 @@ globalThis.fetch = async (input, init) => {
         return new Response(
             JSON.stringify({
                 userPath: `${window.location.origin}/api/v0/user`,
+                dappApiUrl: `${window.location.origin}/api/v0/dapp`,
             }),
             { status: 200, headers: { 'Content-Type': 'application/json' } }
         )


### PR DESCRIPTION

<img width="450" height="562" alt="Screenshot 2026-08-05 at 5 13 03 PM" src="https://github.com/user-attachments/assets/e85ed99a-ffa2-4193-83da-ba30857b81f7" />



## Summary
- Adds a header menu item **Dapp API URL** that copies this Wallet Gateway instance’s dApp API URL to the clipboard (with success toast)
- Exposes `dappApiUrl` on `GET /.well-known/wallet-gateway-config` (`publicUrl` + `server.dappPath`)
- Hovering the menu item shows the full URL via `title` / `aria-label`
- Addresses #2234

### Why
The Wallet Picker often needs a custom Wallet API URL. Users can see the host in the address bar but may not know the API path (default `/api/v0/dapp`). This makes the correct instance URL discoverable from the WG UI.

### Notes
- URL is per WG instance (same for all dApps talking to that gateway), not a placeholder
- Local default: `http://localhost:3030/api/v0/dapp`
- Related: #2239 proposes showing a truncated URL in the menu. Happy to adjust the UI toward that design if preferred. May the best UX gets merge here. 

## Test plan
- [x] Unit tests: `app-header` copy event + hover title; `fetchDappApiUrl`; UserApp clipboard/toast + passes URL into layout
- [x] `curl -s http://localhost:3030/.well-known/wallet-gateway-config` includes `dappApiUrl`
- [x] Manual: login → ☰ → hover **Dapp API URL** → tooltip shows full URL
- [x] Manual: click → paste → `http://localhost:3030/api/v0/dapp`
- [ ] Optional: paste into ping Wallet Picker → connect

