### PR TITLE
fix: drop token sub matches clientId assertion

### DIFF
--- a/core/wallet-ui-components/src/windows/popup.ts
+++ b/core/wallet-ui-components/src/windows/popup.ts
@@ -72,6 +72,23 @@ class PopupInstance {
                 origin: window.location.origin,
             }
 
+            const MAX_TIMEOUT = 10000 // 10 seconds
+            let isConnected = false
+
+            const originPoller = setInterval(() => {
+                win.postMessage(message, childOrigin)
+            }, 500)
+
+            // Set the timeout and save its ID
+            const timeoutId = setTimeout(() => {
+                clearInterval(originPoller)
+                if (!isConnected) {
+                    console.error(
+                        'Connection timed out waiting for child window.'
+                    )
+                }
+            }, MAX_TIMEOUT)
+
             // due to the asynchronicity when sending the postMessage immediately after redirecting,
             // there is a chance that the child window has not yet loaded,
             // and does not an event listener established yet. Therefore,
@@ -85,15 +102,13 @@ class PopupInstance {
                     return
                 if (childOrigin !== event.origin) return
 
+                isConnected = true
                 clearInterval(originPoller)
+                clearTimeout(timeoutId)
                 window.removeEventListener('message', handleMessage)
             }
 
             window.addEventListener('message', handleMessage)
-
-            const originPoller = setInterval(() => {
-                win.postMessage(message, childOrigin)
-            }, 500)
 
             win.focus()
             return win

--- a/wallet-gateway/remote/src/user-api/controller.test.ts
+++ b/wallet-gateway/remote/src/user-api/controller.test.ts
@@ -959,7 +959,7 @@ describe('userController', () => {
             exp: number
             iat: number
             azp?: string
-            'client-id'?: string
+            client_id?: string
         }
 
         const createAuthWithAddSessionClaims = (
@@ -1337,9 +1337,9 @@ describe('userController', () => {
             ).rejects.toThrow('Failed to add session')
         })
 
-        it('addSession rejects token with client-id claim and auth.clientId mismatch', async () => {
+        it('addSession rejects token with client_id claim and auth.clientId mismatch', async () => {
             const authWithInvalidSubject = createAuthWithAddSessionClaims({
-                azp: 'wrong-client-id',
+                client_id: 'wrong-client-id',
             })
             const store = await createStore(logger, authWithInvalidSubject, {
                 withWallet: false,

--- a/wallet-gateway/remote/src/user-api/controller.test.ts
+++ b/wallet-gateway/remote/src/user-api/controller.test.ts
@@ -950,8 +950,20 @@ describe('userController', () => {
             iat: 1_800_000_000,
         }
 
+        interface JwtClaims {
+            iss: string
+            aud: string
+            sub: string
+            scope?: string
+            scp?: string[]
+            exp: number
+            iat: number
+            azp?: string
+            'client-id'?: string
+        }
+
         const createAuthWithAddSessionClaims = (
-            claimsOverride: Partial<typeof validAddSessionClaims> = {}
+            claimsOverride: Partial<JwtClaims> = {}
         ): AuthContext => ({
             ...auth,
             accessToken: createJwt({
@@ -1325,9 +1337,53 @@ describe('userController', () => {
             ).rejects.toThrow('Failed to add session')
         })
 
-        it('addSession rejects token with subject mismatch', async () => {
+        it('addSession rejects token with client-id claim and auth.clientId mismatch', async () => {
             const authWithInvalidSubject = createAuthWithAddSessionClaims({
-                sub: 'wrong-client-id',
+                azp: 'wrong-client-id',
+            })
+            const store = await createStore(logger, authWithInvalidSubject, {
+                withWallet: false,
+            })
+            const controller = createController(
+                store,
+                notificationService,
+                logger,
+                authWithInvalidSubject
+            )
+
+            await expect(
+                controller.addSession({
+                    origin: 'dapp-1',
+                    networkId: 'network1',
+                })
+            ).rejects.toThrow('Failed to add session')
+        })
+
+        it('addSession rejects token with azp claim and auth.clientId mismatch', async () => {
+            const authWithInvalidSubject = createAuthWithAddSessionClaims({
+                azp: 'wrong-client-id',
+            })
+            const store = await createStore(logger, authWithInvalidSubject, {
+                withWallet: false,
+            })
+            const controller = createController(
+                store,
+                notificationService,
+                logger,
+                authWithInvalidSubject
+            )
+
+            await expect(
+                controller.addSession({
+                    origin: 'dapp-1',
+                    networkId: 'network1',
+                })
+            ).rejects.toThrow('Failed to add session')
+        })
+
+        it("addSession passes when token doesn't token have azp and client-id claims", async () => {
+            const authWithInvalidSubject = createAuthWithAddSessionClaims({
+                azp: 'wrong-client-id',
             })
             const store = await createStore(logger, authWithInvalidSubject, {
                 withWallet: false,

--- a/wallet-gateway/remote/src/user-api/controller.test.ts
+++ b/wallet-gateway/remote/src/user-api/controller.test.ts
@@ -1382,9 +1382,7 @@ describe('userController', () => {
         })
 
         it("addSession passes when token doesn't token have azp and client-id claims", async () => {
-            const authWithInvalidSubject = createAuthWithAddSessionClaims({
-                azp: 'wrong-client-id',
-            })
+            const authWithInvalidSubject = createAuthWithAddSessionClaims()
             const store = await createStore(logger, authWithInvalidSubject, {
                 withWallet: false,
             })
@@ -1395,12 +1393,19 @@ describe('userController', () => {
                 authWithInvalidSubject
             )
 
-            await expect(
-                controller.addSession({
-                    origin: 'dapp-1',
-                    networkId: 'network1',
-                })
-            ).rejects.toThrow('Failed to add session')
+            const result = await controller.addSession({
+                origin: 'dapp-1',
+                networkId: 'network1',
+            })
+            expect(result).toMatchObject({
+                network: expect.objectContaining({
+                    id: 'network1',
+                    auth: expect.objectContaining({
+                        method: 'authorization_code',
+                    }),
+                }),
+                status: 'connected',
+            })
         })
     })
 

--- a/wallet-gateway/remote/src/user-api/token-network-matching.ts
+++ b/wallet-gateway/remote/src/user-api/token-network-matching.ts
@@ -61,10 +61,11 @@ export function assertTokenClaimsMatchNetwork(
         )
     }
 
-    const tokenSubject = tokenClaims.sub
-    if (tokenSubject !== network.auth.clientId) {
+    // check client ID based on `azp` (Authorized Party) claim or `client_id` claim, only if present.
+    const tokenClientId = tokenClaims.azp || tokenClaims.client_id
+    if (tokenClientId && tokenClientId !== network.auth.clientId) {
         throw new Error(
-            `Token sub claim doesn't match network's auth clientId.`
+            `Token client ID doesn't match network's auth clientId.`
         )
     }
 


### PR DESCRIPTION
This PR 

- fixes the auth bug connecting to an OAuth IDP (faulty assumption on `sub` value)
- adds backwards compatibility with newer dapp-sdks to older WGs (pre multi-session) 

I tested the latter by running the latest SDK against WG v1.5.0, and was able to connect and sign TXs in the ping dApp